### PR TITLE
feat(MegaperController): implement request delay

### DIFF
--- a/Data/crontab
+++ b/Data/crontab
@@ -22,9 +22,9 @@
 *    */4 *   *   *    curl -s "http://127.0.0.1:9117/cron/selezen/UpdateTasksParse"
 */5  *   *   *   *    curl -s "http://127.0.0.1:9117/cron/selezen/ParseAllTask"
 
-*/30 *   *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/parse"
-*    */4 *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/UpdateTasksParse"
-*/15 *   *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/ParseAllTask"
+0   *   *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/parse"
+5   */4 *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/UpdateTasksParse"
+30  *   *   *   *    curl -s "http://127.0.0.1:9117/cron/megapeer/ParseAllTask"
 
 */15 *   *   *   *    curl -s "http://127.0.0.1:9117/cron/torrentby/parse"
 *    */4 *   *   *    curl -s "http://127.0.0.1:9117/cron/torrentby/UpdateTasksParse"


### PR DESCRIPTION
- added a delay cycle for page/category requests to reduce rate limiting
- introduced a semaphore to ensure only one browse request is processed at a time
- updated the `GetMegapeerBrowsePage` method to utilize the new delay and locking mechanism
- modified crontab timings for Megapeer tasks to optimize execution schedule