### PR TITLE
feat(docker): add support for linux/arm/v7 architecture

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -31,7 +31,7 @@ on:
         description: "Target platforms for multi-arch builds"
         type: string
         required: false
-        default: "linux/amd64,linux/arm64"
+        default: "linux/amd64,linux/arm64,linux/arm/v7"
 
       push:
         description: "Whether to push the image to the registry"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY . .
 # Restore and publish
 RUN set -eu; \
     case "${TARGETARCH}" in \
+    386)   RID=linux-musl-x86 ;; \
     amd64) RID=linux-musl-x64 ;; \
     arm)   RID=linux-musl-arm ;; \
     arm64) RID=linux-musl-arm64 ;; \


### PR DESCRIPTION
- added support for the 386 architecture in the Dockerfile
- updated default target platforms in the GitHub Actions workflow to include linux/arm/v7