### PR TITLE
fix(knaben): normalize Knaben torrent names

### DIFF
--- a/Controllers/CRON/KnabenController.cs
+++ b/Controllers/CRON/KnabenController.cs
@@ -213,6 +213,9 @@ namespace JacRed.Controllers.CRON
             var createTime = ParseDate(h.Date) ?? ParseDate(h.LastSeen) ?? DateTime.UtcNow;
             var updateTime = ParseDate(h.LastSeen) ?? createTime;
             var (name, relased) = ParseNameAndYear(title);
+            // Append source tracker (EZTV, 1337x, etc.) for display — Knaben aggregates from multiple trackers
+            if (!string.IsNullOrWhiteSpace(h.Tracker) && !title.Contains(h.Tracker))
+                title = $"{title} | {h.Tracker}";
 
             return new TorrentDetails
             {
@@ -234,18 +237,55 @@ namespace JacRed.Controllers.CRON
             };
         }
 
-        static (string, int) ParseNameAndYear(string title)
+        /// <summary>
+        /// Strips metadata from title (season/episode, quality, release tags) so the base
+        /// show/movie name remains. Enables API v1/v2 exact search by content name only.
+        /// </summary>
+        static string CleanTitleForSearch(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title)) return title;
+            string t = title.Trim();
+
+            // Year in parentheses/brackets — strip and everything after
+            var yearMatch = Regex.Match(t, @"[\(\[](\d{4})[\)\]]");
+            if (yearMatch.Success && yearMatch.Index > 0)
+                t = t.Substring(0, yearMatch.Index);
+
+            // Season/Episode: S01E01, S1E1, S01, E01, 1x01
+            t = Regex.Replace(t, @"\b(S\d{1,2}E\d{1,2}|S\d{1,2}E?\d{0,2}|E\d{1,2}|\d{1,2}x\d{1,2})\b", "", RegexOptions.IgnoreCase);
+            // Season X (Russian/English) — only 1–2 digit season numbers, not 480p/720p etc.
+            t = Regex.Replace(t, @"\b(Сезон|Season)\s*\d{1,2}(?!\d).*$", "", RegexOptions.IgnoreCase);
+            // Quality
+            t = Regex.Replace(t, @"\b(2160p|1080p|720p|480p)\b", "", RegexOptions.IgnoreCase);
+            // Release tags
+            t = Regex.Replace(t, @"\b(WEB[-\s]?DL|WEB[-\s]?Rip|BDRip|BDRemux|HDRip|BluRay|BRRip|DVDRip|HDTV)\b", "", RegexOptions.IgnoreCase);
+            t = Regex.Replace(t, @"\b(x264|x265|h\.?264|h\.?265|hevc|avc|aac|ac3|dts)\b", "", RegexOptions.IgnoreCase);
+
+            t = Regex.Replace(t, @"[\[\]\|]", " ");
+            t = Regex.Replace(t, @"\s{2,}", " ").Trim().TrimEnd(' ', '/', '-', '|');
+            // Strip trailing release group (e.g. -FENiX, -MeGusta, .x265-ELiTE) to unify search keys
+            t = Regex.Replace(t, @"[.\s]+-\s*[A-Za-z0-9][A-Za-z0-9.-]*$", "", RegexOptions.IgnoreCase);
+            t = t.Trim().TrimEnd(' ', '-');
+            return string.IsNullOrWhiteSpace(t) ? title : t;
+        }
+
+        public static (string name, int relased) ParseNameAndYear(string title)
         {
             if (string.IsNullOrWhiteSpace(title)) return (null, 0);
             string name = title.Trim();
+            // Strip source tracker suffix added by MapToTorrentDetails (e.g. " | EZTV", " | The Pirate Bay")
+            name = Regex.Replace(name, @"\s+\|\s+[^|]+$", "").Trim();
+            if (string.IsNullOrWhiteSpace(name)) return (null, 0);
             int relased = 0;
-            var m = Regex.Match(title, @"[\(\[](\d{4})[\)\]]");
+            var m = Regex.Match(name, @"[\(\[](\d{4})[\)\]]");
             if (m.Success && int.TryParse(m.Groups[1].Value, out int y))
             {
                 relased = y;
-                if (m.Index > 0) name = title.Substring(0, m.Index).TrimEnd(' ', '/', '-', '|');
+                if (m.Index > 0) name = name.Substring(0, m.Index).TrimEnd(' ', '/', '-', '|');
             }
-            return (string.IsNullOrWhiteSpace(name) ? title : name, relased);
+            // Strip metadata so search by base content name works in API v1/v2
+            name = CleanTitleForSearch(name);
+            return (string.IsNullOrWhiteSpace(name) ? title.Trim() : name, relased);
         }
 
         static int GetQualityFromCategoryId(int[] ids)

--- a/Controllers/DevController.cs
+++ b/Controllers/DevController.cs
@@ -7,6 +7,7 @@ using JacRed.Engine;
 using JacRed.Engine.CORE;
 using JacRed.Models.Details;
 using Microsoft.AspNetCore.Mvc;
+using JacRed.Controllers.CRON;
 
 namespace JacRed.Controllers
 {
@@ -185,6 +186,70 @@ namespace JacRed.Controllers
 
             FileDB.SaveChangesToFile();
             return Json(new { ok = true });
+        }
+
+        /// <summary>
+        /// Normalizes names for existing Knaben torrents: strips metadata from title so
+        /// name/originalname contain only the base content name. Fixes search in API v1/v2.
+        /// GET /dev/fixKnabenNames
+        /// </summary>
+        public JsonResult FixKnabenNames()
+        {
+            if (HttpContext.Connection.RemoteIpAddress.ToString() != "127.0.0.1")
+                return Json(new { badip = true });
+
+            const string trackerName = "knaben";
+            int processed = 0, updated = 0, migrated = 0;
+
+            foreach (var item in FileDB.masterDb.ToArray())
+            {
+                using (var fdb = FileDB.OpenWrite(item.Key))
+                {
+                    var toMigrate = new List<(string url, TorrentDetails t, string newKey)>();
+
+                    foreach (var kv in fdb.Database.ToList())
+                    {
+                        var t = kv.Value;
+                        if (t == null || !string.Equals(t.trackerName, trackerName, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        processed++;
+                        string source = !string.IsNullOrWhiteSpace(t.title) ? t.title : (t.name ?? "");
+                        if (string.IsNullOrWhiteSpace(source)) continue;
+
+                        var (newName, _) = KnabenController.ParseNameAndYear(source);
+                        if (string.IsNullOrWhiteSpace(newName) || newName == t.name) continue;
+
+                        t.name = newName;
+                        t.originalname = newName;
+                        t._sn = StringConvert.SearchName(newName);
+                        t._so = StringConvert.SearchName(newName);
+                        updated++;
+
+                        string newKey = FileDB.KeyForTorrent(t.name, t.originalname);
+                        if (!string.IsNullOrEmpty(newKey) && newKey != item.Key && newKey.IndexOf(':') > 0)
+                            toMigrate.Add((kv.Key, t, newKey));
+                    }
+
+                    foreach (var (url, t, newKey) in toMigrate)
+                    {
+                        fdb.Database.Remove(url);
+                        FileDB.MigrateTorrentToNewKey(t, newKey);
+                        migrated++;
+                    }
+
+                    if (fdb.Database.Count == 0)
+                        FileDB.RemoveKeyFromMasterDb(item.Key);
+
+                    if (updated > 0 || migrated > 0)
+                        fdb.savechanges = true;
+                }
+            }
+
+            FileDB.SaveChangesToFile();
+            try { Controllers.ApiController.getFastdb(update: true); } catch { }
+
+            return Json(new { ok = true, processed, updated, migrated });
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -349,7 +349,23 @@ Anifilm, AniLibria, HDRezka.
 
 - **`GET /dev/*`** — инструменты разработки и отладки БД (только localhost или с `devkey`).
   - Доступ: только из локальной сети или с `devkey` (заголовок `X-Dev-Key` или параметр `?devkey=...`).
-  - Эндпоинты: `/dev/UpdateSize`, `/dev/ResetCheckTime`, `/dev/UpdateDetails`, `/dev/FindCorrupt`, `/dev/RemoveNullValues` и др.
+
+| Эндпоинт | Описание |
+| --------- | --------- |
+| **`/dev/UpdateSize`** | Пересчитывает поле `size` (байты) из `sizeName` для всех торрентов. Обновляет `updateTime`. |
+| **`/dev/ResetCheckTime`** | Сбрасывает `checkTime` на вчера для всех торрентов (для повторной проверки). |
+| **`/dev/UpdateDetails`** | Обновляет детали торрентов через `updateFullDetails` (качество, сезоны и т.п.). |
+| **`/dev/UpdateSearchName`** | Пересчитывает `_sn` и `_so` из `name`/`originalname`, мигрирует торренты при смене ключа бакета. |
+| **`/dev/FixKnabenNames`** | Нормализует имена торрентов Knaben: убирает метаданные из title, оставляет базовое имя. Исправляет поиск в API v1/v2. Возвращает `{ ok, processed, updated, migrated }`. |
+| **`/dev/FindCorrupt`** | Сканирует БД на повреждённые записи (null Value, пустые name/originalname/trackerName). Только чтение. Параметр: `?sampleSize=20`. |
+| **`/dev/RemoveNullValues`** | Удаляет записи, где `torrent.Value == null` (битые ссылки). |
+| **`/dev/FindDuplicateKeys`** | Ищет дубликаты ключей вида `X:X` (например `ponies:ponies`). Параметры: `?tracker=lostfilm`, `?excludeNumeric=false`. |
+| **`/dev/RemoveBucket`** | Удаляет бакет по ключу. Параметры: `?key=ponies:ponies` — удалить; `?key=...&migrateName=...&migrateOriginalname=...` — перенести торренты в новый бакет. |
+| **`/dev/FindEmptySearchFields`** | Ищет торренты с пустыми `_sn` или `_so`. Только чтение. Параметр: `?sampleSize=20`. |
+| **`/dev/FixEmptySearchFields`** | Заполняет пустые `_sn`/`_so` из name/originalname/title, мигрирует при смене ключа. Пересобирает fastdb. |
+| **`/dev/MigrateAnilibertyUrls`** | Мигрирует торренты Aniliberty на URL с хешем из magnet (`?hash=...`). |
+| **`/dev/RemoveDuplicateAniliberty`** | Удаляет дубликаты Aniliberty по хешу magnet, оставляет запись с последним `updateTime`. |
+| **`/dev/FixAnimelayerDuplicates`** | Устраняет дубликаты Animelayer: нормализует HTTP→HTTPS, удаляет HTTP-дубликаты. |
 
 ### Статистика и синхронизация
 


### PR DESCRIPTION
- updated README to include detailed descriptions of new development endpoints
- implemented FixKnabenNames method in DevController to normalize torrent names by stripping metadata
- added CleanTitleForSearch method in KnabenController to improve search accuracy by removing unnecessary details from titles
- enhanced ParseNameAndYear method to support cleaner title parsing for API searches