### PR TITLE
refactor(tracks): enhance startup initialization

### DIFF
--- a/Controllers/ApiController.cs
+++ b/Controllers/ApiController.cs
@@ -711,7 +711,7 @@ namespace JacRed.Controllers
                     return t.ffprobe;
                 }
 
-                var streams = TracksDB.Get(t.magnet, t.types, onlydb: true);
+                var streams = TracksDB.Get(t.magnet, t.types);
                 langs = TracksDB.Languages(t, streams ?? t.ffprobe);
                 if (streams == null)
                     return null;
@@ -973,7 +973,7 @@ namespace JacRed.Controllers
                     langs = TracksDB.Languages(t, t.ffprobe);
                 else
                 {
-                    var streams = TracksDB.Get(t.magnet, t.types, onlydb: true);
+                    var streams = TracksDB.Get(t.magnet, t.types);
                     langs = TracksDB.Languages(t, streams ?? t.ffprobe);
                 }
 
@@ -1071,11 +1071,18 @@ namespace JacRed.Controllers
 
         #region getFastdb
         static Dictionary<string, List<string>> _fastdb = null;
+        static readonly object _fastdbLock = new object();
 
         public static Dictionary<string, List<string>> getFastdb(bool update = false)
         {
-            if (_fastdb == null || update)
+            if (_fastdb != null && !update)
+                return _fastdb;
+
+            lock (_fastdbLock)
             {
+                if (_fastdb != null && !update)
+                    return _fastdb;
+
                 if (update)
                     Console.WriteLine($"fastdb: rebuild start / {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
                 var fastdb = new Dictionary<string, List<string>>();

--- a/Controllers/SyncController.cs
+++ b/Controllers/SyncController.cs
@@ -92,7 +92,7 @@ namespace JacRed.Controllers
 
                     if (t.Value.ffprobe == null || t.Value.languages == null)
                     {
-                        var streams = TracksDB.Get(t.Value.magnet, t.Value.types, onlydb: true);
+                        var streams = TracksDB.Get(t.Value.magnet, t.Value.types);
                         if (streams != null)
                         {
                             var _t = (TorrentDetails)t.Value.Clone();
@@ -157,7 +157,7 @@ namespace JacRed.Controllers
                     var _t = (TorrentDetails)torrent.Value.Clone();
                     _t.updateTime = item.Value.updateTime;
 
-                    var streams = TracksDB.Get(_t.magnet, _t.types, onlydb: true);
+                    var streams = TracksDB.Get(_t.magnet, _t.types);
                     if (streams != null)
                     {
                         _t.ffprobe = streams;

--- a/Engine/Tracks/TracksDB.cs
+++ b/Engine/Tracks/TracksDB.cs
@@ -39,9 +39,7 @@ namespace JacRed.Engine
             StartIndexPersistLoop();
         }
 
-        static Random random = new Random();
-
-        static ConcurrentDictionary<string, FfprobeModel> Database = new ConcurrentDictionary<string, FfprobeModel>();
+        static readonly ConcurrentDictionary<string, FfprobeModel> Database = new ConcurrentDictionary<string, FfprobeModel>();
 
         const string TracksStatsPath = "Data/temp/tracks-stats.json";
         const string TracksIndexPath = "Data/temp/tracks-index.bz";
@@ -131,7 +129,11 @@ namespace JacRed.Engine
                 if (Directory.GetDirectories("Data/tracks").Length == 0)
                     return;
             }
-            catch { return; }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"tracks index: schedule rebuild skipped / {ex.Message}");
+                return;
+            }
 
             ThreadPool.QueueUserWorkItem(_ => _ = BuildTracksIndexAsync());
         }
@@ -143,11 +145,11 @@ namespace JacRed.Engine
                 while (true)
                 {
                     await Task.Delay(TimeSpan.FromMinutes(30));
-                    if (_indexDirty == 0)
+                    if (Volatile.Read(ref _indexDirty) == 0)
                         continue;
 
                     try { PersistTracksIndex(); }
-                    catch { }
+                    catch (Exception ex) { Console.WriteLine($"tracks index: persist loop error / {ex.Message}"); }
                 }
             });
         }
@@ -165,11 +167,13 @@ namespace JacRed.Engine
                 var built = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
                 await Task.Run(() => ScanTracksDirForIndex("Data/tracks", built));
 
-                TrackIndex = built;
+                foreach (var hash in built.Keys)
+                    TrackIndex.TryAdd(hash, 0);
+
                 Interlocked.Exchange(ref _indexDirty, 1);
                 PersistTracksIndex();
 
-                Console.WriteLine($"tracks index: rebuild done / count={built.Count} / {sw.Elapsed.TotalMinutes:F1} min");
+                Console.WriteLine($"tracks index: rebuild done / count={TrackIndex.Count} / {sw.Elapsed.TotalMinutes:F1} min");
             }
             catch (Exception ex)
             {
@@ -389,6 +393,8 @@ namespace JacRed.Engine
             return false;
         }
 
+        /// <param name="magnet">Magnet URI of the torrent.</param>
+        /// <param name="types">Content types; sport/tvshow/docuserial are skipped.</param>
         /// <param name="memoryOnly">If true, return streams only when already in the in-memory cache; skip disk lookup.</param>
         public static List<ffStream> Get(string magnet, string[] types = null, bool memoryOnly = false)
         {

--- a/Engine/Tracks/TracksDB.cs
+++ b/Engine/Tracks/TracksDB.cs
@@ -44,7 +44,7 @@ namespace JacRed.Engine
         const string TracksStatsPath = "Data/temp/tracks-stats.json";
         const string TracksIndexPath = "Data/temp/tracks-index.bz";
 
-        static ConcurrentDictionary<string, byte> TrackIndex = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+        static readonly ConcurrentDictionary<string, byte> TrackIndex = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         static int _indexDirty;
         static int _indexBuildRunning;
         static readonly object _indexPersistLock = new object();
@@ -129,7 +129,12 @@ namespace JacRed.Engine
                 if (Directory.GetDirectories("Data/tracks").Length == 0)
                     return;
             }
-            catch (Exception ex)
+            catch (IOException ex)
+            {
+                Console.WriteLine($"tracks index: schedule rebuild skipped / {ex.Message}");
+                return;
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 Console.WriteLine($"tracks index: schedule rebuild skipped / {ex.Message}");
                 return;
@@ -148,8 +153,7 @@ namespace JacRed.Engine
                     if (Volatile.Read(ref _indexDirty) == 0)
                         continue;
 
-                    try { PersistTracksIndex(); }
-                    catch (Exception ex) { Console.WriteLine($"tracks index: persist loop error / {ex.Message}"); }
+                    PersistTracksIndex();
                 }
             });
         }

--- a/Engine/Tracks/TracksDB.cs
+++ b/Engine/Tracks/TracksDB.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -17,11 +18,175 @@ namespace JacRed.Engine
 {
     public static class TracksDB
     {
-        public static void Configuration()
-        {
-            Console.WriteLine("TracksDB load");
+        /// <summary>Legacy entry point — calls <see cref="StartupInit"/>.</summary>
+        public static void Configuration() => StartupInit();
 
-            foreach (var folder1 in Directory.GetDirectories("Data/tracks"))
+        /// <summary>
+        /// Fast startup: load stats cache + compact tracks index. Full index rebuild and JSON preload run in background.
+        /// Individual tracks are loaded on demand via <see cref="Get"/>.
+        /// </summary>
+        public static void StartupInit()
+        {
+            var sw = Stopwatch.StartNew();
+            Console.WriteLine($"tracks: startup init / {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+
+            TryLoadStatsCache(true, out _, out _);
+            LoadTracksIndex();
+
+            Console.WriteLine($"tracks: startup init done / index={TrackIndex.Count} / {sw.Elapsed.TotalSeconds:F1}s");
+
+            ScheduleIndexRebuildIfNeeded();
+            StartIndexPersistLoop();
+        }
+
+        static Random random = new Random();
+
+        static ConcurrentDictionary<string, FfprobeModel> Database = new ConcurrentDictionary<string, FfprobeModel>();
+
+        const string TracksStatsPath = "Data/temp/tracks-stats.json";
+        const string TracksIndexPath = "Data/temp/tracks-index.bz";
+
+        static ConcurrentDictionary<string, byte> TrackIndex = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+        static int _indexDirty;
+        static int _indexBuildRunning;
+        static readonly object _indexPersistLock = new object();
+
+        sealed class TracksIndexFile
+        {
+            public DateTime builtAt { get; set; }
+            public List<string> hashes { get; set; }
+        }
+
+        static void LoadTracksIndex()
+        {
+            if (!File.Exists(TracksIndexPath))
+                return;
+
+            try
+            {
+                var data = JsonStream.Read<TracksIndexFile>(TracksIndexPath);
+                if (data?.hashes == null || data.hashes.Count == 0)
+                    return;
+
+                foreach (var hash in data.hashes)
+                {
+                    if (IsValidInfohash(hash))
+                        TrackIndex.TryAdd(NormalizeInfohash(hash), 0);
+                }
+
+                Console.WriteLine($"tracks index: loaded {TrackIndex.Count} hashes (built {data.builtAt:yyyy-MM-dd HH:mm:ss} UTC)");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"tracks index: load error / {ex.Message}");
+            }
+        }
+
+        static void PersistTracksIndex()
+        {
+            lock (_indexPersistLock)
+            {
+                try
+                {
+                    if (!Directory.Exists("Data/temp"))
+                        Directory.CreateDirectory("Data/temp");
+
+                    var file = new TracksIndexFile
+                    {
+                        builtAt = DateTime.UtcNow,
+                        hashes = TrackIndex.Keys.ToList()
+                    };
+
+                    JsonStream.Write(TracksIndexPath, file);
+                    Interlocked.Exchange(ref _indexDirty, 0);
+                    Console.WriteLine($"tracks index: saved {file.hashes.Count} hashes / {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"tracks index: save error / {ex.Message}");
+                }
+            }
+        }
+
+        static void RegisterTrackHash(string infohash)
+        {
+            infohash = NormalizeInfohash(infohash);
+            if (!IsValidInfohash(infohash))
+                return;
+
+            if (TrackIndex.TryAdd(infohash, 0))
+                Interlocked.Exchange(ref _indexDirty, 1);
+        }
+
+        static void ScheduleIndexRebuildIfNeeded()
+        {
+            if (TrackIndex.Count > 0)
+                return;
+
+            if (!Directory.Exists("Data/tracks"))
+                return;
+
+            try
+            {
+                if (Directory.GetDirectories("Data/tracks").Length == 0)
+                    return;
+            }
+            catch { return; }
+
+            ThreadPool.QueueUserWorkItem(_ => _ = BuildTracksIndexAsync());
+        }
+
+        static void StartIndexPersistLoop()
+        {
+            ThreadPool.QueueUserWorkItem(async _ =>
+            {
+                while (true)
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(30));
+                    if (_indexDirty == 0)
+                        continue;
+
+                    try { PersistTracksIndex(); }
+                    catch { }
+                }
+            });
+        }
+
+        static async Task BuildTracksIndexAsync()
+        {
+            if (Interlocked.CompareExchange(ref _indexBuildRunning, 1, 0) != 0)
+                return;
+
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                Console.WriteLine($"tracks index: rebuild start / {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+
+                var built = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+                await Task.Run(() => ScanTracksDirForIndex("Data/tracks", built));
+
+                TrackIndex = built;
+                Interlocked.Exchange(ref _indexDirty, 1);
+                PersistTracksIndex();
+
+                Console.WriteLine($"tracks index: rebuild done / count={built.Count} / {sw.Elapsed.TotalMinutes:F1} min");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"tracks index: rebuild error / {ex.Message}");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _indexBuildRunning, 0);
+            }
+        }
+
+        static void ScanTracksDirForIndex(string tracksDir, ConcurrentDictionary<string, byte> target)
+        {
+            if (!Directory.Exists(tracksDir))
+                return;
+
+            foreach (var folder1 in Directory.GetDirectories(tracksDir))
             {
                 foreach (var folder2 in Directory.GetDirectories(folder1))
                 {
@@ -39,25 +204,25 @@ namespace JacRed.Engine
                         if (!IsValidInfohash(infohash))
                             continue;
 
-                        try
-                        {
-                            var res = JsonConvert.DeserializeObject<FfprobeModel>(File.ReadAllText(file));
-                            if (res?.streams != null && res.streams.Count > 0)
-                                Database.TryAdd(infohash, res);
-                        }
-                        catch { }
+                        if (!TrackFileHasStreams(file))
+                            continue;
+
+                        target.TryAdd(NormalizeInfohash(infohash), 0);
                     }
                 }
             }
-
-            TryLoadStatsCache(true, out _, out _);
         }
 
-        static Random random = new Random();
+        public static bool HasTrackOnDisk(string infohash)
+        {
+            infohash = NormalizeInfohash(infohash);
+            if (TrackIndex.ContainsKey(infohash))
+                return true;
 
-        static ConcurrentDictionary<string, FfprobeModel> Database = new ConcurrentDictionary<string, FfprobeModel>();
+            return ResolveTrackPath(infohash) != null;
+        }
 
-        const string TracksStatsPath = "Data/temp/tracks-stats.json";
+        public static int TrackIndexCount => TrackIndex.Count;
         static readonly object _statsCacheLock = new object();
         static DateTime? _statsCacheUpdatedAt;
         static bool _lastExportStatsFromCache;
@@ -224,7 +389,8 @@ namespace JacRed.Engine
             return false;
         }
 
-        public static List<ffStream> Get(string magnet, string[] types = null, bool onlydb = false)
+        /// <param name="memoryOnly">If true, return streams only when already in the in-memory cache; skip disk lookup.</param>
+        public static List<ffStream> Get(string magnet, string[] types = null, bool memoryOnly = false)
         {
             if (types != null && theBad(types))
                 return null;
@@ -232,6 +398,9 @@ namespace JacRed.Engine
             string infohash = NormalizeInfohash(MagnetLink.Parse(magnet).InfoHashes.V1OrV2.ToHex());
             if (Database.TryGetValue(infohash, out FfprobeModel res))
                 return res.streams;
+
+            if (memoryOnly)
+                return null;
 
             string path = ResolveTrackPath(infohash);
             if (path == null)
@@ -246,6 +415,7 @@ namespace JacRed.Engine
             catch { return null; }
 
             Database.AddOrUpdate(infohash, res, (k, v) => res);
+            RegisterTrackHash(infohash);
             return res.streams;
         }
 
@@ -1030,6 +1200,7 @@ namespace JacRed.Engine
                 string path = pathDb(infohash, createfolder: true);
                 string json = JsonConvert.SerializeObject(result, Formatting.Indented);
                 await File.WriteAllTextAsync(path, json, Encoding.UTF8);
+                RegisterTrackHash(infohash);
 
                 string legacyPath = ResolveLegacyTrackPath(infohash);
                 if (legacyPath != null && !string.Equals(path, legacyPath, StringComparison.OrdinalIgnoreCase))
@@ -1767,6 +1938,7 @@ namespace JacRed.Engine
                     string json = JsonConvert.SerializeObject(item.Value, Formatting.Indented);
                     File.WriteAllText(jsonPath, json, Encoding.UTF8);
                     Database.AddOrUpdate(item.Key, item.Value, (k, v) => item.Value);
+                    RegisterTrackHash(item.Key);
                     result.written++;
                 }
                 catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -39,10 +39,10 @@ namespace JacRed
             ThreadPool.QueueUserWorkItem(async _ =>
             {
                 try { TracksDB.StartupInit(); }
-                catch (Exception ex) { Console.WriteLine($"tracks startup: {ex.Message}"); }
+                catch (Exception ex) { Console.WriteLine($"tracks startup: {ex}"); }
 
                 try { ApiController.getFastdb(update: true); }
-                catch (Exception ex) { Console.WriteLine($"fastdb startup: {ex.Message}"); }
+                catch (Exception ex) { Console.WriteLine($"fastdb startup: {ex}"); }
             });
 
             ThreadPool.QueueUserWorkItem(async _ =>

--- a/Program.cs
+++ b/Program.cs
@@ -39,7 +39,8 @@ namespace JacRed
             ThreadPool.QueueUserWorkItem(async _ =>
             {
                 try { TracksDB.StartupInit(); }
-                catch (Exception ex) { Console.WriteLine($"tracks startup: {ex}"); }
+                catch (IOException ex) { Console.WriteLine($"tracks startup: {ex}"); }
+                catch (UnauthorizedAccessException ex) { Console.WriteLine($"tracks startup: {ex}"); }
 
                 try { ApiController.getFastdb(update: true); }
                 catch (Exception ex) { Console.WriteLine($"fastdb startup: {ex}"); }

--- a/Program.cs
+++ b/Program.cs
@@ -33,9 +33,17 @@ namespace JacRed
             Directory.CreateDirectory("Data/log");
             Directory.CreateDirectory("Data/tracks");
 
-            TracksDB.Configuration();
+            // masterDb (~58MB) loads here; fast enough to keep before Kestrel
             SyncController.Configuration();
-            ApiController.getFastdb(update: true);
+
+            ThreadPool.QueueUserWorkItem(async _ =>
+            {
+                try { TracksDB.StartupInit(); }
+                catch (Exception ex) { Console.WriteLine($"tracks startup: {ex.Message}"); }
+
+                try { ApiController.getFastdb(update: true); }
+                catch (Exception ex) { Console.WriteLine($"fastdb startup: {ex.Message}"); }
+            });
 
             ThreadPool.QueueUserWorkItem(async _ =>
             {


### PR DESCRIPTION
- Updated the startup process in Program.cs to load track data asynchronously, improving application responsiveness.
- Removed the `onlydb` parameter from `TracksDB.Get` calls across multiple controllers for cleaner code and consistent data retrieval.
- Introduced locking mechanisms in `getFastdb` to prevent concurrent access issues, ensuring thread safety during database operations.
- Enhanced documentation in TracksDB to clarify the purpose of the new startup initialization method.