### PR TITLE
feat(maintenance): introduce FDB integrity check service and endpoints

### DIFF
--- a/AccessTraceabilityMatrix.md
+++ b/AccessTraceabilityMatrix.md
@@ -80,6 +80,7 @@
 | `/dev/*` | DevMaintenanceController, DevDiagnosticsController, DevMigrationController, DevTracksController |
 | `/jsondb/*` | DbController |
 | `/cron/{tracker}/*` | Controllers/Cron/* (17 трекеров) |
+| `/cron/maintenance/Check`, `/Status` | Controllers/Cron/MaintenanceController (FDB integrity) |
 
 ### ApiKeyWhenConfigured
 

--- a/Application/Maintenance/FdbMaintenanceService.cs
+++ b/Application/Maintenance/FdbMaintenanceService.cs
@@ -1,0 +1,634 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JacRed.Application.Index;
+using JacRed.Infrastructure.Logging;
+using JacRed.Infrastructure.Persistence;
+using JacRed.Infrastructure.Trackers;
+using JacRed.Infrastructure.Utils;
+using JacRed.Models.Details;
+using Newtonsoft.Json;
+
+namespace JacRed.Application.Maintenance
+{
+    public sealed class FdbMaintenanceService : IFdbMaintenanceService
+    {
+        const string ReportPath = "Data/temp/maintenance-last.json";
+        static readonly TimeSpan MaxDuration = TimeSpan.FromHours(6);
+
+        readonly IFastDbIndex _fastDbIndex;
+        readonly TrackerWorkFlag _workFlag = new TrackerWorkFlag();
+
+        volatile bool _running;
+        string _currentMode;
+        DateTime? _startedAtUtc;
+        long _progressCurrent;
+        long _progressTotal;
+        string _progressDetail;
+        object _lastReport;
+
+        public FdbMaintenanceService(IFastDbIndex fastDbIndex)
+        {
+            _fastDbIndex = fastDbIndex;
+            TryLoadLastReport();
+        }
+
+        public string Check(string mode = "report", int sampleSize = 20, bool excludeNumericXx = true)
+        {
+            mode = NormalizeMode(mode);
+            if (sampleSize < 1)
+                sampleSize = 20;
+            if (sampleSize > 200)
+                sampleSize = 200;
+
+            return TrackerSyncHelpers.RunInBackground(
+                "maintenance",
+                "Check",
+                _workFlag,
+                checkDisabled: false,
+                ct =>
+                {
+                    RunJob(mode, sampleSize, excludeNumericXx, ct);
+                    return Task.CompletedTask;
+                },
+                MaxDuration);
+        }
+
+        public object Status()
+        {
+            return new
+            {
+                ok = true,
+                running = _running,
+                mode = _currentMode,
+                startedAt = _startedAtUtc,
+                progress = _running
+                    ? new
+                    {
+                        current = Interlocked.Read(ref _progressCurrent),
+                        total = Interlocked.Read(ref _progressTotal),
+                        detail = _progressDetail
+                    }
+                    : null,
+                last = _lastReport
+            };
+        }
+
+        static string NormalizeMode(string mode)
+        {
+            if (string.IsNullOrWhiteSpace(mode))
+                return "report";
+            mode = mode.Trim().ToLowerInvariant();
+            return mode is "safe" or "full" ? mode : "report";
+        }
+
+        void RunJob(string mode, int sampleSize, bool excludeNumericXx, CancellationToken ct)
+        {
+            _running = true;
+            _currentMode = mode;
+            _startedAtUtc = DateTime.UtcNow;
+            _progressDetail = "scan";
+            Interlocked.Exchange(ref _progressCurrent, 0);
+            Interlocked.Exchange(ref _progressTotal, FileDB.masterDb.Count);
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                JacRedLog.Information(JacRedLogCategories.Fdb,
+                    $"maintenance: Check started mode={mode} sampleSize={sampleSize}");
+
+                var report = Scan(sampleSize, excludeNumericXx, ct);
+                ct.ThrowIfCancellationRequested();
+
+                var fixedCounts = new FixedCounts();
+                if (mode is "safe" or "full")
+                {
+                    _progressDetail = "fix";
+                    ApplySafeFixes(fixedCounts, ct);
+                }
+
+                if (mode == "full")
+                {
+                    _progressDetail = "full-fix";
+                    ApplyFullFixes(fixedCounts, ct);
+                }
+
+                if (mode is "safe" or "full")
+                {
+                    FileDB.SaveChangesToFile();
+                    try { _fastDbIndex.Rebuild(); } catch { }
+                }
+
+                sw.Stop();
+                report["ok"] = true;
+                report["mode"] = mode;
+                report["running"] = false;
+                report["startedAt"] = _startedAtUtc;
+                report["finishedAt"] = DateTime.UtcNow;
+                report["durationSec"] = Math.Round(sw.Elapsed.TotalSeconds, 1);
+                report["fixed"] = fixedCounts.ToObject();
+
+                _lastReport = report;
+                WriteReport(report);
+
+                JacRedLog.Information(JacRedLogCategories.Fdb,
+                    $"maintenance: Check finished mode={mode} duration={sw.Elapsed.TotalSeconds:F1}s " +
+                    $"keys={report["totals"]} fixed={JsonConvert.SerializeObject(fixedCounts.ToObject())}");
+            }
+            catch (OperationCanceledException)
+            {
+                JacRedLog.Warning(JacRedLogCategories.Fdb, "maintenance: Check cancelled");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                JacRedLog.Error(JacRedLogCategories.Fdb, $"maintenance: Check error: {ex.Message}");
+                _lastReport = new
+                {
+                    ok = false,
+                    mode,
+                    error = ex.Message,
+                    startedAt = _startedAtUtc,
+                    finishedAt = DateTime.UtcNow
+                };
+                WriteReport(_lastReport);
+            }
+            finally
+            {
+                _running = false;
+                _progressDetail = null;
+                _currentMode = null;
+                _startedAtUtc = null;
+            }
+        }
+
+        Dictionary<string, object> Scan(int sampleSize, bool excludeNumericXx, CancellationToken ct)
+        {
+            var nullValue = new IssueBucket(sampleSize);
+            var missingName = new IssueBucket(sampleSize);
+            var missingOriginalname = new IssueBucket(sampleSize);
+            var missingTrackerName = new IssueBucket(sampleSize);
+            var emptySn = new IssueBucket(sampleSize);
+            var emptySo = new IssueBucket(sampleSize);
+            var emptyBoth = new IssueBucket(sampleSize);
+            var bucketMismatch = new IssueBucket(sampleSize);
+            var urlKeyMismatch = new IssueBucket(sampleSize);
+            var emptyMagnetOrTypes = new IssueBucket(sampleSize);
+            var missingShardFile = new IssueBucket(sampleSize);
+            var emptyShardListed = new IssueBucket(sampleSize);
+            var xxKeys = new IssueBucket(sampleSize);
+
+            var expectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            int totalTorrents = 0;
+            var masterKeys = FileDB.masterDb.ToArray();
+            Interlocked.Exchange(ref _progressTotal, masterKeys.Length);
+
+            for (int i = 0; i < masterKeys.Length; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                Interlocked.Exchange(ref _progressCurrent, i + 1);
+
+                string fdbKey = masterKeys[i].Key;
+                string shardPath = FileDB.PathForKey(fdbKey);
+                try { expectedPaths.Add(Path.GetFullPath(shardPath)); } catch { expectedPaths.Add(shardPath); }
+
+                if (IsXxKey(fdbKey, excludeNumericXx))
+                    xxKeys.Add(new { key = fdbKey });
+
+                if (!File.Exists(shardPath))
+                {
+                    missingShardFile.Add(new { fdbKey, path = shardPath });
+                    continue;
+                }
+
+                var db = FileDB.OpenRead(fdbKey, cache: false);
+                if (db == null || db.Count == 0)
+                {
+                    emptyShardListed.Add(new { fdbKey, path = shardPath });
+                    continue;
+                }
+
+                foreach (var kv in db)
+                {
+                    totalTorrents++;
+                    string url = kv.Key;
+                    var t = kv.Value;
+
+                    if (t == null)
+                    {
+                        nullValue.Add(new { fdbKey, url });
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(t.trackerName))
+                        missingTrackerName.Add(new { fdbKey, url, title = t.title });
+                    if (string.IsNullOrWhiteSpace(t.name))
+                        missingName.Add(new { fdbKey, url, title = t.title });
+                    if (string.IsNullOrWhiteSpace(t.originalname))
+                        missingOriginalname.Add(new { fdbKey, url, title = t.title });
+
+                    bool hasEmptySn = string.IsNullOrWhiteSpace(t._sn);
+                    bool hasEmptySo = string.IsNullOrWhiteSpace(t._so);
+                    if (hasEmptySn && hasEmptySo)
+                        emptyBoth.Add(new { fdbKey, url, title = t.title, name = t.name, originalname = t.originalname });
+                    else if (hasEmptySn)
+                        emptySn.Add(new { fdbKey, url, title = t.title, name = t.name, originalname = t.originalname });
+                    else if (hasEmptySo)
+                        emptySo.Add(new { fdbKey, url, title = t.title, name = t.name, originalname = t.originalname });
+
+                    string expectedKey = FileDB.KeyForTorrent(t.name, t.originalname);
+                    if (!string.IsNullOrEmpty(expectedKey) && !string.Equals(expectedKey, fdbKey, StringComparison.Ordinal))
+                        bucketMismatch.Add(new { fdbKey, expectedKey, url, title = t.title, name = t.name, originalname = t.originalname });
+
+                    if (!string.IsNullOrEmpty(t.url) && !string.Equals(t.url, url, StringComparison.Ordinal))
+                        urlKeyMismatch.Add(new { fdbKey, dictKey = url, torrentUrl = t.url, title = t.title });
+
+                    bool emptyMagnet = string.IsNullOrWhiteSpace(t.magnet);
+                    bool emptyTypes = t.types == null || t.types.Length == 0;
+                    if (emptyMagnet || emptyTypes)
+                        emptyMagnetOrTypes.Add(new { fdbKey, url, title = t.title, emptyMagnet, emptyTypes });
+                }
+            }
+
+            var orphanShardFiles = new IssueBucket(sampleSize);
+            ScanOrphanShardFiles(expectedPaths, orphanShardFiles, ct);
+
+            return new Dictionary<string, object>
+            {
+                ["totals"] = new { fdbKeys = masterKeys.Length, torrents = totalTorrents },
+                ["issues"] = new
+                {
+                    nullValue = nullValue.ToObject(),
+                    missingName = missingName.ToObject(),
+                    missingOriginalname = missingOriginalname.ToObject(),
+                    missingTrackerName = missingTrackerName.ToObject(),
+                    emptySearchFields = new
+                    {
+                        emptySn = emptySn.ToObject(),
+                        emptySo = emptySo.ToObject(),
+                        emptyBoth = emptyBoth.ToObject(),
+                        total = emptySn.Count + emptySo.Count + emptyBoth.Count
+                    },
+                    xxKeys = xxKeys.ToObject(),
+                    bucketMismatch = bucketMismatch.ToObject(),
+                    urlKeyMismatch = urlKeyMismatch.ToObject(),
+                    missingShardFile = missingShardFile.ToObject(),
+                    emptyShardListed = emptyShardListed.ToObject(),
+                    orphanShardFiles = orphanShardFiles.ToObject(),
+                    emptyMagnetOrTypes = emptyMagnetOrTypes.ToObject()
+                }
+            };
+        }
+
+        static void ScanOrphanShardFiles(HashSet<string> expectedPaths, IssueBucket orphans, CancellationToken ct)
+        {
+            if (!Directory.Exists("Data/fdb"))
+                return;
+
+            foreach (var file in Directory.EnumerateFiles("Data/fdb", "*", SearchOption.AllDirectories))
+            {
+                ct.ThrowIfCancellationRequested();
+                if (file.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string full;
+                try { full = Path.GetFullPath(file); }
+                catch { full = file; }
+
+                if (!expectedPaths.Contains(full))
+                    orphans.Add(new { path = file });
+            }
+        }
+
+        static bool IsXxKey(string key, bool excludeNumeric)
+        {
+            if (string.IsNullOrEmpty(key))
+                return false;
+            int colon = key.IndexOf(':');
+            if (colon <= 0 || colon >= key.Length - 1)
+                return false;
+            string part1 = key.Substring(0, colon);
+            string part2 = key.Substring(colon + 1);
+            if (!string.Equals(part1, part2, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (excludeNumeric && part1.Length > 0 && part1.All(char.IsDigit))
+                return false;
+            return true;
+        }
+
+        void ApplySafeFixes(FixedCounts fixedCounts, CancellationToken ct)
+        {
+            foreach (var item in FileDB.masterDb.ToArray())
+            {
+                ct.ThrowIfCancellationRequested();
+                using (var fdb = FileDB.OpenWrite(item.Key))
+                {
+                    var keysToRemove = new List<string>();
+                    var toMigrate = new List<(string url, TorrentDetails t, string newKey)>();
+                    bool changed = false;
+
+                    foreach (var torrent in fdb.Database.ToList())
+                    {
+                        if (torrent.Value == null)
+                        {
+                            keysToRemove.Add(torrent.Key);
+                            continue;
+                        }
+
+                        var t = torrent.Value;
+                        bool fixedSn = false;
+                        bool fixedSo = false;
+
+                        if (string.IsNullOrWhiteSpace(t._sn))
+                        {
+                            if (!string.IsNullOrWhiteSpace(t.name))
+                            {
+                                t._sn = StringConvert.SearchName(t.name);
+                                fixedSn = true;
+                            }
+                            else if (!string.IsNullOrWhiteSpace(t.title))
+                            {
+                                t._sn = StringConvert.SearchName(t.title);
+                                fixedSn = true;
+                            }
+                        }
+
+                        if (string.IsNullOrWhiteSpace(t._so))
+                        {
+                            if (!string.IsNullOrWhiteSpace(t.originalname))
+                            {
+                                t._so = StringConvert.SearchName(t.originalname);
+                                fixedSo = true;
+                            }
+                            else if (!string.IsNullOrWhiteSpace(t.name))
+                            {
+                                t._so = StringConvert.SearchName(t.name);
+                                fixedSo = true;
+                            }
+                            else if (!string.IsNullOrWhiteSpace(t.title))
+                            {
+                                t._so = StringConvert.SearchName(t.title);
+                                fixedSo = true;
+                            }
+                        }
+
+                        if (string.IsNullOrWhiteSpace(t.name))
+                            t.name = t.title ?? "";
+                        if (string.IsNullOrWhiteSpace(t.originalname))
+                            t.originalname = t.name ?? t.title ?? "";
+
+                        if (string.IsNullOrWhiteSpace(t._sn) && !string.IsNullOrWhiteSpace(t.name))
+                        {
+                            t._sn = StringConvert.SearchName(t.name);
+                            fixedSn = true;
+                        }
+                        if (string.IsNullOrWhiteSpace(t._so) && !string.IsNullOrWhiteSpace(t.originalname))
+                        {
+                            t._so = StringConvert.SearchName(t.originalname);
+                            fixedSo = true;
+                        }
+
+                        if (fixedSn || fixedSo)
+                        {
+                            fixedCounts.searchFieldsFixed++;
+                            changed = true;
+                            string newKey = FileDB.KeyForTorrent(t.name, t.originalname);
+                            if (!string.IsNullOrEmpty(newKey) && newKey != item.Key && newKey.IndexOf(':') > 0)
+                                toMigrate.Add((torrent.Key, t, newKey));
+                        }
+                    }
+
+                    foreach (var k in keysToRemove)
+                    {
+                        fdb.Database.Remove(k);
+                        fixedCounts.nullRemoved++;
+                        changed = true;
+                    }
+
+                    foreach (var (url, t, newKey) in toMigrate)
+                    {
+                        fdb.Database.Remove(url);
+                        FileDB.MigrateTorrentToNewKey(t, newKey);
+                        fixedCounts.migrated++;
+                        changed = true;
+                    }
+
+                    if (fdb.Database.Count == 0)
+                    {
+                        FileDB.RemoveKeyFromMasterDb(item.Key);
+                        fixedCounts.emptyBucketsRemoved++;
+                        changed = true;
+                    }
+
+                    if (changed)
+                        fdb.savechanges = true;
+                }
+            }
+        }
+
+        void ApplyFullFixes(FixedCounts fixedCounts, CancellationToken ct)
+        {
+            // Remigrate bucket mismatches + url re-key + remove incomplete records
+            foreach (var item in FileDB.masterDb.ToArray())
+            {
+                ct.ThrowIfCancellationRequested();
+                string shardPath = FileDB.PathForKey(item.Key);
+                if (!File.Exists(shardPath))
+                {
+                    FileDB.RemoveKeyFromMasterDb(item.Key);
+                    fixedCounts.missingShardKeysRemoved++;
+                    continue;
+                }
+
+                using (var fdb = FileDB.OpenWrite(item.Key))
+                {
+                    var keysToRemove = new List<string>();
+                    var toMigrate = new List<(string url, TorrentDetails t, string newKey)>();
+                    var toRekey = new List<(string oldKey, string newUrl, TorrentDetails t)>();
+                    bool changed = false;
+
+                    foreach (var kv in fdb.Database.ToList())
+                    {
+                        if (kv.Value == null)
+                        {
+                            keysToRemove.Add(kv.Key);
+                            continue;
+                        }
+
+                        var t = kv.Value;
+                        bool emptyMagnet = string.IsNullOrWhiteSpace(t.magnet);
+                        bool emptyTypes = t.types == null || t.types.Length == 0;
+                        if (emptyMagnet && emptyTypes)
+                        {
+                            keysToRemove.Add(kv.Key);
+                            fixedCounts.incompleteRemoved++;
+                            continue;
+                        }
+
+                        string expectedKey = FileDB.KeyForTorrent(t.name, t.originalname);
+                        if (!string.IsNullOrEmpty(expectedKey) && expectedKey != item.Key && expectedKey.IndexOf(':') > 0)
+                        {
+                            toMigrate.Add((kv.Key, t, expectedKey));
+                            continue;
+                        }
+
+                        if (!string.IsNullOrEmpty(t.url) && !string.Equals(t.url, kv.Key, StringComparison.Ordinal))
+                        {
+                            if (fdb.Database.ContainsKey(t.url) && !string.Equals(t.url, kv.Key, StringComparison.Ordinal))
+                            {
+                                // Collision: drop the desynced dict entry
+                                keysToRemove.Add(kv.Key);
+                                fixedCounts.urlKeyFixed++;
+                            }
+                            else
+                            {
+                                toRekey.Add((kv.Key, t.url, t));
+                            }
+                        }
+                    }
+
+                    foreach (var k in keysToRemove)
+                    {
+                        fdb.Database.Remove(k);
+                        changed = true;
+                    }
+
+                    foreach (var (oldKey, newUrl, t) in toRekey)
+                    {
+                        fdb.Database.Remove(oldKey);
+                        if (!fdb.Database.ContainsKey(newUrl))
+                            fdb.Database[newUrl] = t;
+                        fixedCounts.urlKeyFixed++;
+                        changed = true;
+                    }
+
+                    foreach (var (url, t, newKey) in toMigrate)
+                    {
+                        fdb.Database.Remove(url);
+                        FileDB.MigrateTorrentToNewKey(t, newKey);
+                        fixedCounts.migrated++;
+                        changed = true;
+                    }
+
+                    if (fdb.Database.Count == 0)
+                    {
+                        FileDB.RemoveKeyFromMasterDb(item.Key);
+                        fixedCounts.emptyBucketsRemoved++;
+                        changed = true;
+                    }
+
+                    if (changed)
+                        fdb.savechanges = true;
+                }
+            }
+
+            // Delete orphan shard files on disk
+            if (!Directory.Exists("Data/fdb"))
+                return;
+
+            var expectedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var key in FileDB.masterDb.Keys)
+            {
+                try { expectedPaths.Add(Path.GetFullPath(FileDB.PathForKey(key))); }
+                catch { expectedPaths.Add(FileDB.PathForKey(key)); }
+            }
+
+            foreach (var file in Directory.EnumerateFiles("Data/fdb", "*", SearchOption.AllDirectories))
+            {
+                ct.ThrowIfCancellationRequested();
+                if (file.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string full;
+                try { full = Path.GetFullPath(file); }
+                catch { full = file; }
+
+                if (expectedPaths.Contains(full))
+                    continue;
+
+                try
+                {
+                    File.Delete(file);
+                    fixedCounts.orphansDeleted++;
+                }
+                catch (Exception ex)
+                {
+                    JacRedLog.Warning(JacRedLogCategories.Fdb,
+                        $"maintenance: failed to delete orphan {file}: {ex.Message}");
+                }
+            }
+        }
+
+        void WriteReport(object report)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.Combine("Data", "temp"));
+                File.WriteAllText(ReportPath, JsonConvert.SerializeObject(report, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                JacRedLog.Warning(JacRedLogCategories.Fdb,
+                    $"maintenance: failed to write {ReportPath}: {ex.Message}");
+            }
+        }
+
+        void TryLoadLastReport()
+        {
+            try
+            {
+                if (!File.Exists(ReportPath))
+                    return;
+                _lastReport = JsonConvert.DeserializeObject(File.ReadAllText(ReportPath));
+            }
+            catch { }
+        }
+
+        sealed class IssueBucket
+        {
+            readonly int _sampleSize;
+            readonly List<object> _sample = new List<object>();
+
+            public IssueBucket(int sampleSize) => _sampleSize = sampleSize;
+
+            public int Count { get; private set; }
+
+            public void Add(object sample)
+            {
+                Count++;
+                if (_sample.Count < _sampleSize)
+                    _sample.Add(sample);
+            }
+
+            public object ToObject() => new { count = Count, sample = _sample };
+        }
+
+        sealed class FixedCounts
+        {
+            public int nullRemoved;
+            public int searchFieldsFixed;
+            public int migrated;
+            public int emptyBucketsRemoved;
+            public int missingShardKeysRemoved;
+            public int orphansDeleted;
+            public int urlKeyFixed;
+            public int incompleteRemoved;
+
+            public object ToObject() => new
+            {
+                nullRemoved,
+                searchFieldsFixed,
+                migrated,
+                emptyBucketsRemoved,
+                missingShardKeysRemoved,
+                orphansDeleted,
+                urlKeyFixed,
+                incompleteRemoved
+            };
+        }
+    }
+}

--- a/Application/Maintenance/IFdbMaintenanceService.cs
+++ b/Application/Maintenance/IFdbMaintenanceService.cs
@@ -1,0 +1,11 @@
+namespace JacRed.Application.Maintenance
+{
+    public interface IFdbMaintenanceService
+    {
+        /// <summary>Start background integrity job. Returns ok / work.</summary>
+        string Check(string mode = "report", int sampleSize = 20, bool excludeNumericXx = true);
+
+        /// <summary>In-progress state + last completed report.</summary>
+        object Status();
+    }
+}

--- a/Controllers/Cron/MaintenanceController.cs
+++ b/Controllers/Cron/MaintenanceController.cs
@@ -1,0 +1,26 @@
+using JacRed.Application.Maintenance;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JacRed.Controllers.Cron
+{
+    [Route("/cron/maintenance/[action]")]
+    public class MaintenanceController : Controller
+    {
+        readonly IFdbMaintenanceService _maintenanceService;
+
+        public MaintenanceController(IFdbMaintenanceService maintenanceService)
+        {
+            _maintenanceService = maintenanceService;
+        }
+
+        /// <summary>
+        /// Start FDB integrity check. Returns ok / work.
+        /// mode=report|safe|full (default report), sampleSize, excludeNumericXx.
+        /// </summary>
+        public string Check(string mode = "report", int sampleSize = 20, bool excludeNumericXx = true)
+            => _maintenanceService.Check(mode, sampleSize, excludeNumericXx);
+
+        /// <summary>In-progress state and last completed report.</summary>
+        public JsonResult Status() => Json(_maintenanceService.Status());
+    }
+}

--- a/Infrastructure/Persistence/FileDB/FileDB.MasterDb.cs
+++ b/Infrastructure/Persistence/FileDB/FileDB.MasterDb.cs
@@ -120,6 +120,9 @@ namespace JacRed.Infrastructure.Persistence
         /// <summary>Ключ бакета по name/originalname (для поиска и миграции).</summary>
         public static string KeyForTorrent(string name, string originalname) => keyDb(name, originalname);
 
+        /// <summary>Путь shard-файла для ключа бакета (Data/fdb/...).</summary>
+        public static string PathForKey(string key) => pathDb(key);
+
         #endregion
 
         /// <summary>Перенос торрента в бакет с ключом newKey (после смены name/originalname). Вызывается из FileDB и из DevMaintenanceService.UpdateSearchName.</summary>

--- a/Infrastructure/Security/JacRedAccessCatalog.cs
+++ b/Infrastructure/Security/JacRedAccessCatalog.cs
@@ -40,6 +40,8 @@ namespace JacRed.Infrastructure.Security
             new("/dev/TracksStats", JacRedAccessPolicy.DevAdmin, "DevTracksController"),
             new("/dev/FixKnabenNames", JacRedAccessPolicy.DevAdmin, "DevMigrationController"),
             new("/jsondb/save", JacRedAccessPolicy.DevAdmin, "DbController"),
+            new("/cron/maintenance/Check", JacRedAccessPolicy.DevAdmin, "MaintenanceController", "FDB integrity report|safe|full"),
+            new("/cron/maintenance/Status", JacRedAccessPolicy.DevAdmin, "MaintenanceController"),
 
             // Search — apikey when configured
             new("/api/v1.0/torrents", JacRedAccessPolicy.ApiKeyWhenConfigured, "TorrentsController"),

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using JacRed.Application.Dev;
 using JacRed.Application.Dev.Migrations;
 using JacRed.Application.Index;
+using JacRed.Application.Maintenance;
 using JacRed.Application.Search;
 using JacRed.Configuration;
 using JacRed.Controllers;
@@ -118,6 +119,7 @@ namespace JacRed
             builder.Services.AddScoped<RemoveDuplicateAnilibertyMigration>();
             builder.Services.AddScoped<FixAnimelayerDuplicatesMigration>();
             builder.Services.AddScoped<ITracksAdminService, TracksAdminService>();
+            builder.Services.AddSingleton<IFdbMaintenanceService, FdbMaintenanceService>();
 
             builder.Services.AddHostedService<FastDbRefreshWorker>();
             builder.Services.AddHostedService<SyncWorker>();

--- a/README.md
+++ b/README.md
@@ -767,6 +767,34 @@ curl -s 'http://127.0.0.1:9117/dev/ExportTracksStatus'
 - **`GET /cron/{tracker}/parseMagnet`** — парсинг магнет-ссылок (для поддерживающих трекеров).
 - Дополнительные параметры: `parseFrom`, `parseTo`, `parseFromDate` (зависит от трекера).
 
+### Обслуживание FDB (`/cron/maintenance`)
+
+Единый проход по FileDB (ключи бакетов + shard-файлы) на битые/устаревшие/несогласованные данные. Фоновый job (как `ParseAllTask`): `Check` сразу возвращает `ok` / `work`, результат — в `Status` и `Data/temp/maintenance-last.json`.
+
+| Эндпоинт | Описание |
+| --------- | --------- |
+| **`/cron/maintenance/Check`** | Старт проверки. Параметры: `?mode=report\|safe\|full` (по умолчанию `report`), `?sampleSize=20`, `?excludeNumericXx=true`. |
+| **`/cron/maintenance/Status`** | Текущий прогресс и последний отчёт. |
+
+**Режимы `mode`:**
+
+| Mode | Поведение |
+| ---- | --------- |
+| `report` | Только чтение: null Value, пустые name/originalname/trackerName/`_sn`/`_so`, ключи `X:X`, несовпадение ключа бакета, dict-key ≠ `url`, отсутствующие/пустые shard, orphan-файлы под `Data/fdb`, пустые magnet/types. |
+| `safe` | Отчёт + удаление null, заполнение `_sn`/`_so` (с миграцией бакета при необходимости), удаление пустых бакетов, пересборка fastdb. |
+| `full` | `safe` + миграция неверных бакетов, синхронизация dict-key с `url`, удаление masterDb-ключей без файла на диске, удаление orphan shard-файлов, удаление записей с пустыми magnet **и** types. |
+
+Трекер-специфичные миграции (Knaben, Bitru, Aniliberty, Animelayer) остаются на `/dev/*`.
+
+Примеры:
+
+```bash
+curl -s 'http://127.0.0.1:9117/cron/maintenance/Check'
+curl -s 'http://127.0.0.1:9117/cron/maintenance/Check?mode=safe'
+curl -s 'http://127.0.0.1:9117/cron/maintenance/Check?mode=full&sampleSize=50'
+curl -s 'http://127.0.0.1:9117/cron/maintenance/Status'
+```
+
 **Доступ:** политика **DevAdmin** (`/cron/*`). Подробные таблицы LAN / tunnel / ключи — в разделе **[Безопасность и доступ к API](#безопасность-и-доступ-к-api)**.
 
 HTTP-вызовы `/cron/*` логируются с префиксом `cron:` (уровень зависит от `logging.cronSkipFastMs`).


### PR DESCRIPTION
- Added `FdbMaintenanceService` and `IFdbMaintenanceService` for background integrity checks on FileDB.
- Implemented `/cron/maintenance/Check` and `/cron/maintenance/Status` endpoints in `MaintenanceController`.
- Updated documentation to include new maintenance functionality and usage examples.
- Enhanced access control for new endpoints with `DevAdmin` policy.