### PR TITLE
feat(cloudflare): integrate FlareSolverr for СF bypass

### DIFF
--- a/Configuration/AppOptions.cs
+++ b/Configuration/AppOptions.cs
@@ -151,6 +151,9 @@ namespace JacRed.Configuration
         // TODO: fix parser
         public TrackerSettings Baibako = new TrackerSettings("http://baibako.tv");
 
+        /// <summary>Cloudflare bypass via FlareSolverr (persistent browser session).</summary>
+        public FlareSolverrSettings flaresolverr = new FlareSolverrSettings();
+
         public ProxySettings proxy = new ProxySettings();
 
         public SearchSettings search = new SearchSettings();

--- a/Configuration/Schema/ConfigSchema.cs
+++ b/Configuration/Schema/ConfigSchema.cs
@@ -125,6 +125,15 @@ namespace JacRed.Configuration.Schema
                         Field("proxy.list", "stringList", "Proxy list", "ip:port или socks5://…"),
                         Field("globalproxy", "json", "Global proxy", "JSON-массив ProxySettings")
                     }),
+                    Group("flaresolverr", "FlareSolverr", "Cloudflare bypass через безголовый браузер (Rutracker)", new[]
+                    {
+                        Field("flaresolverr.enable", "bool", "Включить", "Ходить на CF-хосты через браузер"),
+                        Field("flaresolverr.url", "string", "URL", "http://127.0.0.1:8191/v1 или http://flaresolverr:8191/v1"),
+                        Field("flaresolverr.maxTimeoutMs", "int", "Таймаут (мс)", "Первая страница ~80 с", min: 1000),
+                        Field("flaresolverr.sessionIdleMinutes", "int", "Idle сессии (мин)", "Закрыть Chromium после простоя", min: 0),
+                        Field("flaresolverr.guardedHours", "int", "Guarded hours", "Сколько помнить CF на хосте", min: 1),
+                        Field("flaresolverr.recheckMinutes", "int", "Recheck (мин)", "Как часто пробовать обычный GET", min: 1)
+                    }),
                     TrackerGroups()
                 }
             };

--- a/Controllers/Cron/CloudflareController.cs
+++ b/Controllers/Cron/CloudflareController.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using JacRed.Infrastructure.Networking;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace JacRed.Controllers.Cron
+{
+    /// <summary>
+    /// Прогрев проверки Cloudflare через FlareSolverr.
+    /// Решение задачи занимает до ~80–180 с и грузит CPU — лучше вызывать
+    /// отдельным cron за несколько минут до обхода Rutracker.
+    /// </summary>
+    [Route("/cron/cloudflare/[action]")]
+    public class CloudflareController : BaseController
+    {
+        public CloudflareController(IMemoryCache memoryCache) : base(memoryCache)
+        {
+        }
+
+        /// <summary>
+        /// Открывает браузером указанный адрес, чтобы сессия была готова к обходу.
+        /// По умолчанию — rutracker forum f=2090 (надёжный CF-триггер).
+        /// </summary>
+        async public Task<IActionResult> Warmup(string url = "https://rutracker.org/forum/viewforum.php?f=2090")
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            string host = null;
+            try { host = new System.Uri(url).Host; } catch (System.UriFormatException) { }
+
+            string html = await CloudflareClearance.FetchAsync(url);
+            bool ok = !string.IsNullOrWhiteSpace(html);
+
+            // Помечаем хост только после успешного прогрева — иначе при падении
+            // FlareSolverr все GET уйдут в браузер на hours (guardedHours).
+            if (ok)
+                CloudflareClearance.MarkGuarded(host);
+            else
+                CloudflareClearance.Unguard(host);
+
+            return Json(new
+            {
+                ok,
+                host,
+                length = html?.Length ?? 0,
+                tookSeconds = System.Math.Round(sw.Elapsed.TotalSeconds, 1)
+            });
+        }
+    }
+}

--- a/Controllers/Cron/RutrackerController.cs
+++ b/Controllers/Cron/RutrackerController.cs
@@ -15,9 +15,9 @@ namespace JacRed.Controllers.Cron
             _syncService = syncService;
         }
 
-        async public Task<string> Parse(int page)
+        async public Task<string> Parse(int page = 0, string cat = null, int maxTopics = 0)
         {
-            return await _syncService.ParseAsync(page);
+            return await _syncService.ParseAsync(page, cat, maxTopics);
         }
 
         async public Task<string> UpdateTasksParse()

--- a/Controllers/Cron/RutrackerController.cs
+++ b/Controllers/Cron/RutrackerController.cs
@@ -20,14 +20,14 @@ namespace JacRed.Controllers.Cron
             return await _syncService.ParseAsync(page, cat, maxTopics);
         }
 
-        async public Task<string> UpdateTasksParse()
+        async public Task<string> UpdateTasksParse(string cat = null)
         {
-            return await _syncService.UpdateTasksParseAsync();
+            return await _syncService.UpdateTasksParseAsync(cat);
         }
 
-        async public Task<string> ParseAllTask()
+        async public Task<string> ParseAllTask(string cat = null, int maxPages = 0)
         {
-            return await _syncService.ParseAllTaskAsync();
+            return await _syncService.ParseAllTaskAsync(cat, maxPages);
         }
 
         async public Task<string> ParseLatest(int pages = 5)

--- a/Data/crontab
+++ b/Data/crontab
@@ -24,6 +24,10 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # runs daily at 04:30, 16:30
 30 4,16 * * *  /opt/jacred/Data/run-job.sh rutor-ParseAllTask http://127.0.0.1:9117/cron/rutor/ParseAllTask 60
 
+# cloudflare-warmup -> /cron/cloudflare/Warmup (max_time=180s)
+# runs every hour at :55 — warm FlareSolverr session before rutracker-parse at :00
+55 * * * *  /opt/jacred/Data/run-job.sh cloudflare-warmup http://127.0.0.1:9117/cron/cloudflare/Warmup 180
+
 # rutracker-parse -> /cron/rutracker/parse (max_time=900s)
 # runs every hour at :00 (e.g. 00:00, 01:00, 02:00, …)
 0 * * * *  /opt/jacred/Data/run-job.sh rutracker-parse http://127.0.0.1:9117/cron/rutracker/parse 900

--- a/Data/example.conf
+++ b/Data/example.conf
@@ -3,6 +3,14 @@
   "listenport": 9117,
   "apikey": "", //Ключ авторизации API (пусто — без проверки)
   "devkey": "", //Ключ для доступа к /dev/, /cron/, /jsondb за туннелем/прокси (пусто — только локальная сеть)
+  "flaresolverr": {
+    "enable": true,
+    "url": "http://127.0.0.1:8191/v1", // в docker-compose: http://flaresolverr:8191/v1
+    "maxTimeoutMs": 180000,
+    "sessionIdleMinutes": 30,
+    "guardedHours": 6,
+    "recheckMinutes": 30
+  },
   "mergeduplicates": true,
   "mergenumduplicates": true, //Объединять дубликаты по номеру (серии и т.п.)
   "openstats": true,
@@ -140,7 +148,7 @@
   },
   "Rutracker": {
     "host": "https://rutracker.org",
-    "alias": "",
+    "alias": "", // optional Worker/onion when flaresolverr.enable=false
     "useproxy": false,
     "reqMinute": 8,
     "parseDelay": 7000,

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -6,6 +6,17 @@ listenip: any
 listenport: 9117
 apikey: "" # Ключ авторизации API (пусто — без проверки)
 devkey: "" # Ключ для доступа к /dev/, /cron/, /jsondb за туннелем/прокси (пусто — только локальная сеть)
+
+# Cloudflare bypass via FlareSolverr (required for Rutracker when no Worker alias).
+# Local debug: 127.0.0.1; in docker-compose use http://flaresolverr:8191/v1
+flaresolverr:
+  enable: true
+  url: http://127.0.0.1:8191/v1
+  maxTimeoutMs: 180000
+  sessionIdleMinutes: 30
+  guardedHours: 6
+  recheckMinutes: 30
+
 mergeduplicates: true
 mergenumduplicates: true # Объединять дубликаты по номеру (серии и т.п.)
 openstats: true
@@ -162,7 +173,7 @@ Mazepa:
 
 Rutracker:
   host: https://rutracker.org
-  alias: ""
+  alias: "" # optional Worker/onion when flaresolverr.enable=false; FDB urls stay on host
   useproxy: false
   reqMinute: 8
   parseDelay: 7000

--- a/Data/fdb/.gitignore
+++ b/Data/fdb/.gitignore
@@ -1,0 +1,3 @@
+# Runtime FileDB shards — never commit
+*
+!.gitignore

--- a/Infrastructure/Networking/CloudflareClearance.cs
+++ b/Infrastructure/Networking/CloudflareClearance.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JacRed.Infrastructure.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JacRed.Infrastructure.Networking
+{
+    /// <summary>
+    /// Ходит на хосты, закрытые проверкой Cloudflare, через FlareSolverr —
+    /// безголовый браузер, стоящий рядом в compose.
+    ///
+    /// Cookie `cf_clearance` нельзя переиспользовать в обычном .NET HttpClient:
+    /// Cloudflare сверяет TLS-отпечаток. Поэтому guarded-хосты обслуживает
+    /// браузер целиком, в одной постоянной сессии (первая ~80 с, далее 2–3 с).
+    /// </summary>
+    public static class CloudflareClearance
+    {
+        const string SessionName = "jacred";
+
+        sealed class GuardState
+        {
+            public DateTime Since;
+
+            /// <summary>Когда последний раз давали дешёвому пути шанс.</summary>
+            public DateTime LastProbe;
+        }
+
+        static readonly ConcurrentDictionary<string, GuardState> _guarded = new(StringComparer.OrdinalIgnoreCase);
+
+        static readonly SemaphoreSlim _gate = new(1, 1);
+
+        static bool _sessionAlive;
+        static DateTime _lastUse = DateTime.MinValue;
+        static Timer _idleTimer;
+
+        static FlareSolverrSettingsView Conf
+        {
+            get
+            {
+                var c = AppInit.conf?.flaresolverr;
+
+                return c == null || !c.enable || string.IsNullOrWhiteSpace(c.url)
+                    ? default
+                    : new FlareSolverrSettingsView(c);
+            }
+        }
+
+        readonly struct FlareSolverrSettingsView
+        {
+            public readonly string Url;
+            public readonly int MaxTimeoutMs;
+            public readonly int SessionIdleMinutes;
+            public readonly int GuardedHours;
+            public readonly int RecheckMinutes;
+
+            public FlareSolverrSettingsView(Models.AppConf.FlareSolverrSettings c)
+            {
+                Url = c.url;
+                MaxTimeoutMs = c.maxTimeoutMs;
+                SessionIdleMinutes = c.sessionIdleMinutes;
+                GuardedHours = c.guardedHours;
+                RecheckMinutes = c.recheckMinutes;
+            }
+        }
+
+        #region признак «хост за проверкой»
+
+        /// <summary>
+        /// Ответ похож на вызов Cloudflare. Признак — <c>cf-mitigated</c>, не <c>cf-ray</c>
+        /// (cf-ray стоит на каждом ответе сайта за Cloudflare, включая обычный 200).
+        /// </summary>
+        public static bool IsChallenge(HttpResponseMessage response)
+        {
+            if (response == null)
+                return false;
+
+            if (response.StatusCode != System.Net.HttpStatusCode.Forbidden &&
+                response.StatusCode != System.Net.HttpStatusCode.ServiceUnavailable)
+                return false;
+
+            return response.Headers.TryGetValues("cf-mitigated", out _);
+        }
+
+        /// <summary>
+        /// Разметка задачи Cloudflare в теле (старые виды без <c>cf-mitigated</c>).
+        /// </summary>
+        public static bool IsChallengeBody(string body)
+        {
+            if (string.IsNullOrEmpty(body) || body.Length > 200_000)
+                return false;
+
+            return body.Contains("cf-browser-verification", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("cf_chl_opt", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("challenge-platform", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("Just a moment", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("Один момент", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsGuarded(string host)
+        {
+            var conf = Conf;
+            if (conf.Url == null || string.IsNullOrWhiteSpace(host))
+                return false;
+
+            if (!_guarded.TryGetValue(host, out var state))
+                return false;
+
+            var now = DateTime.UtcNow;
+
+            if (now > state.Since.AddHours(conf.GuardedHours))
+            {
+                _guarded.TryRemove(host, out _);
+                return false;
+            }
+
+            if (now > state.LastProbe.AddMinutes(conf.RecheckMinutes))
+            {
+                state.LastProbe = now;
+                return false;
+            }
+
+            return true;
+        }
+
+        public static void Unguard(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return;
+
+            if (_guarded.TryRemove(host, out _))
+                JacRedLog.Information(JacRedLogCategories.Host, $"{host} отвечает обычному клиенту, браузер больше не нужен");
+        }
+
+        public static void MarkGuarded(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return;
+
+            var now = DateTime.UtcNow;
+
+            if (_guarded.TryGetValue(host, out var state))
+            {
+                state.Since = now;
+                state.LastProbe = now;
+                return;
+            }
+
+            _guarded[host] = new GuardState { Since = now, LastProbe = now };
+            JacRedLog.Warning(JacRedLogCategories.Host, $"{host} закрыт проверкой Cloudflare, переходим на браузер");
+        }
+
+        #endregion
+
+        #region получение страницы
+
+        /// <summary>
+        /// Забирает страницу через браузер. Возвращает готовый HTML либо null.
+        /// Свой таймаут: решение задачи занимает до полутора минут.
+        /// </summary>
+        public static async Task<string> FetchAsync(string url, string cookie = null)
+        {
+            var conf = Conf;
+            if (conf.Url == null || string.IsNullOrWhiteSpace(url))
+                return null;
+
+            string host;
+            try { host = new Uri(url).Host; }
+            catch (UriFormatException) { return null; }
+
+            await _gate.WaitAsync();
+            try
+            {
+                if (!_sessionAlive && !await CreateSessionAsync(conf))
+                    return null;
+
+                var (outcome, html) = await RequestAsync(conf, url, cookie);
+
+                if (outcome == FetchOutcome.BrowserFailed)
+                {
+                    await DestroySessionAsync(conf);
+
+                    if (!await CreateSessionAsync(conf))
+                        return null;
+
+                    (outcome, html) = await RequestAsync(conf, url, cookie);
+
+                    if (outcome == FetchOutcome.Ok)
+                        JacRedLog.Warning(JacRedLogCategories.Host, $"{host}: получилось со второй попытки, сессия пересоздана");
+                }
+
+                _lastUse = DateTime.UtcNow;
+                ArmIdleTimer(conf);
+
+                return outcome == FetchOutcome.Ok ? html : null;
+            }
+            catch (Exception ex)
+            {
+                JacRedLog.Error(JacRedLogCategories.Host, $"FlareSolverr: {host}: {ex.GetType().Name}: {ex.Message}");
+                return null;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        enum FetchOutcome
+        {
+            Ok,
+            PageFailed,
+            BrowserFailed
+        }
+
+        static async Task<(FetchOutcome outcome, string html)> RequestAsync(FlareSolverrSettingsView conf, string url, string cookie)
+        {
+            var payload = new Dictionary<string, object>
+            {
+                ["cmd"] = "request.get",
+                ["session"] = SessionName,
+                ["url"] = url,
+                ["maxTimeout"] = conf.MaxTimeoutMs
+            };
+
+            var jar = ParseCookies(cookie);
+            if (jar.Count > 0)
+                payload["cookies"] = jar;
+
+            var root = await CallAsync(conf, payload, conf.MaxTimeoutMs + 30000);
+
+            if (root == null)
+                return (FetchOutcome.BrowserFailed, null);
+
+            if (!string.Equals(root.Value<string>("status"), "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                string message = root.Value<string>("message") ?? "";
+                JacRedLog.Error(JacRedLogCategories.Host, $"FlareSolverr отказал: {message}");
+
+                if (message.IndexOf("session", StringComparison.OrdinalIgnoreCase) >= 0)
+                    _sessionAlive = false;
+
+                return (FetchOutcome.BrowserFailed, null);
+            }
+
+            var solution = root.Value<JObject>("solution");
+            int status = solution?.Value<int?>("status") ?? 0;
+            string html = solution?.Value<string>("response");
+
+            if (status != 200 || string.IsNullOrWhiteSpace(html))
+                return (FetchOutcome.PageFailed, null);
+
+            return (FetchOutcome.Ok, html);
+        }
+
+        static List<Dictionary<string, string>> ParseCookies(string cookie)
+        {
+            var list = new List<Dictionary<string, string>>();
+            if (string.IsNullOrWhiteSpace(cookie))
+                return list;
+
+            foreach (var part in cookie.Split(';'))
+            {
+                int eq = part.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+
+                string name = part.Substring(0, eq).Trim();
+                string value = part.Substring(eq + 1).Trim();
+
+                if (name.Length > 0)
+                    list.Add(new Dictionary<string, string> { ["name"] = name, ["value"] = value });
+            }
+
+            return list;
+        }
+
+        #endregion
+
+        #region сессия
+
+        static async Task<bool> CreateSessionAsync(FlareSolverrSettingsView conf)
+        {
+            var root = await CallAsync(conf, new Dictionary<string, object>
+            {
+                ["cmd"] = "sessions.create",
+                ["session"] = SessionName
+            }, conf.MaxTimeoutMs + 30000);
+
+            bool ok = root != null &&
+                      (string.Equals(root.Value<string>("status"), "ok", StringComparison.OrdinalIgnoreCase)
+                       || (root.Value<string>("message") ?? "").IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0);
+
+            _sessionAlive = ok;
+
+            if (ok)
+                JacRedLog.Warning(JacRedLogCategories.Host, "FlareSolverr: сессия браузера создана");
+            else
+                JacRedLog.Error(JacRedLogCategories.Host, $"FlareSolverr: сессию создать не удалось: {root?.Value<string>("message")}");
+
+            return ok;
+        }
+
+        static async Task DestroySessionAsync(FlareSolverrSettingsView conf)
+        {
+            if (!_sessionAlive)
+                return;
+
+            await CallAsync(conf, new Dictionary<string, object>
+            {
+                ["cmd"] = "sessions.destroy",
+                ["session"] = SessionName
+            }, 60000);
+
+            _sessionAlive = false;
+        }
+
+        static void ArmIdleTimer(FlareSolverrSettingsView conf)
+        {
+            if (conf.SessionIdleMinutes <= 0)
+                return;
+
+            _idleTimer ??= new Timer(_ => CloseIfIdle(), null, Timeout.Infinite, Timeout.Infinite);
+
+            var period = TimeSpan.FromMinutes(1);
+            _idleTimer.Change(period, period);
+        }
+
+        static void CloseIfIdle()
+        {
+            var conf = Conf;
+            if (conf.Url == null || !_sessionAlive || conf.SessionIdleMinutes <= 0)
+                return;
+
+            if (DateTime.UtcNow < _lastUse.AddMinutes(conf.SessionIdleMinutes))
+                return;
+
+            if (!_gate.Wait(0))
+                return;
+
+            try
+            {
+                CallAsync(conf, new Dictionary<string, object>
+                {
+                    ["cmd"] = "sessions.destroy",
+                    ["session"] = SessionName
+                }, 60000).GetAwaiter().GetResult();
+
+                _sessionAlive = false;
+                _idleTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+
+                JacRedLog.Warning(JacRedLogCategories.Host, "FlareSolverr: сессия закрыта по простою, память освобождена");
+            }
+            catch (Exception ex)
+            {
+                JacRedLog.Error(JacRedLogCategories.Host, $"FlareSolverr: не удалось закрыть сессию: {ex.Message}");
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        #endregion
+
+        static async Task<JObject> CallAsync(FlareSolverrSettingsView conf, Dictionary<string, object> payload, int timeoutMs)
+        {
+            try
+            {
+                using var client = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromMilliseconds(timeoutMs) };
+                using var content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+                using var response = await client.PostAsync(conf.Url, content);
+
+                return JObject.Parse(await response.Content.ReadAsStringAsync());
+            }
+            catch (Exception ex)
+            {
+                JacRedLog.Error(JacRedLogCategories.Host, $"FlareSolverr недоступен: {ex.GetType().Name}: {ex.Message}");
+                _sessionAlive = false;
+                return null;
+            }
+        }
+    }
+}

--- a/Infrastructure/Networking/HttpClient.cs
+++ b/Infrastructure/Networking/HttpClient.cs
@@ -137,6 +137,25 @@ namespace JacRed.Infrastructure.Networking
             if (proxies.Count == 0)
                 proxies.Add(null);
 
+            string requestHost = null;
+            try { requestHost = new Uri(url).Host; } catch (UriFormatException) { }
+
+            // Хост уже за Cloudflare — не тратим обычный GET на заведомый 403.
+            // Если браузер тоже не отдал страницу, не делаем второй FetchAsync
+            // через challenge-ветку ниже (таймаут до 180 с).
+            if (CloudflareClearance.IsGuarded(requestHost))
+            {
+                string viaBrowser = await CloudflareClearance.FetchAsync(url, cookie);
+                if (!string.IsNullOrWhiteSpace(viaBrowser))
+                    return (viaBrowser, OkResponse(url));
+
+                return (null, new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.InternalServerError,
+                    RequestMessage = new HttpRequestMessage()
+                });
+            }
+
             foreach (var px in proxies)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -168,8 +187,41 @@ namespace JacRed.Infrastructure.Networking
 
                         using (HttpResponseMessage response = await client.SendAsync(req, cancellationToken))
                         {
+                            if (response.StatusCode == HttpStatusCode.OK)
+                                CloudflareClearance.Unguard(requestHost);
+
                             if (response.StatusCode != HttpStatusCode.OK)
+                            {
+                                // cf-mitigated или разметка «Just a moment…» → браузер.
+                                // Таймаут браузера свой; token вызывающего сюда не идёт.
+                                bool challenge = CloudflareClearance.IsChallenge(response);
+
+                                if (!challenge
+                                    && (response.StatusCode == HttpStatusCode.Forbidden
+                                        || response.StatusCode == HttpStatusCode.ServiceUnavailable))
+                                {
+                                    try
+                                    {
+                                        challenge = CloudflareClearance.IsChallengeBody(
+                                            await response.Content.ReadAsStringAsync(cancellationToken));
+                                    }
+                                    catch
+                                    {
+                                        // Тело не прочиталось — не помечаем хост guarded.
+                                    }
+                                }
+
+                                if (challenge)
+                                {
+                                    CloudflareClearance.MarkGuarded(requestHost);
+
+                                    string viaBrowser = await CloudflareClearance.FetchAsync(url, cookie);
+                                    if (!string.IsNullOrWhiteSpace(viaBrowser))
+                                        return (viaBrowser, OkResponse(url));
+                                }
+
                                 continue;
+                            }
 
                             using (HttpContent content = response.Content)
                             {
@@ -208,6 +260,15 @@ namespace JacRed.Infrastructure.Networking
                 StatusCode = HttpStatusCode.InternalServerError,
                 RequestMessage = new HttpRequestMessage()
             });
+        }
+
+        /// <summary>Ответ-заглушка для страниц, добытых браузером: вызывающие смотрят на код.</summary>
+        static HttpResponseMessage OkResponse(string url)
+        {
+            var request = new HttpRequestMessage();
+            try { request.RequestUri = new Uri(url); } catch (UriFormatException) { }
+
+            return new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request };
         }
         #endregion
 

--- a/Infrastructure/Trackers/Rutracker/README.md
+++ b/Infrastructure/Trackers/Rutracker/README.md
@@ -2,22 +2,51 @@
 
 JacRed sync for [rutracker.org](https://rutracker.org) via cron endpoints under `/cron/rutracker/`.
 
-Cloudflare often blocks direct clients (`403` / “Just a moment…”). Use a Worker reverse-proxy **alias** so fetches go through CF edge:
+## Cloudflare / FlareSolverr
+
+Rutracker sits behind Cloudflare (`403` / `cf-mitigated` / “Just a moment…”). Direct .NET `HttpClient` cannot reuse `cf_clearance` cookies (TLS fingerprint differs). Production path:
+
+1. **FlareSolverr** (primary) — persistent browser session; guarded hosts are fetched entirely through the browser (~80 s first page, then 2–3 s).
+2. **Worker `alias`** (optional fallback when FlareSolverr is disabled) — reverse-proxy so fetches go through CF edge.
 
 ```yaml
+flaresolverr:
+  enable: true
+  url: http://127.0.0.1:8191/v1   # compose: http://flaresolverr:8191/v1
+  maxTimeoutMs: 180000
+  sessionIdleMinutes: 30
+  guardedHours: 6
+  recheckMinutes: 30
+
 Rutracker:
-  alias: https://rutracker.workers.dev
+  host: https://rutracker.org
+  alias: ""          # optional Worker URL if flaresolverr.enable=false
 ```
 
-- **HTTP** (lists, topics): `rqHost()` → alias when set  
+- **HTTP** (lists, topics): `HttpClient.Get` → auto-routes to FlareSolverr when the host is guarded; `rqHost()` still applies alias when set  
 - **FDB `url`**: always canonical `https://rutracker.org/forum/viewtopic.php?t=…`  
 - **Login**: not required for current parser (magnets on public topic pages; auth code is commented out)
+
+Warm the browser session before parse (first solve is expensive):
+
+```cron
+55 * * * *  /opt/jacred/Data/run-job.sh cloudflare-warmup http://127.0.0.1:9117/cron/cloudflare/Warmup 180
+0 * * * *   /opt/jacred/Data/run-job.sh rutracker-parse http://127.0.0.1:9117/cron/rutracker/parse 900
+```
+
+Limited smoke (after app + FlareSolverr are up):
+
+```bash
+./scripts/cron_rutracker_smoke.sh
+# or: curl 'http://127.0.0.1:9117/cron/rutracker/parse?page=0&cat=2090&maxTopics=3'
+```
 
 ## Cron endpoints
 
 | Action | Code path | What it does |
 | -------- | ----------- | -------------- |
-| `Parse` | `ParseAsync` | First page (`page=0` by default) of each **QuickParse** forum (~**65**) |
+| `Warmup` | `/cron/cloudflare/Warmup` | FlareSolverr session warm (default forum `f=2090`) |
+| `Parse` | `ParseAsync` | First page (`page=0` by default) of each **QuickParse** forum (~**65**); optional `cat`, `maxTopics` for smoke |
 | `UpdateTasksParse` | `UpdateTasksParseAsync` | Hits **all ~211** forums to learn page counts → `Data/temp/rutracker_taskParse.json` (**no lock**) |
 | `ParseLatest` | `ParseLatestAsync` | First *N* pages of **every** cat in `taskParse` (heavy once the map is full) |
 | `ParseAllTask` | `ParseAllTaskAsync` | Full backlog of every page in `taskParse` (multi-hour) |
@@ -38,6 +67,9 @@ Primary freshness is **`Parse` page 0 of QuickParse**, not `ParseAllTask`.
 Repo [`Data/crontab`](../../../Data/crontab) follows this cadence (ParseAll twice daily so a 6h wall can continue same day):
 
 ```cron
+# Warm FlareSolverr ~5 min before parse
+55 * * * *    /opt/jacred/Data/run-job.sh cloudflare-warmup http://127.0.0.1:9117/cron/cloudflare/Warmup 180
+
 # Fresh releases: 65 quick forums, first page only (~65 GETs/run)
 0 * * * *     /opt/jacred/Data/run-job.sh rutracker-parse http://127.0.0.1:9117/cron/rutracker/parse 900
 
@@ -52,6 +84,7 @@ Repo [`Data/crontab`](../../../Data/crontab) follows this cadence (ParseAll twic
 
 - Hourly `UpdateTasksParse` / `ParseAllTask` — over-requests; while a crawl runs cron only gets `work`. Prefer 2×/day ParseAll (start + continue).  
 - Scheduling `ParseLatest?pages=5` for “light” refresh — with a full `taskParse` it is **heavier** than hourly `parse` (~211×N forum pages).
+- Skipping warmup when FlareSolverr is cold — first CF solve under CPU contention often times out.
 
 ### Tunable intensity
 
@@ -61,9 +94,9 @@ Repo [`Data/crontab`](../../../Data/crontab) follows this cadence (ParseAll twic
 | Quieter | `0 */2 * * *` → `parse` |
 | Slower deep crawl | raise `Rutracker.reqMinute` (longer `parseDelay`) |
 
-## Worker requests / day (recommended cron)
+## FlareSolverr / Worker requests / day (recommended cron)
 
-Assumptions: 65 QuickParse, 211 forums, ~**40** pages/cat average for full crawl; topic GETs only when FDB misses title.
+Assumptions: 65 QuickParse, 211 forums, ~**40** pages/cat average for full crawl; topic GETs only when FDB misses title. With FlareSolverr each GET is a browser navigation (serialized).
 
 ### Fixed forum GETs
 
@@ -82,7 +115,7 @@ Assumptions: 65 QuickParse, 211 forums, ~**40** pages/cat average for full crawl
 | **7 days** | ~21 000 | ~23 000 | ~27 000 | ~32 000 |
 | **30 days** | ~89 000 | ~100 000 | ~114 000 | ~136 000 |
 
-Planning ballpark: **~3.5k–4.5k / day**, **~25k–30k / week**, **~100k–120k / month** via the Worker.
+Planning ballpark: **~3.5k–4.5k / day**, **~25k–30k / week**, **~100k–120k / month**.
 
 A cold first full crawl can spike topic GETs for several days until the task map pages catch up.
 
@@ -96,4 +129,7 @@ Forum floor alone is often **~15k+ / day** if Update/ParseAll fire hourly; prefe
 - `RutrackerParser.cs` — HTML → torrents / magnets  
 - `RutrackerCategories.cs` — forum map + QuickParse  
 - `Controllers/Cron/RutrackerController.cs` — HTTP entrypoints  
+- `Controllers/Cron/CloudflareController.cs` — FlareSolverr warmup  
+- `Infrastructure/Networking/CloudflareClearance.cs` — FlareSolverr client  
+- `scripts/cron_rutracker_smoke.sh` — limited live smoke  
 - Repo `Data/crontab` / `Data/run-job.sh` — balanced schedule (matches recommended block above)

--- a/Infrastructure/Trackers/Rutracker/README.md
+++ b/Infrastructure/Trackers/Rutracker/README.md
@@ -47,9 +47,9 @@ Limited smoke (after app + FlareSolverr are up):
 | -------- | ----------- | -------------- |
 | `Warmup` | `/cron/cloudflare/Warmup` | FlareSolverr session warm (default forum `f=2090`) |
 | `Parse` | `ParseAsync` | First page (`page=0` by default) of each **QuickParse** forum (~**65**); optional `cat`, `maxTopics` for smoke |
-| `UpdateTasksParse` | `UpdateTasksParseAsync` | Hits **all ~211** forums to learn page counts → `Data/temp/rutracker_taskParse.json` (**no lock**) |
+| `UpdateTasksParse` | `UpdateTasksParseAsync` | Hits forums to learn page counts → `Data/temp/rutracker_taskParse.json`; optional `cat` (smoke: one forum, not all ~211) |
 | `ParseLatest` | `ParseLatestAsync` | First *N* pages of **every** cat in `taskParse` (heavy once the map is full) |
-| `ParseAllTask` | `ParseAllTaskAsync` | Full backlog of every page in `taskParse` (multi-hour) |
+| `ParseAllTask` | `ParseAllTaskAsync` | Full backlog of every page in `taskParse` (multi-hour); optional `cat`, `maxPages` for smoke |
 
 ### Request unit (`parsePage`)
 

--- a/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
@@ -110,7 +110,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             return false;
         }
 
-        public async Task<string> ParseAsync(int page)
+        public async Task<string> ParseAsync(int page, string cat = null, int maxTopics = 0)
         {
             return await TrackerSyncHelpers.RunParseAsync(TrackerName, _parseLock, checkDisabled: false, async () =>
             {
@@ -120,13 +120,33 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                 {
                     var sw = Stopwatch.StartNew();
                     string baseUrl = $"{AppInit.conf.Rutracker.rqHost()}/forum/viewforum.php";
-                    ParserLog.Write(TrackerName, $"Starting parse page={page}, base: {baseUrl}");
-                    foreach (string cat in RutrackerCategories.QuickParseIds)
+
+                    var catFilter = string.IsNullOrWhiteSpace(cat)
+                        ? null
+                        : new HashSet<string>(
+                            cat.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                            StringComparer.OrdinalIgnoreCase);
+
+                    string[] cats;
+                    if (catFilter == null)
                     {
-                        string pageUrl = page == 0 ? $"{baseUrl}?f={cat}" : $"{baseUrl}?f={cat}&start={page * 50}";
-                        ParserLog.Write(TrackerName, $"Category {cat}: {pageUrl}");
-                        bool result = await parsePage(cat, page);
-                        log += $"{cat} - {page} - {result}\n";
+                        cats = RutrackerCategories.QuickParseIds.ToArray();
+                    }
+                    else
+                    {
+                        cats = RutrackerCategories.QuickParseIds.Where(c => catFilter.Contains(c)).ToArray();
+                        // Smoke: allow any known forum id, not only QuickParse.
+                        if (cats.Length == 0)
+                            cats = RutrackerCategories.Ids.Where(c => catFilter.Contains(c)).ToArray();
+                    }
+
+                    ParserLog.Write(TrackerName, $"Starting parse page={page}, cats={cats.Length}, maxTopics={maxTopics}, base: {baseUrl}");
+                    foreach (string c in cats)
+                    {
+                        string pageUrl = page == 0 ? $"{baseUrl}?f={c}" : $"{baseUrl}?f={c}&start={page * 50}";
+                        ParserLog.Write(TrackerName, $"Category {c}: {pageUrl}");
+                        bool result = await parsePage(c, page, maxTopics: maxTopics);
+                        log += $"{c} - {page} - {result}\n";
                     }
                     ParserLog.Write(TrackerName, $"Parse completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
@@ -258,7 +278,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             });
         }
 
-        async Task<bool> parsePage(string cat, int page, CancellationToken cancellationToken = default)
+        async Task<bool> parsePage(string cat, int page, CancellationToken cancellationToken = default, int maxTopics = 0)
         {
             #region Авторизация
             //if (Cookie == null)
@@ -273,14 +293,23 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                 return false;
 
             var torrents = RutrackerParser.ParseTorrentsFromPage(html, cat);
+            if (maxTopics > 0 && torrents.Count > maxTopics)
+                torrents = torrents.Take(maxTopics).ToList();
 
+            int topicsDone = 0;
             await FileDB.AddOrUpdate(torrents, async (t, db) =>
             {
+                if (maxTopics > 0 && topicsDone >= maxTopics)
+                    return true;
+
                 if (db.TryGetValue(t.url, out TorrentDetails _tcache) && _tcache.title == t.title)
                     return true;
 
                 var fullNews = await HttpClient.Get(AppInit.conf.Rutracker.rqHost(t.url), useproxy: AppInit.conf.Rutracker.useproxy, cancellationToken: cancellationToken);
-                return RutrackerParser.ApplyTopicPageDetails(t, fullNews);
+                bool ok = RutrackerParser.ApplyTopicPageDetails(t, fullNews);
+                if (ok)
+                    topicsDone++;
+                return ok;
             });
 
             return torrents.Count > 0;

--- a/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
@@ -159,43 +159,43 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             });
         }
 
-        public Task<string> UpdateTasksParseAsync()
+        public Task<string> UpdateTasksParseAsync(string cat = null)
         {
             return Task.FromResult(TrackerSyncHelpers.RunUpdateTasksParseInBackground(TrackerName, _updateTasksWork, checkDisabled: false, async ct =>
             {
-                foreach (string cat in RutrackerCategories.Ids)
+                var cats = ResolveCatFilter(cat) ?? RutrackerCategories.Ids.ToArray();
+                ParserLog.Write(TrackerName, $"UpdateTasksParse start cats={cats.Length}");
+
+                foreach (string c in cats)
                 {
                     ct.ThrowIfCancellationRequested();
 
                     try
                     {
-                        // Получаем html
-                        string html = await HttpClient.Get($"{AppInit.conf.Rutracker.rqHost()}/forum/viewforum.php?f={cat}", useproxy: AppInit.conf.Rutracker.useproxy, cancellationToken: ct);
+                        string html = await HttpClient.Get($"{AppInit.conf.Rutracker.rqHost()}/forum/viewforum.php?f={c}", useproxy: AppInit.conf.Rutracker.useproxy, cancellationToken: ct);
                         if (html == null)
                             continue;
 
-                        // Максимальное количиство страниц
                         int.TryParse(Regex.Match(html, "Страница <b>1</b> из <b>([0-9]+)</b>").Groups[1].Value, out int maxpages);
 
                         if (maxpages > 0)
                         {
-                            // Загружаем список страниц в список задач
                             for (int page = 0; page <= maxpages; page++)
                             {
-                                if (!taskParse.ContainsKey(cat))
-                                    taskParse.Add(cat, new List<TaskParse>());
+                                if (!taskParse.ContainsKey(c))
+                                    taskParse.Add(c, new List<TaskParse>());
 
-                                var val = taskParse[cat];
+                                var val = taskParse[c];
                                 if (val.FirstOrDefault(i => i.page == page) == null)
                                     val.Add(new TaskParse(page));
                             }
                         }
                         else
                         {
-                            if (!taskParse.ContainsKey(cat))
-                                taskParse.Add(cat, new List<TaskParse>());
+                            if (!taskParse.ContainsKey(c))
+                                taskParse.Add(c, new List<TaskParse>());
 
-                            var val = taskParse[cat];
+                            var val = taskParse[c];
                             if (val.FirstOrDefault(i => i.page == 1) == null)
                                 val.Add(new TaskParse(1));
                         }
@@ -204,20 +204,28 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                 }
 
                 PersistTaskParse();
+                ParserLog.Write(TrackerName, $"UpdateTasksParse done cats={cats.Length}");
             }));
         }
 
-        public Task<string> ParseAllTaskAsync()
+        public Task<string> ParseAllTaskAsync(string cat = null, int maxPages = 0)
         {
             return Task.FromResult(TrackerSyncHelpers.RunParseAllTaskInBackground(TrackerName, _parseAllTaskWork, checkDisabled: false, async ct =>
             {
                 try
                 {
+                    var catFilter = ResolveCatFilter(cat);
                     var pending = taskParse.ToArray()
+                        .Where(t => catFilter == null || catFilter.Contains(t.Key))
                         .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
+
+                    if (maxPages > 0 && pending.Length > maxPages)
+                        pending = pending.Take(maxPages).ToArray();
+
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start pending={pending.Length} maxPages={maxPages}");
 
                     foreach (var item in pending)
                     {
@@ -231,12 +239,27 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
                     }
+
+                    ParserLog.Write(TrackerName, $"ParseAllTask done {done}/{pending.Length}");
                 }
                 finally
                 {
                     PersistTaskParse();
                 }
             }));
+        }
+
+        static string[] ResolveCatFilter(string cat)
+        {
+            if (string.IsNullOrWhiteSpace(cat))
+                return null;
+
+            var filter = new HashSet<string>(
+                cat.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
+
+            var cats = RutrackerCategories.Ids.Where(c => filter.Contains(c)).ToArray();
+            return cats.Length > 0 ? cats : null;
         }
 
         public async Task<string> ParseLatestAsync(int pages = 5)

--- a/Models/AppConf/FlareSolverrSettings.cs
+++ b/Models/AppConf/FlareSolverrSettings.cs
@@ -1,0 +1,45 @@
+namespace JacRed.Models.AppConf
+{
+    /// <summary>
+    /// Прохождение проверки Cloudflare через FlareSolverr — безголовый браузер,
+    /// который стоит рядом в compose и не публикуется наружу.
+    ///
+    /// Дешёвый путь «забрать cookie и ходить дальше обычным клиентом» проверен
+    /// и не работает: с той же cookie и тем же User-Agent прилетает 403 —
+    /// Cloudflare сверяет ещё и отпечаток TLS. Поэтому такие хосты обслуживает
+    /// браузер целиком, в одной постоянной сессии.
+    /// </summary>
+    public class FlareSolverrSettings
+    {
+        public bool enable { get; set; } = true;
+
+        /// <summary>
+        /// Адрес службы.
+        /// Host-run JacRed + published FlareSolverr: http://127.0.0.1:8191/v1
+        /// JacRed in docker-compose: http://flaresolverr:8191/v1
+        /// </summary>
+        public string url { get; set; } = "http://127.0.0.1:8191/v1";
+
+        /// <summary>
+        /// Сколько ждать ответа браузера, мс. Первое обращение долгое — там
+        /// решается задача: на rutracker замерено около 80 секунд.
+        /// </summary>
+        public int maxTimeoutMs { get; set; } = 180000;
+
+        /// <summary>
+        /// Через сколько минут простоя закрывать сессию браузера (~700 МБ).
+        /// </summary>
+        public int sessionIdleMinutes { get; set; } = 30;
+
+        /// <summary>
+        /// Сколько часов помнить, что хост закрыт проверкой, и ходить туда
+        /// сразу браузером, не тратя запрос на заведомый отказ.
+        /// </summary>
+        public int guardedHours { get; set; } = 6;
+
+        /// <summary>
+        /// Как часто давать закрытому хосту шанс ответить обычным путём.
+        /// </summary>
+        public int recheckMinutes { get; set; } = 30;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -513,9 +513,10 @@ Anifilm, AniLibria, HDRezka.
 1. Настроить **`init.yaml`** или **`init.conf`** (примеры в **`Data/example.yaml`**, **`Data/example.conf`**).
    - Убедитесь, что для нужных трекеров указаны правильные `host`, `login` (если требуется) или `cookie`.
    - Настройте прокси, если требуется доступ к .onion доменам.
+   - **Rutracker / Cloudflare:** включите блок **`flaresolverr`** (см. примеры конфига). Cookie `cf_clearance` нельзя переиспользовать в обычном HttpClient — запросы идут через persistent-сессию FlareSolverr. В Docker Compose URL: `http://flaresolverr:8191/v1`; при запуске на хосте: `http://127.0.0.1:8191/v1`. Альтернатива без FlareSolverr — Worker **`Rutracker.alias`**. Подробности: [`Infrastructure/Trackers/Rutracker/README.md`](Infrastructure/Trackers/Rutracker/README.md).
 
 2. Выберите режим работы:
-   - **Парсинг через cron:** По умолчанию база скачивается при установке, парсинг выполняется по расписанию из **`Data/crontab`**. Активируйте: `crontab /opt/jacred/Data/crontab`
+   - **Парсинг через cron:** По умолчанию база скачивается при установке, парсинг выполняется по расписанию из **`Data/crontab`** (включая `cloudflare-warmup` за ~5 мин до `rutracker-parse`). Активируйте: `crontab /opt/jacred/Data/crontab`
    - **Синхронизация:** Укажите **`syncapi`** в конфиге, чтобы подтягивать базу с удалённого сервера. Включите `opensync: true` для участия в синхронизации.
    - **Docker:** в образе нет cron — расписание выносится на хост, отдельный контейнер или оркестратор; см. раздел **«Docker → Самостоятельный парсинг и расписание (cron) в Docker»**.
 
@@ -946,13 +947,13 @@ volumes:
   - ./data:/app/Data
 ```
 
-Готовые примеры: **`docker/docker-compose.yml`** (bind mounts), **`docker-compose.example.yml`** (named volumes).
+Готовый пример: **`docker-compose.example.yml`** (JacRed + FlareSolverr, named volumes).
 
 **Полезно:**
 
-- **Конфиг:** после первого запуска настройте **`init.yaml`** или **`init.conf`** в томе `jacred-config` или каталоге `./config` (при bind mount). Конфиг автоматически копируется из `/app/config/` в `/app/` при старте контейнера.
-- **Порты:** веб-интерфейс и API доступны на порту **9117** (при необходимости измените маппинг `ports` и `listenport` в конфиге).
-- **Память:** при большой базе или активном парсинге увеличьте лимит `memory` в `deploy.resources.limits` (рекомендуется минимум 2GB).
+- **Конфиг:** после первого запуска настройте **`init.yaml`** или **`init.conf`** в томе `jacred-config` или каталоге `./config` (при bind mount). Конфиг автоматически копируется из `/app/config/` в `/app/` при старте контейнера. Для Rutracker в compose задайте `flaresolverr.url: http://flaresolverr:8191/v1`.
+- **Порты:** веб-интерфейс и API доступны на порту **9117** (при необходимости измените маппинг `ports` и `listenport` в конфиге). Порт FlareSolverr **8191** в примере не публикуется наружу — только внутренняя сеть Compose.
+- **Память:** JacRed + FlareSolverr (~1 GiB) — ориентир **≥4 GiB** на сервис JacRed в примере compose; при большой базе увеличьте лимит.
 - **Тома:**
   - `jacred-config` — хранит конфигурацию (`init.yaml` или `init.conf`)
   - `jacred-data` — хранит базу данных (`fdb/`), логи (`log/`), временные файлы (`temp/`) и треки (`tracks/`)
@@ -970,7 +971,7 @@ volumes:
 2. **Отдельный контейнер с cron** — маленький образ (например `curl` + `cron`), в том же Docker Compose, который по расписанию дергает сервис JacRed по **внутреннему** имени и порту (например `http://jacred:9117/...`). Убедитесь, что с точки зрения JacRed IP источника остаётся в приватном диапазоне (типично так и есть в user-defined bridge-сети).
 3. **Kubernetes CronJob**, **systemd timer** на хосте — по сути то же, что п.1: периодический HTTP-запрос к JacRed.
 
-**Ориентир по расписанию:** в репозитории лежит пример **`Data/crontab`** (парсинг по трекерам через `Data/run-job.sh` и `*/5 * * * *` для **`/jsondb/save`**). Скопируйте нужные строки в свой crontab на хосте (или в свой шаблон для контейнера с cron) и:
+**Ориентир по расписанию:** в репозитории лежит пример **`Data/crontab`** (парсинг по трекерам через `Data/run-job.sh`, `cloudflare-warmup` перед `rutracker-parse`, и `*/5 * * * *` для **`/jsondb/save`**). Скопируйте нужные строки в свой crontab на хосте (или в свой шаблон для контейнера с cron) и:
 
 - при использовании `run-job.sh` убедитесь, что скрипт доступен по пути из crontab (в релизе — `/opt/jacred/Data/run-job.sh`); либо замените строки на прямой `curl`;
 - замените хост/порт в URL на ваши (`127.0.0.1:9117` или имя сервиса в Compose);
@@ -1000,6 +1001,7 @@ volumes:
 - Убедитесь, что `syncapi` указан корректно (если используется синхронизация)
 - Проверьте логи парсеров: `tail -f Data/log/{tracker}.log`
 - Убедитесь, что трекер доступен и учётные данные верны
+- **Rutracker / Cloudflare:** проверьте, что FlareSolverr доступен (`curl http://127.0.0.1:8191/` или `http://flaresolverr:8191/` в compose), в конфиге `flaresolverr.enable: true` и верный `url`, и что срабатывает warmup: `curl http://127.0.0.1:9117/cron/cloudflare/Warmup` (первый ответ может занять до ~180 с). Smoke: `./scripts/cron_rutracker_smoke.sh`
 
 ### API не отвечает
 
@@ -1021,6 +1023,7 @@ volumes:
 - Уменьшите `maxreadfile` в конфиге
 - Настройте ротацию логов через `logFdbRetentionDays`, `logFdbMaxSizeMb`, `logFdbMaxFiles`
 - Для Docker: увеличьте лимит памяти в `deploy.resources.limits.memory`
+- FlareSolverr держит ~600–700 МБ на сессию Chromium; при простое сессия закрывается через `flaresolverr.sessionIdleMinutes` (по умолчанию 30)
 
 ---
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,6 +13,8 @@ services:
     environment:
       - TZ=Europe/London
       - UMASK=0027
+    depends_on:
+      - flaresolverr
     healthcheck:
       test: ["CMD", "curl", "-f", "-s", "--max-time", "10", "http://127.0.0.1:9117/health"]
       interval: 30s
@@ -24,6 +26,26 @@ services:
         limits:
           memory: 4096M
           cpus: "4"
+
+  # Cloudflare bypass for Rutracker (~1 GiB RAM). Reachable as flaresolverr:8191
+  # on the compose network. Do not publish 8191 externally in production.
+  # Local host-run JacRed (outside compose): map ports below and use
+  # flaresolverr.url: http://127.0.0.1:8191/v1 in init.yaml.
+  flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: flaresolverr
+    restart: unless-stopped
+    # Uncomment for host-side debug of FlareSolverr:
+    # ports:
+    #   - "8191:8191"
+    environment:
+      - LOG_LEVEL=info
+      - TZ=Europe/London
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+          cpus: "2"
 
 volumes:
   jacred-config:

--- a/scripts/cron_rutracker_smoke.sh
+++ b/scripts/cron_rutracker_smoke.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-# Limited live Rutracker parse smoke via FlareSolverr.
-# Prerequisites: JacRed running, FlareSolverr up (e.g. http://127.0.0.1:8191).
+# Limited live Rutracker smoke via FlareSolverr — all three cron jobs, capped.
+#
+# Covers:
+#   1) /cron/cloudflare/Warmup
+#   2) /cron/rutracker/parse            (one cat, maxTopics)
+#   3) /cron/rutracker/UpdateTasksParse (one cat — NOT all 211 forums)
+#   4) /cron/rutracker/ParseAllTask     (one cat, maxPages — NOT full backlog)
+#
+# Background jobs are polled via /health/background-jobs (re-calling cron
+# endpoints would start a new run).
 #
 # Usage:
 #   ./scripts/cron_rutracker_smoke.sh
@@ -12,6 +20,9 @@ DEVKEY="${DEVKEY:-}"
 TIMEOUT="${TIMEOUT:-180}"
 CAT="${CAT:-2090}"
 MAX_TOPICS="${MAX_TOPICS:-3}"
+MAX_PAGES="${MAX_PAGES:-1}"
+POLL_SEC="${POLL_SEC:-2}"
+WAIT_BG="${WAIT_BG:-180}"
 
 admin_url() {
   local path="$1"
@@ -26,10 +37,40 @@ admin_url() {
   fi
 }
 
-echo "cron_rutracker_smoke BASE_URL=$BASE_URL TIMEOUT=${TIMEOUT}s cat=$CAT maxTopics=$MAX_TOPICS"
+# Wait until jobKey (e.g. rutracker:ParseAllTask) leaves /health/background-jobs.
+wait_bg_job() {
+  local job_key="$1"
+  local deadline=$((SECONDS + WAIT_BG))
+  local seen=0
+  while (( SECONDS < deadline )); do
+    local jobs
+    jobs="$(curl -fsS --max-time 15 "$(admin_url /health/background-jobs)" || echo '[]')"
+    if [[ "$jobs" == *"$job_key"* ]]; then
+      seen=1
+      echo "  … $job_key still running"
+      sleep "$POLL_SEC"
+      continue
+    fi
+    if (( seen == 1 )); then
+      echo "  $job_key finished"
+      return 0
+    fi
+    # Job may finish before first poll — treat as done after a brief settle.
+    sleep "$POLL_SEC"
+    jobs="$(curl -fsS --max-time 15 "$(admin_url /health/background-jobs)" || echo '[]')"
+    if [[ "$jobs" != *"$job_key"* ]]; then
+      echo "  $job_key finished (or was very fast)"
+      return 0
+    fi
+  done
+  echo "FAIL: $job_key still active after ${WAIT_BG}s" >&2
+  return 1
+}
+
+echo "cron_rutracker_smoke BASE_URL=$BASE_URL TIMEOUT=${TIMEOUT}s cat=$CAT maxTopics=$MAX_TOPICS maxPages=$MAX_PAGES"
 
 warm_url="$(admin_url /cron/cloudflare/Warmup)"
-echo "→ warmup $warm_url"
+echo "→ 1/4 warmup $warm_url"
 warm_out="$(curl -fsS --max-time "$TIMEOUT" "$warm_url" || true)"
 echo "  $warm_out"
 if [[ "$warm_out" != *'"ok":true'* && "$warm_out" != *'"ok": true'* ]]; then
@@ -38,13 +79,32 @@ if [[ "$warm_out" != *'"ok":true'* && "$warm_out" != *'"ok": true'* ]]; then
 fi
 
 parse_url="$(admin_url "/cron/rutracker/parse?page=0&cat=${CAT}&maxTopics=${MAX_TOPICS}")"
-echo "→ parse $parse_url"
+echo "→ 2/4 parse $parse_url"
 parse_out="$(curl -fsS --max-time "$TIMEOUT" "$parse_url" || true)"
 echo "  $parse_out"
-
 if [[ "$parse_out" != *"${CAT} - 0 - True"* && "$parse_out" != *"${CAT} - 0 - true"* ]]; then
   echo "FAIL: expected '${CAT} - 0 - True' in parse output" >&2
   exit 1
 fi
 
-echo "PASS: rutracker smoke ok"
+update_url="$(admin_url "/cron/rutracker/UpdateTasksParse?cat=${CAT}")"
+echo "→ 3/4 UpdateTasksParse $update_url"
+update_ack="$(curl -fsS --max-time 30 "$update_url" || true)"
+echo "  ack: $update_ack"
+if [[ "$update_ack" != "ok" && "$update_ack" != "work" ]]; then
+  echo "FAIL: UpdateTasksParse unexpected ack: $update_ack" >&2
+  exit 1
+fi
+wait_bg_job "rutracker:UpdateTasksParse"
+
+parse_all_url="$(admin_url "/cron/rutracker/ParseAllTask?cat=${CAT}&maxPages=${MAX_PAGES}")"
+echo "→ 4/4 ParseAllTask $parse_all_url"
+all_ack="$(curl -fsS --max-time 30 "$parse_all_url" || true)"
+echo "  ack: $all_ack"
+if [[ "$all_ack" != "ok" && "$all_ack" != "work" ]]; then
+  echo "FAIL: ParseAllTask unexpected ack: $all_ack" >&2
+  exit 1
+fi
+wait_bg_job "rutracker:ParseAllTask"
+
+echo "PASS: rutracker smoke ok (parse + UpdateTasksParse + ParseAllTask, capped)"

--- a/scripts/cron_rutracker_smoke.sh
+++ b/scripts/cron_rutracker_smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Limited live Rutracker parse smoke via FlareSolverr.
+# Prerequisites: JacRed running, FlareSolverr up (e.g. http://127.0.0.1:8191).
+#
+# Usage:
+#   ./scripts/cron_rutracker_smoke.sh
+#   BASE_URL=http://127.0.0.1:9117 DEVKEY=secret TIMEOUT=180 ./scripts/cron_rutracker_smoke.sh
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:9117}"
+DEVKEY="${DEVKEY:-}"
+TIMEOUT="${TIMEOUT:-180}"
+CAT="${CAT:-2090}"
+MAX_TOPICS="${MAX_TOPICS:-3}"
+
+admin_url() {
+  local path="$1"
+  if [[ -n "$DEVKEY" ]]; then
+    if [[ "$path" == *\?* ]]; then
+      echo "${BASE_URL}${path}&devkey=${DEVKEY}"
+    else
+      echo "${BASE_URL}${path}?devkey=${DEVKEY}"
+    fi
+  else
+    echo "${BASE_URL}${path}"
+  fi
+}
+
+echo "cron_rutracker_smoke BASE_URL=$BASE_URL TIMEOUT=${TIMEOUT}s cat=$CAT maxTopics=$MAX_TOPICS"
+
+warm_url="$(admin_url /cron/cloudflare/Warmup)"
+echo "→ warmup $warm_url"
+warm_out="$(curl -fsS --max-time "$TIMEOUT" "$warm_url" || true)"
+echo "  $warm_out"
+if [[ "$warm_out" != *'"ok":true'* && "$warm_out" != *'"ok": true'* ]]; then
+  echo "FAIL: warmup did not return ok:true" >&2
+  exit 1
+fi
+
+parse_url="$(admin_url "/cron/rutracker/parse?page=0&cat=${CAT}&maxTopics=${MAX_TOPICS}")"
+echo "→ parse $parse_url"
+parse_out="$(curl -fsS --max-time "$TIMEOUT" "$parse_url" || true)"
+echo "  $parse_out"
+
+if [[ "$parse_out" != *"${CAT} - 0 - True"* && "$parse_out" != *"${CAT} - 0 - true"* ]]; then
+  echo "FAIL: expected '${CAT} - 0 - True' in parse output" >&2
+  exit 1
+fi
+
+echo "PASS: rutracker smoke ok"

--- a/tests/JacRed.Tests/Networking/ChallengeDetectionTests.cs
+++ b/tests/JacRed.Tests/Networking/ChallengeDetectionTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http;
+using JacRed.Infrastructure.Networking;
+using Xunit;
+
+namespace JacRed.Tests.Networking;
+
+/// <summary>
+/// Отличаем вызов Cloudflare от обычного отказа трекера.
+///
+/// Цена ошибки несимметрична. Не распознали проверку — потеряли одну
+/// страницу. Приняли обычный отказ за проверку — хост уходит в браузер
+/// на часы, и обход встаёт целиком.
+///
+/// Признак — <c>cf-mitigated</c>, не <c>cf-ray</c> (cf-ray стоит на каждом
+/// ответе сайта за Cloudflare, включая обычный 200).
+/// </summary>
+public class ChallengeDetectionTests
+{
+    static HttpResponseMessage Response(HttpStatusCode code, params (string name, string value)[] headers)
+    {
+        var r = new HttpResponseMessage(code);
+        foreach (var (name, value) in headers)
+            r.Headers.TryAddWithoutValidation(name, value);
+        return r;
+    }
+
+    [Fact]
+    public void Cf_ray_сам_по_себе_проверкой_не_считается()
+    {
+        Assert.False(IsChallenge(Response(HttpStatusCode.ServiceUnavailable, ("cf-ray", "a23b3a1cf9f8dbcb-FRA"))));
+        Assert.False(IsChallenge(Response(HttpStatusCode.Forbidden, ("cf-ray", "a23b3a1cf9f8dbcb-FRA"))));
+    }
+
+    [Fact]
+    public void Cf_mitigated_считается()
+    {
+        Assert.True(IsChallenge(Response(HttpStatusCode.Forbidden, ("cf-mitigated", "challenge"))));
+        Assert.True(IsChallenge(Response(HttpStatusCode.ServiceUnavailable, ("cf-mitigated", "challenge"))));
+    }
+
+    [Fact]
+    public void Успешный_ответ_проверкой_не_считается()
+    {
+        Assert.False(IsChallenge(Response(HttpStatusCode.OK, ("cf-mitigated", "challenge"))));
+        Assert.False(IsChallenge(null));
+    }
+
+    [Theory]
+    [InlineData("<html><head><title>Just a moment...</title></head></html>")]
+    [InlineData("<html><head><title>Один момент...</title></head></html>")]
+    [InlineData("<div class=\"cf-browser-verification\"></div>")]
+    [InlineData("window._cf_chl_opt = {}")]
+    [InlineData("/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1")]
+    public void Разметка_задачи_в_теле_считается(string body)
+    {
+        Assert.True(CloudflareClearance.IsChallengeBody(body));
+    }
+
+    [Theory]
+    [InlineData("<html><body>Форум временно недоступен</body></html>")]
+    [InlineData("504 Gateway Time-out")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Обычная_страница_отказа_проверкой_не_считается(string body)
+    {
+        Assert.False(CloudflareClearance.IsChallengeBody(body));
+    }
+
+    [Fact]
+    public void Большое_тело_не_разбираем()
+    {
+        Assert.False(CloudflareClearance.IsChallengeBody(new string('a', 300_000) + "Just a moment"));
+    }
+
+    static bool IsChallenge(HttpResponseMessage r) => CloudflareClearance.IsChallenge(r);
+}


### PR DESCRIPTION
- Added FlareSolverr service to `docker-compose.example.yml` for handling Cloudflare challenges.
- Implemented `CloudflareController` for warming up the FlareSolverr session before Rutracker parsing.
- Updated configuration schema and settings for FlareSolverr integration.
- Enhanced Rutracker parsing logic to utilize FlareSolverr for guarded hosts.
- Revised documentation to include FlareSolverr setup instructions and cron job configurations for warmup and parsing.

Signed-off-by: Pavel Pikta <devops@pavelpikta.com>