### PR TITLE
feat(kinozal): add FixKinozalDomainDuplicates migration 

### DIFF
--- a/Application/Dev/DevMigrationService.cs
+++ b/Application/Dev/DevMigrationService.cs
@@ -10,6 +10,7 @@ namespace JacRed.Application.Dev
         readonly FixAnilibertyUrlsMigration _fixAnilibertyUrls;
         readonly RemoveDuplicateAnilibertyMigration _removeDuplicateAniliberty;
         readonly FixAnimelayerDuplicatesMigration _fixAnimelayerDuplicates;
+        readonly FixKinozalDomainDuplicatesMigration _fixKinozalDomainDuplicates;
 
         public DevMigrationService(
             FixKnabenNamesMigration fixKnabenNames,
@@ -17,7 +18,8 @@ namespace JacRed.Application.Dev
             CleanupMigrations cleanup,
             FixAnilibertyUrlsMigration fixAnilibertyUrls,
             RemoveDuplicateAnilibertyMigration removeDuplicateAniliberty,
-            FixAnimelayerDuplicatesMigration fixAnimelayerDuplicates)
+            FixAnimelayerDuplicatesMigration fixAnimelayerDuplicates,
+            FixKinozalDomainDuplicatesMigration fixKinozalDomainDuplicates)
         {
             _fixKnabenNames = fixKnabenNames;
             _fixBitruNames = fixBitruNames;
@@ -25,6 +27,7 @@ namespace JacRed.Application.Dev
             _fixAnilibertyUrls = fixAnilibertyUrls;
             _removeDuplicateAniliberty = removeDuplicateAniliberty;
             _fixAnimelayerDuplicates = fixAnimelayerDuplicates;
+            _fixKinozalDomainDuplicates = fixKinozalDomainDuplicates;
         }
 
         public object FixKnabenNames() => _fixKnabenNames.Run();
@@ -43,5 +46,7 @@ namespace JacRed.Application.Dev
         public object RemoveDuplicateAniliberty() => _removeDuplicateAniliberty.Run();
 
         public object FixAnimelayerDuplicates() => _fixAnimelayerDuplicates.Run();
+
+        public object FixKinozalDomainDuplicates() => _fixKinozalDomainDuplicates.Run();
     }
 }

--- a/Application/Dev/IDevMigrationService.cs
+++ b/Application/Dev/IDevMigrationService.cs
@@ -10,5 +10,6 @@ namespace JacRed.Application.Dev
         object MigrateAnilibertyUrls();
         object RemoveDuplicateAniliberty();
         object FixAnimelayerDuplicates();
+        object FixKinozalDomainDuplicates();
     }
 }

--- a/Application/Dev/Migrations/FixKinozalDomainDuplicatesMigration.cs
+++ b/Application/Dev/Migrations/FixKinozalDomainDuplicatesMigration.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using JacRed.Infrastructure.Persistence;
+using JacRed.Models.Details;
+
+namespace JacRed.Application.Dev.Migrations
+{
+    /// <summary>
+    /// Схлопывает дубли kinozal после смены домена (.tv → .guru) и
+    /// переписывает одиночные URL на канонический хост из конфига.
+    /// Группировка по details.php?id= — стабильный ID раздачи.
+    /// </summary>
+    public sealed class FixKinozalDomainDuplicatesMigration : IDevMigration
+    {
+        public string Name => "fixKinozalDomainDuplicates";
+
+        static readonly Regex RxId = new Regex(@"details\.php\?id=(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public object Run()
+        {
+            int scanned = 0, rewritten = 0, merged = 0, removed = 0;
+            string canonicalHost = HostOf(AppInit.conf.Kinozal.host) ?? "kinozal.guru";
+            string canonicalBase = (AppInit.conf.Kinozal.host ?? "https://kinozal.guru").TrimEnd('/');
+
+            foreach (var item in FileDB.masterDb.ToArray())
+            {
+                using (var fdb = FileDB.OpenWrite(item.Key))
+                {
+                    var groups = new Dictionary<int, List<KeyValuePair<string, TorrentDetails>>>();
+
+                    foreach (var kv in fdb.Database)
+                    {
+                        var torrent = kv.Value;
+                        if (torrent == null)
+                            continue;
+
+                        if (!string.Equals(torrent.trackerName, "kinozal", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        scanned++;
+
+                        var m = RxId.Match(kv.Key);
+                        if (!m.Success || !int.TryParse(m.Groups[1].Value, out int id) || id <= 0)
+                            continue;
+
+                        if (!groups.TryGetValue(id, out var list))
+                            groups[id] = list = new List<KeyValuePair<string, TorrentDetails>>();
+
+                        list.Add(kv);
+                    }
+
+                    var toRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    var toWrite = new Dictionary<string, TorrentDetails>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var pair in groups)
+                    {
+                        int id = pair.Key;
+                        var entries = pair.Value;
+                        string canonicalUrl = $"{canonicalBase}/details.php?id={id}";
+
+                        var keep = entries.FirstOrDefault(kv =>
+                            string.Equals(HostOf(kv.Key), canonicalHost, StringComparison.OrdinalIgnoreCase));
+
+                        if (keep.Key == null)
+                        {
+                            keep = entries
+                                .OrderByDescending(kv => !string.IsNullOrWhiteSpace(kv.Value.magnet))
+                                .ThenByDescending(kv => kv.Value.sid)
+                                .ThenByDescending(kv => kv.Value.updateTime)
+                                .First();
+                        }
+
+                        var keepTorrent = keep.Value;
+                        int losersInGroup = 0;
+
+                        foreach (var kv in entries)
+                        {
+                            if (ReferenceEquals(kv.Value, keepTorrent))
+                                continue;
+
+                            MergeFields(keepTorrent, kv.Value);
+                            toRemove.Add(kv.Key);
+                            losersInGroup++;
+                            merged++;
+                            removed++;
+                        }
+
+                        bool needsRewrite = !string.Equals(keep.Key, canonicalUrl, StringComparison.OrdinalIgnoreCase);
+                        if (needsRewrite)
+                        {
+                            // Канонический ключ мог принадлежать loser — уже в toRemove.
+                            if (fdb.Database.ContainsKey(canonicalUrl) && !toRemove.Contains(canonicalUrl))
+                            {
+                                // Неожиданный конфликт: оставляем текущий ключ.
+                                continue;
+                            }
+
+                            toRemove.Add(keep.Key);
+                            keepTorrent.url = canonicalUrl;
+                            toWrite[canonicalUrl] = keepTorrent;
+                            rewritten++;
+                        }
+                        else if (losersInGroup > 0)
+                        {
+                            keepTorrent.url = canonicalUrl;
+                        }
+                    }
+
+                    if (toRemove.Count == 0 && toWrite.Count == 0)
+                        continue;
+
+                    foreach (string url in toRemove)
+                        fdb.Database.Remove(url);
+
+                    foreach (var kv in toWrite)
+                    {
+                        kv.Value.url = kv.Key;
+                        fdb.Database[kv.Key] = kv.Value;
+                    }
+
+                    fdb.savechanges = true;
+                }
+            }
+
+            FileDB.SaveChangesToFile();
+
+            return new
+            {
+                ok = true,
+                scanned,
+                rewritten,
+                merged,
+                removed,
+                canonicalHost
+            };
+        }
+
+        static void MergeFields(TorrentDetails keep, TorrentDetails other)
+        {
+            if (other == null)
+                return;
+
+            if (other.sid > keep.sid)
+            {
+                keep.sid = other.sid;
+                keep.pir = other.pir;
+            }
+            else if (other.sid == keep.sid && other.pir > keep.pir)
+            {
+                keep.pir = other.pir;
+            }
+
+            if (other.updateTime > keep.updateTime)
+                keep.updateTime = other.updateTime;
+
+            if (string.IsNullOrWhiteSpace(keep.magnet) && !string.IsNullOrWhiteSpace(other.magnet))
+                keep.magnet = other.magnet;
+        }
+
+        static string HostOf(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+
+            try { return new Uri(url).Host; }
+            catch (UriFormatException) { return null; }
+        }
+    }
+}

--- a/Controllers/Dev/DevMigrationController.cs
+++ b/Controllers/Dev/DevMigrationController.cs
@@ -29,5 +29,7 @@ namespace JacRed.Controllers.Dev
         public JsonResult RemoveDuplicateAniliberty() => Json(_migrationService.RemoveDuplicateAniliberty());
 
         public JsonResult FixAnimelayerDuplicates() => Json(_migrationService.FixAnimelayerDuplicates());
+
+        public JsonResult FixKinozalDomainDuplicates() => Json(_migrationService.FixKinozalDomainDuplicates());
     }
 }

--- a/Infrastructure/Persistence/FileDB/FileDB.UrlParsing.cs
+++ b/Infrastructure/Persistence/FileDB/FileDB.UrlParsing.cs
@@ -51,6 +51,13 @@ namespace JacRed.Infrastructure.Persistence
                 return m.Success && int.TryParse(m.Groups[1].Value, out int id) ? id : 0;
             }
 
+            // Kinozal: .../details.php?id=2058877 (домен мог смениться .tv → .guru)
+            if (string.Equals(trackerName, "kinozal", StringComparison.OrdinalIgnoreCase))
+            {
+                var m = Regex.Match(url, @"details\.php\?id=(\d+)", RegexOptions.IgnoreCase);
+                return m.Success && int.TryParse(m.Groups[1].Value, out int id) ? id : 0;
+            }
+
             // NNMClub: .../forum/viewtopic.php?t=1882070
             if (string.Equals(trackerName, "nnmclub", StringComparison.OrdinalIgnoreCase))
             {

--- a/Program.cs
+++ b/Program.cs
@@ -121,6 +121,7 @@ namespace JacRed
             builder.Services.AddScoped<FixAnilibertyUrlsMigration>();
             builder.Services.AddScoped<RemoveDuplicateAnilibertyMigration>();
             builder.Services.AddScoped<FixAnimelayerDuplicatesMigration>();
+            builder.Services.AddScoped<FixKinozalDomainDuplicatesMigration>();
             builder.Services.AddScoped<ITracksAdminService, TracksAdminService>();
             builder.Services.AddSingleton<IFdbMaintenanceService, FdbMaintenanceService>();
 

--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ REST API и страница **`/settings`** для редактирования
 | **`/dev/MigrateAnilibertyUrls`** | Мигрирует торренты Aniliberty на URL с хешем из magnet (`?hash=...`). |
 | **`/dev/RemoveDuplicateAniliberty`** | Удаляет дубликаты Aniliberty по хешу magnet, оставляет запись с последним `updateTime`. |
 | **`/dev/FixAnimelayerDuplicates`** | Устраняет дубликаты Animelayer: нормализует HTTP→HTTPS, удаляет HTTP-дубликаты. |
+| **`/dev/FixKinozalDomainDuplicates`** | Схлопывает дубли Kinozal после смены домена (`.tv`→`.guru`): группирует по `details.php?id=`, оставляет канонический хост из `Kinozal.host`, переписывает одиночные старые URL. Возвращает `{ ok, scanned, rewritten, merged, removed, canonicalHost }`. |
 | **`/dev/TracksStats`** | Статистика ffprobe/tracks (кэш `Data/temp/tracks-stats.json`, обновляется вместе с `stats.json` по `timeStatsUpdate`). Параметры: `?includeTorrentDb=true`, `?refresh=true` — принудительный пересчёт (игнорирует отложенный сбор при пустом index). |
 | **`/dev/ExportTracks`** | Экспорт ffprobe в JSON для lampa-tracks/R2. Параметры: `?dir=Data/tracks-export`, `?dryRun=true`, `?includeTorrentDb=true`, `?background=true`. Формат: `{aa}/{b}/{hash}.json`, тело `{ "streams": [ ... ] }`. |
 | **`/dev/ExportTracksStatus`** | Статус фонового экспорта (см. `ExportTracks` с `background=true`). |


### PR DESCRIPTION
- Introduced `FixKinozalDomainDuplicatesMigration` to consolidate duplicate Kinozal entries after domain changes.
- Updated `IDevMigrationService` and `DevMigrationService` to include the new migration method.
- Enhanced `DevMigrationController` to expose the new migration endpoint.
- Updated `README.md` with details about the new migration functionality.