### PR TITLE
feat(knaben): add new API endpoints for Knaben backfill and parsing

### DIFF
--- a/Controllers/Cron/KnabenController.cs
+++ b/Controllers/Cron/KnabenController.cs
@@ -8,9 +8,10 @@ namespace JacRed.Controllers.Cron
     /// <summary>
     /// Knaben API v1 — TV + Movies from TPB, 1337x, EZTV, Rutracker.
     /// Config: init.yaml Knaben (host, parseDelay, useproxy).
-    /// Parse: /cron/knaben/parse?pages=1&amp;query=&amp;orderBy=date — query, hours, orderBy (date|seeders|peers).
+    /// Parse: /cron/knaben/parse?pages=1&amp;orderBy=date&amp;orderDirection=desc — query, hours, orderBy, orderDirection, from, size, categories.
+    /// Backfill: /cron/knaben/backfill?pages=10 — leaf subcategories asc→desc, state in Data/temp/knaben_backfill.json.
     /// Name: Call the Midwife S15E08→Call the Midwife; War.Machine.2026→War Machine; [2026, ...]→relased.
-    /// Title normalized for FileDB (2160p, .HDR→ HDR). Migrate: /dev/fixKnabenNames.
+    /// Title normalized for FileDB (2160p, .HDR→ HDR). Migrate: /dev/FixKnabenNames.
     /// </summary>
     [Route("/cron/knaben/[action]")]
     public class KnabenController : BaseController
@@ -29,9 +30,22 @@ namespace JacRed.Controllers.Cron
             string query = null,
             int hours = 0,
             string orderBy = "date",
+            string orderDirection = "desc",
             string categories = null)
         {
-            return await _syncService.ParseAsync(from, size, pages, query, hours, orderBy, categories);
+            return await _syncService.ParseAsync(from, size, pages, query, hours, orderBy, orderDirection, categories);
         }
+
+        /// <summary>
+        /// Archive backfill by leaf TV/Movies subcategories (asc then desc, Knaben window ≤10000).
+        /// Progress: Data/temp/knaben_backfill.json. Reset with ?reset=true.
+        /// </summary>
+        async public Task<string> Backfill(int size = 300, int pages = 10, bool reset = false)
+        {
+            return await _syncService.BackfillAsync(size, pages, reset);
+        }
+
+        /// <summary>Read-only backfill checkpoint summary.</summary>
+        public string BackfillStatus() => _syncService.GetBackfillStatus();
     }
 }

--- a/Data/crontab
+++ b/Data/crontab
@@ -124,6 +124,11 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # runs every hour at :12,:32,:52 (e.g. 00:12, 00:32, 00:52)
 12,32,52 * * * *  /opt/jacred/Data/run-job.sh knaben-parse http://127.0.0.1:9117/cron/knaben/parse 900
 
+# knaben-backfill -> /cron/knaben/backfill (max_time=900s)
+# leaf TV/Movies subcategories, asc→desc within Knaben 10k window; state: Data/temp/knaben_backfill.json
+# runs hourly at :42 (staggered from parse)
+42 * * * *  /opt/jacred/Data/run-job.sh knaben-backfill "http://127.0.0.1:9117/cron/knaben/backfill?pages=10" 900
+
 # animelayer-parse -> /cron/animelayer/parse (max_time=900s)
 # runs every hour at :02,:17,:32,:47 (e.g. 00:02, 00:17, 00:32, …)
 2,17,32,47 * * * *  /opt/jacred/Data/run-job.sh animelayer-parse http://127.0.0.1:9117/cron/animelayer/parse 900

--- a/Infrastructure/Trackers/Knaben/KnabenSyncService.cs
+++ b/Infrastructure/Trackers/Knaben/KnabenSyncService.cs
@@ -11,6 +11,7 @@ using JacRed.Infrastructure.Parsing;
 using JacRed.Models.Details;
 using JacRed.Models.tParse;
 using Newtonsoft.Json;
+using IO = System.IO;
 
 namespace JacRed.Infrastructure.Trackers.Knaben
 {
@@ -20,6 +21,8 @@ namespace JacRed.Infrastructure.Trackers.Knaben
         const int MinApiDelayMs = 500;
         const int MaxSize = 300;
         const int MaxPages = 10;
+        const int MaxFromWindow = 10000;
+        const string BackfillStatePath = "Data/temp/knaben_backfill.json";
 
         static readonly int[] DefaultCategories =
         {
@@ -27,10 +30,19 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             3000000, 3001000, 3002000, 3003000, 3004000, 3005000, 3006000, 3007000, 3008000
         };
 
+        /// <summary>Leaf TV/Movies subcategories for archive backfill (no parent 2000000 / 3000000).</summary>
+        static readonly int[] BackfillCategories =
+        {
+            2001000, 2002000, 2003000, 2004000, 2005000, 2006000, 2007000, 2008000,
+            3001000, 3002000, 3003000, 3004000, 3005000, 3006000, 3007000, 3008000
+        };
+
         static string ApiUrl => $"{AppInit.conf.Knaben.host.TrimEnd('/')}/v1";
         static int ApiDelayMs => Math.Max(MinApiDelayMs, AppInit.conf.Knaben.parseDelay);
 
         static readonly TrackerParseLock _parseLock = new TrackerParseLock();
+        static readonly TrackerParseLock _backfillLock = new TrackerParseLock();
+        static readonly object _backfillStateLock = new object();
 
         public async Task<string> ParseAsync(
             int from = 0,
@@ -39,6 +51,7 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             string query = null,
             int hours = 0,
             string orderBy = "date",
+            string orderDirection = "desc",
             string categories = null,
             CancellationToken cancellationToken = default)
         {
@@ -50,9 +63,33 @@ namespace JacRed.Infrastructure.Trackers.Knaben
                 int s = Math.Min(MaxSize, Math.Max(1, size));
                 int p = Math.Max(1, Math.Min(MaxPages, pages));
                 int[] cats = ParseCategories(categories);
+                string dir = NormalizeOrderDirection(orderDirection);
 
-                return await ParseCore(from, s, p, query?.Trim(), hours, orderBy, cats, cancellationToken);
+                return await ParseCore(from, s, p, query?.Trim(), hours, orderBy, dir, cats, cancellationToken);
             });
+        }
+
+        public async Task<string> BackfillAsync(
+            int size = 300,
+            int pages = 10,
+            bool reset = false,
+            CancellationToken cancellationToken = default)
+        {
+            return await TrackerSyncHelpers.RunParseAsync($"{TrackerName}-backfill", _backfillLock, checkDisabled: false, async () =>
+            {
+                if (!EnsureConfig())
+                    return "config missing";
+
+                int s = Math.Min(MaxSize, Math.Max(1, size));
+                int p = Math.Max(1, Math.Min(MaxPages, pages));
+                return await BackfillCore(s, p, reset, cancellationToken);
+            });
+        }
+
+        public string GetBackfillStatus()
+        {
+            var state = LoadBackfillState(reset: false);
+            return FormatBackfillStatus(state);
         }
 
         static bool EnsureConfig()
@@ -61,6 +98,9 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             ParserLog.Write(TrackerName, "Config missing — add Knaben to init.yaml");
             return false;
         }
+
+        static string NormalizeOrderDirection(string orderDirection)
+            => string.Equals(orderDirection, "asc", StringComparison.OrdinalIgnoreCase) ? "asc" : "desc";
 
         static int[] ParseCategories(string s)
         {
@@ -74,14 +114,20 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             return parsed.Length > 0 ? parsed : DefaultCategories;
         }
 
-        async Task<string> ParseCore(int from, int size, int pages, string query, int hours, string orderBy, int[] categories, CancellationToken cancellationToken)
+        async Task<string> ParseCore(int from, int size, int pages, string query, int hours, string orderBy, string orderDirection, int[] categories, CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
             int totalFetched = 0, added = 0, updated = 0, skipped = 0, failed = 0;
 
             try
             {
-                var opts = new Dictionary<string, object> { { "from", from }, { "size", size }, { "pages", pages } };
+                if (from >= MaxFromWindow)
+                {
+                    ParserLog.Write(TrackerName, "from exceeds Knaben window", new Dictionary<string, object> { { "from", from }, { "max", MaxFromWindow } });
+                    return $"error: from must be < {MaxFromWindow} (Knaben from+size ≤ {MaxFromWindow})";
+                }
+
+                var opts = new Dictionary<string, object> { { "from", from }, { "size", size }, { "pages", pages }, { "orderDirection", orderDirection } };
                 if (!string.IsNullOrEmpty(query)) opts["query"] = query;
                 if (hours > 0) opts["hours"] = hours;
                 opts["orderBy"] = orderBy;
@@ -94,11 +140,15 @@ namespace JacRed.Infrastructure.Trackers.Knaben
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     int offset = from + page * size;
-                    var batch = await FetchTorrentsFromApi(offset, size, secondsSince, query, orderBy, categories, cancellationToken);
-                    if (batch == null || batch.Count == 0) break;
-                    all.AddRange(batch);
-                    totalFetched += batch.Count;
-                    if (batch.Count < size) break;
+                    if (offset >= MaxFromWindow) break;
+                    int pageSize = Math.Min(size, MaxFromWindow - offset);
+                    if (pageSize <= 0) break;
+
+                    var batch = await FetchTorrentsFromApi(offset, pageSize, secondsSince, query, orderBy, orderDirection, categories, hideUnsafe: true, cancellationToken);
+                    if (batch.Torrents == null || batch.Torrents.Count == 0) break;
+                    all.AddRange(batch.Torrents);
+                    totalFetched += batch.Torrents.Count;
+                    if (batch.Torrents.Count < pageSize) break;
                     if (page < pages - 1) await Task.Delay(ApiDelayMs, cancellationToken);
                 }
 
@@ -124,6 +174,287 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             }
         }
 
+        async Task<string> BackfillCore(int size, int pages, bool reset, CancellationToken cancellationToken)
+        {
+            var sw = Stopwatch.StartNew();
+            int callFetched = 0, callAdded = 0, callUpdated = 0, callSkipped = 0, callFailed = 0;
+
+            try
+            {
+                var state = LoadBackfillState(reset);
+                if (state.Finished)
+                {
+                    ParserLog.Write(TrackerName, "Backfill already finished", new Dictionary<string, object> { { "status", FormatBackfillStatus(state) } });
+                    return FormatBackfillStatus(state) + " (finished)";
+                }
+
+                ParserLog.Write(TrackerName, "Starting backfill", new Dictionary<string, object>
+                {
+                    { "size", size }, { "pages", pages }, { "reset", reset },
+                    { "cat", state.CategoryId }, { "dir", state.Direction }, { "from", state.From }
+                });
+
+                int pagesDone = 0;
+                while (pagesDone < pages && !state.Finished)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (state.From >= MaxFromWindow)
+                    {
+                        AdvanceBackfillPass(state, lastPageIds: null, earlyEnd: false);
+                        PersistBackfillState(state);
+                        continue;
+                    }
+
+                    int pageSize = Math.Min(size, MaxFromWindow - state.From);
+                    if (pageSize <= 0)
+                    {
+                        AdvanceBackfillPass(state, lastPageIds: null, earlyEnd: false);
+                        PersistBackfillState(state);
+                        continue;
+                    }
+
+                    var batch = await FetchTorrentsFromApi(
+                        state.From,
+                        pageSize,
+                        secondsSince: null,
+                        query: null,
+                        orderBy: "date",
+                        orderDirection: state.Direction,
+                        categories: new[] { state.CategoryId },
+                        hideUnsafe: false,
+                        cancellationToken);
+
+                    if (batch.Torrents.Count > 0)
+                    {
+                        var (added, updated, skipped, failed) = await SaveTorrents(batch.Torrents, cancellationToken);
+                        callFetched += batch.Torrents.Count;
+                        callAdded += added;
+                        callUpdated += updated;
+                        callSkipped += skipped;
+                        callFailed += failed;
+                        state.TotalFetched += batch.Torrents.Count;
+                        state.TotalAdded += added;
+                        state.TotalUpdated += updated;
+                    }
+
+                    bool earlyEnd = batch.Torrents.Count < pageSize;
+                    bool isAsc = state.Direction == "asc";
+
+                    if (isAsc && batch.Ids.Count > 0)
+                        state.AscEdgeIds = batch.Ids;
+
+                    if (!isAsc
+                        && state.AscEdgeIds != null
+                        && state.AscEdgeIds.Count > 0
+                        && batch.Ids.Any(id => state.AscEdgeIds.Contains(id)))
+                    {
+                        state.DescSawOverlap = true;
+                    }
+
+                    state.From += pageSize;
+                    pagesDone++;
+
+                    if (earlyEnd || state.From >= MaxFromWindow)
+                    {
+                        AdvanceBackfillPass(state, batch.Ids, earlyEnd);
+                    }
+
+                    PersistBackfillState(state);
+
+                    if (pagesDone < pages && !state.Finished)
+                        await Task.Delay(ApiDelayMs, cancellationToken);
+                }
+
+                ParserLog.Write(TrackerName, $"Backfill step completed (took {sw.Elapsed.TotalSeconds:F1}s)",
+                    new Dictionary<string, object>
+                    {
+                        { "fetched", callFetched }, { "added", callAdded }, { "updated", callUpdated },
+                        { "skipped", callSkipped }, { "failed", callFailed },
+                        { "cat", state.CategoryId }, { "dir", state.Direction }, { "from", state.From },
+                        { "finished", state.Finished }
+                    });
+
+                return $"cat={state.CategoryId} dir={state.Direction} from={state.From} "
+                    + $"fetched={callFetched} +{callAdded} ~{callUpdated} ={callSkipped} failed={callFailed} "
+                    + FormatBackfillProgress(state)
+                    + (state.Finished ? " finished" : "");
+            }
+            catch (OperationCanceledException oce)
+            {
+                ParserLog.Write(TrackerName, "Backfill canceled", new Dictionary<string, object> { { "message", oce.Message } });
+                return "canceled";
+            }
+            catch (Exception ex)
+            {
+                if (ex is OutOfMemoryException) throw;
+                ParserLog.Write(TrackerName, $"Backfill error: {ex.Message}");
+                return $"error: {ex.Message}";
+            }
+        }
+
+        static void AdvanceBackfillPass(KnabenBackfillState state, List<string> lastPageIds, bool earlyEnd)
+        {
+            bool isAsc = state.Direction == "asc";
+
+            if (isAsc)
+            {
+                if (earlyEnd)
+                {
+                    SetCategoryStatus(state, state.CategoryId, "complete");
+                    MoveToNextBackfillCategory(state);
+                }
+                else
+                {
+                    // Hit 10k window — keep AscEdgeIds, switch to desc.
+                    state.Direction = "desc";
+                    state.From = 0;
+                    state.DescSawOverlap = false;
+                }
+                return;
+            }
+
+            // desc pass finished
+            bool overlap = state.DescSawOverlap
+                || (state.AscEdgeIds != null && lastPageIds != null && lastPageIds.Any(id => state.AscEdgeIds.Contains(id)));
+            SetCategoryStatus(state, state.CategoryId, overlap ? "complete" : "partial");
+            MoveToNextBackfillCategory(state);
+        }
+
+        static void MoveToNextBackfillCategory(KnabenBackfillState state)
+        {
+            state.CategoryIndex++;
+            state.AscEdgeIds = new List<string>();
+            state.DescSawOverlap = false;
+            state.Direction = "asc";
+            state.From = 0;
+
+            if (state.CategoryIndex >= BackfillCategories.Length)
+            {
+                state.Finished = true;
+                state.CategoryId = 0;
+                return;
+            }
+
+            state.CategoryId = BackfillCategories[state.CategoryIndex];
+            EnsureCategoryPending(state, state.CategoryId);
+        }
+
+        static void EnsureCategoryPending(KnabenBackfillState state, int categoryId)
+        {
+            string key = categoryId.ToString();
+            if (!state.CategoryStatus.ContainsKey(key))
+                state.CategoryStatus[key] = "pending";
+        }
+
+        static void SetCategoryStatus(KnabenBackfillState state, int categoryId, string status)
+        {
+            state.CategoryStatus[categoryId.ToString()] = status;
+        }
+
+        static KnabenBackfillState CreateFreshBackfillState()
+        {
+            var state = new KnabenBackfillState
+            {
+                CategoryIndex = 0,
+                CategoryId = BackfillCategories[0],
+                Direction = "asc",
+                From = 0,
+                AscEdgeIds = new List<string>(),
+                CategoryStatus = new Dictionary<string, string>(),
+                Finished = false,
+                UpdatedAt = DateTime.UtcNow
+            };
+            foreach (int cat in BackfillCategories)
+                state.CategoryStatus[cat.ToString()] = "pending";
+            return state;
+        }
+
+        static KnabenBackfillState LoadBackfillState(bool reset)
+        {
+            lock (_backfillStateLock)
+            {
+                if (reset || !IO.File.Exists(BackfillStatePath))
+                {
+                    var fresh = CreateFreshBackfillState();
+                    TryWriteBackfillState(fresh);
+                    return fresh;
+                }
+
+                try
+                {
+                    var state = JsonConvert.DeserializeObject<KnabenBackfillState>(IO.File.ReadAllText(BackfillStatePath));
+                    if (state == null)
+                        return CreateFreshBackfillState();
+
+                    if (state.CategoryStatus == null)
+                        state.CategoryStatus = new Dictionary<string, string>();
+                    if (state.AscEdgeIds == null)
+                        state.AscEdgeIds = new List<string>();
+                    if (string.IsNullOrWhiteSpace(state.Direction))
+                        state.Direction = "asc";
+                    state.Direction = NormalizeOrderDirection(state.Direction);
+
+                    if (!state.Finished && (state.CategoryId == 0 || !BackfillCategories.Contains(state.CategoryId)))
+                    {
+                        if (state.CategoryIndex >= 0 && state.CategoryIndex < BackfillCategories.Length)
+                            state.CategoryId = BackfillCategories[state.CategoryIndex];
+                        else
+                        {
+                            var fresh = CreateFreshBackfillState();
+                            TryWriteBackfillState(fresh);
+                            return fresh;
+                        }
+                    }
+
+                    return state;
+                }
+                catch
+                {
+                    var fresh = CreateFreshBackfillState();
+                    TryWriteBackfillState(fresh);
+                    return fresh;
+                }
+            }
+        }
+
+        static void PersistBackfillState(KnabenBackfillState state)
+        {
+            lock (_backfillStateLock)
+            {
+                state.UpdatedAt = DateTime.UtcNow;
+                TryWriteBackfillState(state);
+            }
+        }
+
+        static void TryWriteBackfillState(KnabenBackfillState state)
+        {
+            try
+            {
+                string dir = IO.Path.GetDirectoryName(BackfillStatePath);
+                if (!string.IsNullOrEmpty(dir) && !IO.Directory.Exists(dir))
+                    IO.Directory.CreateDirectory(dir);
+                IO.File.WriteAllText(BackfillStatePath, JsonConvert.SerializeObject(state, Formatting.Indented));
+            }
+            catch { }
+        }
+
+        static string FormatBackfillProgress(KnabenBackfillState state)
+        {
+            int done = state.CategoryStatus?.Count(kv => kv.Value == "complete" || kv.Value == "partial") ?? 0;
+            int partial = state.CategoryStatus?.Count(kv => kv.Value == "partial") ?? 0;
+            return $"progress={done}/{BackfillCategories.Length}" + (partial > 0 ? $" partial={partial}" : "");
+        }
+
+        static string FormatBackfillStatus(KnabenBackfillState state)
+        {
+            if (state == null) return "no state";
+            return $"finished={state.Finished} cat={state.CategoryId} dir={state.Direction} from={state.From} "
+                + $"totalFetched={state.TotalFetched} +{state.TotalAdded} ~{state.TotalUpdated} "
+                + FormatBackfillProgress(state)
+                + $" updatedAt={state.UpdatedAt:O}";
+        }
+
         async Task<KnabenApiResponse> ApiRequestAsync(KnabenApiRequest req, CancellationToken cancellationToken)
         {
             if (AppInit.conf?.Knaben == null) return null;
@@ -142,16 +473,33 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             return JsonConvert.DeserializeObject<KnabenApiResponse>(response);
         }
 
-        async Task<List<TorrentDetails>> FetchTorrentsFromApi(int from, int size, int? secondsSince, string query, string orderBy, int[] categories, CancellationToken cancellationToken)
+        async Task<KnabenFetchPage> FetchTorrentsFromApi(
+            int from,
+            int size,
+            int? secondsSince,
+            string query,
+            string orderBy,
+            string orderDirection,
+            int[] categories,
+            bool hideUnsafe,
+            CancellationToken cancellationToken)
         {
+            var empty = new KnabenFetchPage { Torrents = new List<TorrentDetails>(), Ids = new List<string>() };
+            if (from >= MaxFromWindow || size <= 0)
+                return empty;
+
+            int clampedSize = Math.Min(size, MaxFromWindow - from);
+            if (clampedSize <= 0)
+                return empty;
+
             var req = new KnabenApiRequest
             {
                 Categories = categories,
                 OrderBy = orderBy == "seeders" || orderBy == "peers" ? orderBy : "date",
-                OrderDirection = "desc",
+                OrderDirection = NormalizeOrderDirection(orderDirection),
                 From = from,
-                Size = size,
-                HideUnsafe = true,
+                Size = clampedSize,
+                HideUnsafe = hideUnsafe,
                 HideXxx = true
             };
             if (!string.IsNullOrWhiteSpace(query)) { req.Query = query; req.SearchField = "title"; }
@@ -160,9 +508,15 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             await Task.Delay(ApiDelayMs, cancellationToken);
 
             var resp = await ApiRequestAsync(req, cancellationToken);
-            if (resp?.Hits == null || resp.Hits.Count == 0) return new List<TorrentDetails>();
+            if (resp?.Hits == null || resp.Hits.Count == 0)
+                return empty;
 
-            return resp.Hits.Select(KnabenParser.MapToTorrentDetails).Where(t => t != null).ToList();
+            var ids = resp.Hits
+                .Select(h => h.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToList();
+            var torrents = resp.Hits.Select(KnabenParser.MapToTorrentDetails).Where(t => t != null).ToList();
+            return new KnabenFetchPage { Torrents = torrents, Ids = ids };
         }
 
         async Task<(int added, int updated, int skipped, int failed)> SaveTorrents(List<TorrentDetails> torrents, CancellationToken cancellationToken)
@@ -218,6 +572,12 @@ namespace JacRed.Infrastructure.Trackers.Knaben
             });
 
             return (added, updated, skipped, failed);
+        }
+
+        sealed class KnabenFetchPage
+        {
+            public List<TorrentDetails> Torrents { get; set; }
+            public List<string> Ids { get; set; }
         }
     }
 }

--- a/Models/tParse/KnabenBackfillState.cs
+++ b/Models/tParse/KnabenBackfillState.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace JacRed.Models.tParse
+{
+    /// <summary>Checkpoint for Knaben archive backfill (Data/temp/knaben_backfill.json).</summary>
+    public class KnabenBackfillState
+    {
+        public int CategoryIndex { get; set; }
+
+        public int CategoryId { get; set; }
+
+        /// <summary>asc | desc</summary>
+        public string Direction { get; set; } = "asc";
+
+        public int From { get; set; }
+
+        /// <summary>categoryId → pending | complete | partial</summary>
+        public Dictionary<string, string> CategoryStatus { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>Knaben hit IDs from the last asc page (inner edge of the old window).</summary>
+        public List<string> AscEdgeIds { get; set; } = new List<string>();
+
+        /// <summary>True if any desc-page ID intersected AscEdgeIds during the current category.</summary>
+        public bool DescSawOverlap { get; set; }
+
+        public bool Finished { get; set; }
+
+        public int TotalFetched { get; set; }
+
+        public int TotalAdded { get; set; }
+
+        public int TotalUpdated { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -768,6 +768,25 @@ curl -s 'http://127.0.0.1:9117/dev/ExportTracksStatus'
 - **`GET /cron/{tracker}/parseMagnet`** — парсинг магнет-ссылок (для поддерживающих трекеров).
 - Дополнительные параметры: `parseFrom`, `parseTo`, `parseFromDate` (зависит от трекера).
 
+#### Knaben
+
+- **`GET /cron/knaben/parse`** — свежие раздачи (по умолчанию `from=0`, `size=300`, `pages=1`, `orderBy=date`, `orderDirection=desc`, все TV+Movies категории). Параметры: `from`, `size` (≤300), `pages` (≤10), `query`, `hours`, `orderBy` (`date`|`seeders`|`peers`), `orderDirection` (`desc`|`asc`), `categories` (через запятую). Окно Knaben API: `from + size ≤ 10000`.
+- **`GET /cron/knaben/backfill`** — заполнение архива по листовым подкатегориям `2001000`–`2008000` и `3001000`–`3008000`: сначала `asc` (старые), при достижении 10 000 — встречный `desc` (новые). Состояние: **`Data/temp/knaben_backfill.json`**. Параметры: `pages` (≤10), `size` (≤300), `reset=true` — начать заново. Категории ≤10 000 — `complete` за один проход; ≤20 000 — за два; больше 20 000 — `partial` (середина недоступна из‑за лимита API).
+- **`GET /cron/knaben/backfillStatus`** — краткий статус checkpoint без запуска.
+
+Пример crontab (см. также [`Data/crontab`](Data/crontab)):
+
+```text
+*/20 * * * * curl -s "http://127.0.0.1:9117/cron/knaben/parse"
+0 * * * * curl -s "http://127.0.0.1:9117/cron/knaben/backfill?pages=10"
+```
+
+Ручной старт архива с `asc`:
+
+```text
+curl -s "http://127.0.0.1:9117/cron/knaben/parse?from=0&size=300&pages=10&orderBy=date&orderDirection=asc&categories=2001000"
+```
+
 ### Обслуживание FDB (`/cron/maintenance` и CLI `maintain`)
 
 Единый проход по FileDB (ключи бакетов + shard-файлы) на битые/устаревшие/несогласованные данные.


### PR DESCRIPTION
- Introduced `GET /cron/knaben/backfill` and `GET /cron/knaben/backfillStatus` endpoints for managing Knaben archive backfill operations.
- Updated `KnabenController` to handle new backfill logic and status retrieval.
- Enhanced `KnabenSyncService` with backfill functionality and improved error handling for API limits.
- Added `KnabenBackfillState` model to track backfill progress and state.
- Updated `README.md` with new API documentation and crontab examples for backfill operations.

Fix #124 