### PR TITLE
fix(security): update evaluation logic for reverse proxies

### DIFF
--- a/AccessTraceabilityMatrix.md
+++ b/AccessTraceabilityMatrix.md
@@ -18,7 +18,7 @@
 
 **Коды отказа:** OPTIONS → 204; ключ задан, но не передан → 401; иначе → 403.
 
-**Сетевой контекст:** Peer IP — прямое TCP-подключение к Kestrel. Client IP из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (same-host proxy); иначе Client IP = peer (см. `ClientNetworkContext`). Private peer (loopback или RFC1918, напр. Traefik в Docker) **плюс** proxy identity headers **не** считается LAN — нужен `devkey` (см. `JacRedAccessEvaluator.IsTrustedLanClient`).
+**Сетевой контекст:** Peer IP — прямое TCP-подключение к Kestrel. Client IP из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (same-host proxy); иначе Client IP = peer (см. `ClientNetworkContext`). Private peer (loopback или RFC1918, напр. Traefik/nginx/Caddy в Docker) **плюс** proxy identity headers (`X-Forwarded-*`, `X-Real-IP`, `Forwarded`, `CF-*`) **не** считается LAN — нужен `devkey`. Прямой LAN без этих заголовков — без ключа (см. `JacRedAccessEvaluator.IsTrustedLanClient`).
 
 ---
 

--- a/AccessTraceabilityMatrix.md
+++ b/AccessTraceabilityMatrix.md
@@ -12,13 +12,13 @@
 | Политика | Правило middleware | Ключи |
 |----------|-------------------|-------|
 | **Public** | Всегда разрешено | — |
-| **ConfigApi** | LAN-клиент **или** валидный devkey (одного same-host proxy **недостаточно**) | `X-Dev-Key`, `?devkey=` |
-| **DevAdmin** | LAN-клиент **или** валидный devkey (одного same-host proxy **недостаточно**) | `X-Dev-Key`, `?devkey=` |
+| **ConfigApi** | LAN-клиент **или** валидный devkey (одного reverse proxy **недостаточно**) | `X-Dev-Key`, `?devkey=` |
+| **DevAdmin** | LAN-клиент **или** валидный devkey (одного reverse proxy **недостаточно**) | `X-Dev-Key`, `?devkey=` |
 | **ApiKeyWhenConfigured** | Если `apikey` в конфиге не задан — открыто; иначе нужен валидный ключ | `?apikey=`, `X-Api-Key`, `Bearer` |
 
 **Коды отказа:** OPTIONS → 204; ключ задан, но не передан → 401; иначе → 403.
 
-**Сетевой контекст:** Peer IP — прямое TCP-подключение к Kestrel. Client IP из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (same-host proxy); иначе Client IP = peer (см. `ClientNetworkContext`).
+**Сетевой контекст:** Peer IP — прямое TCP-подключение к Kestrel. Client IP из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (same-host proxy); иначе Client IP = peer (см. `ClientNetworkContext`). Private peer (loopback или RFC1918, напр. Traefik в Docker) **плюс** proxy identity headers **не** считается LAN — нужен `devkey` (см. `JacRedAccessEvaluator.IsTrustedLanClient`).
 
 ---
 
@@ -104,8 +104,8 @@
 
 ## Доступ по контексту клиента
 
-| Политика | Loopback / LAN | Same-host proxy (без devkey) | Удалённый / туннель |
-|----------|----------------|------------------------------|---------------------|
+| Политика | Loopback / LAN без proxy headers | Reverse proxy (loopback или Docker + XFF) без devkey | Удалённый / туннель |
+|----------|----------------------------------|------------------------------------------------------|---------------------|
 | Public | ✓ | ✓ | ✓ |
 | ConfigApi | ✓ | ✗ | нужен devkey |
 | DevAdmin | ✓ | ✗ | нужен devkey (если задан в конфиге) |

--- a/Infrastructure/Security/ClientNetworkContext.cs
+++ b/Infrastructure/Security/ClientNetworkContext.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using System;
 using System.Net;
 using System.Net.Sockets;
 
@@ -82,8 +81,9 @@ namespace JacRed.Infrastructure.Security
                 return true;
             if (headers.ContainsKey("X-Forwarded-For") || headers.ContainsKey("X-Real-IP"))
                 return true;
-            if (headers.TryGetValue("X-Forwarded-Proto", out var proto)
-                && !string.Equals(proto.ToString(), "http", StringComparison.OrdinalIgnoreCase))
+            // Traefik/nginx/Caddy often set these even when client IP headers vary.
+            if (headers.ContainsKey("X-Forwarded-Host") || headers.ContainsKey("X-Forwarded-Proto")
+                || headers.ContainsKey("Forwarded"))
                 return true;
             return false;
         }

--- a/Infrastructure/Security/JacRedAccessEvaluator.cs
+++ b/Infrastructure/Security/JacRedAccessEvaluator.cs
@@ -68,15 +68,17 @@ namespace JacRed.Infrastructure.Security
         }
 
         /// <summary>
-        /// LAN / direct localhost. Same-host reverse proxy (cloudflared on 127.0.0.1) alone is not enough.
+        /// LAN / direct localhost. Reverse proxy (loopback or Docker/LAN peer) alone is not enough.
         /// </summary>
         static bool IsTrustedLanClient(IClientNetworkContext network, HttpContext httpContext)
         {
             if (!network.IsDirectLocalClient)
                 return false;
 
-            // cloudflared/nginx on loopback: peer is 127.0.0.1; without real client IP the request looks local.
-            if (network.IsSameHostReverseProxy && ClientNetworkContext.HasProxyClientIdentityHeaders(httpContext))
+            // Reverse proxy on loopback OR Docker/LAN (e.g. Traefik peer 172.x): ClientIp stays the
+            // proxy private IP and looks like LAN. Proxy identity headers mean the real client is
+            // behind the proxy — require DEV key. Do not trust header values for granting LAN access.
+            if (network.IsViaLocalPeer && ClientNetworkContext.HasProxyClientIdentityHeaders(httpContext))
                 return false;
 
             return true;

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ sudo -u myservice ./jacred.sh --remove
 | `listenip` | IP для прослушивания (`any` — все интерфейсы) | `any` |
 | `listenport` | Порт HTTP | `9117` |
 | `apikey` | Ключ для поиска, Torznab, `/stats/*` JSON и прочих путей вне [белого списка](#безопасность-и-доступ-к-api). Передаётся: `?apikey=...`, `X-Api-Key`, `Authorization: Bearer`. Пусто — проверка отключена | — |
-| `devkey` | Ключ для `/dev/`, `/cron/`, `/jsondb/*`, `/api/v1.0/config/*` из интернета или через туннель. **LAN-клиент** или **`devkey`** (`X-Dev-Key`, `?devkey=`). Same-host proxy **без** devkey **не открывает** admin/config | — |
+| `devkey` | Ключ для `/dev/`, `/cron/`, `/jsondb/*`, `/api/v1.0/config/*` из интернета или через туннель. **LAN-клиент** или **`devkey`** (`X-Dev-Key`, `?devkey=`). Reverse proxy (loopback или Docker + XFF) **без** devkey **не открывает** admin/config | — |
 | `mergeduplicates` | Объединять дубликаты в выдаче | `true` |
 | `mergenumduplicates` | Объединять дубликаты по номеру (серии и т.п.) | `true` |
 | `openstats` | Открыть доступ к `/stats/*` | `true` |
@@ -540,7 +540,7 @@ Anifilm, AniLibria, HDRezka.
 
 JacRed использует единый слой доступа: **`UseJacRedSecurity()`** (`SecurityHeadersMiddleware` + `JacRedAuthorizationMiddleware`). Политика определяется **только** по префиксу пути в `JacRedEndpointRegistry` — без атрибутов на контроллерах.
 
-**Сеть:** **Peer IP** — прямое TCP-подключение к Kestrel. **Client IP** из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (cloudflared/nginx на том же хосте); иначе Client IP = peer. См. `ClientNetworkContext`.
+**Сеть:** **Peer IP** — прямое TCP-подключение к Kestrel. **Client IP** из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (cloudflared/nginx на том же хосте); иначе Client IP = peer. Если peer — private (loopback **или** RFC1918, напр. Traefik/nginx в Docker `172.x`) **и** есть proxy identity headers (`X-Forwarded-For`, `X-Real-IP`, `CF-*`, …), запрос **не** считается LAN-клиентом — нужен `devkey`. См. `ClientNetworkContext` / `JacRedAccessEvaluator`.
 
 ### Политики
 
@@ -553,7 +553,7 @@ JacRed использует единый слой доступа: **`UseJacRedSe
 
 **Коды отказа:** `OPTIONS` → 204; ключ настроен, но не передан → **401**; иначе → **403**.
 
-> **ConfigApi = DevAdmin** по сети: same-host reverse proxy **сам по себе не заменяет** `devkey`. Нужен LAN-клиент (RFC1918 / loopback по Client IP) или заголовок/`?devkey=`.
+> **ConfigApi = DevAdmin** по сети: reverse proxy (same-host loopback **или** Docker/LAN peer с `X-Forwarded-*` / `X-Real-IP`) **сам по себе не заменяет** `devkey`. Нужен прямой LAN-клиент (RFC1918 / loopback **без** proxy identity headers) или заголовок/`?devkey=`.
 
 ### Префиксы путей → политика
 
@@ -569,8 +569,8 @@ JacRed использует единый слой доступа: **`UseJacRedSe
 
 ### Доступ по контексту клиента
 
-| Политика | Loopback / LAN (Client IP) | Same-host proxy без devkey | Интернет / удалённый прокси |
-| -------- | -------------------------- | -------------------------- | --------------------------- |
+| Политика | Loopback / LAN без proxy headers | Reverse proxy (loopback или Docker `172.x` + XFF) без devkey | Интернет / удалённый прокси |
+| -------- | -------------------------------- | ------------------------------------------------------------ | --------------------------- |
 | Public | ✓ | ✓ | ✓ |
 | ConfigApi | ✓ | ✗ | `devkey` |
 | DevAdmin | ✓ | ✗ | `devkey` (если задан в конфиге) |
@@ -679,7 +679,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 
 REST API и страница **`/settings`** для редактирования **`init.yaml`** / **`init.conf`**.
 
-**Доступ:** политика **ConfigApi** — LAN-клиент **или** `devkey`. Same-host reverse proxy без devkey **недостаточен**. При заданном `apikey` — также ключ API для путей вне белого списка.
+**Доступ:** политика **ConfigApi** — LAN-клиент **или** `devkey`. Reverse proxy (loopback или Docker + XFF) без devkey **недостаточен**. При заданном `apikey` — также ключ API для путей вне белого списка.
 
 | Метод | Путь | Описание |
 |-------|------|----------|

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Anifilm, AniLibria, HDRezka.
 
 JacRed использует единый слой доступа: **`UseJacRedSecurity()`** (`SecurityHeadersMiddleware` + `JacRedAuthorizationMiddleware`). Политика определяется **только** по префиксу пути в `JacRedEndpointRegistry` — без атрибутов на контроллерах.
 
-**Сеть:** **Peer IP** — прямое TCP-подключение к Kestrel. **Client IP** из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (cloudflared/nginx на том же хосте); иначе Client IP = peer. Если peer — private (loopback **или** RFC1918, напр. Traefik/nginx в Docker `172.x`) **и** есть proxy identity headers (`X-Forwarded-For`, `X-Real-IP`, `CF-*`, …), запрос **не** считается LAN-клиентом — нужен `devkey`. См. `ClientNetworkContext` / `JacRedAccessEvaluator`.
+**Сеть:** **Peer IP** — прямое TCP-подключение к Kestrel. **Client IP** из `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` учитывается **только** если peer — loopback (cloudflared/nginx на том же хосте); иначе Client IP = peer. Если peer — private (loopback **или** RFC1918, напр. Traefik/nginx/Caddy в Docker `172.x`) **и** есть proxy identity headers (`X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `Forwarded`, `CF-*`, …), запрос **не** считается LAN-клиентом — нужен `devkey`. Прямой LAN/localhost **без** этих заголовков — по-прежнему без ключа. См. `ClientNetworkContext` / `JacRedAccessEvaluator`.
 
 ### Политики
 

--- a/tests/JacRed.Tests/Security/JacRedAccessEvaluatorTests.cs
+++ b/tests/JacRed.Tests/Security/JacRedAccessEvaluatorTests.cs
@@ -131,6 +131,69 @@ public class JacRedAccessEvaluatorTests
         });
     }
 
+    [Fact]
+    public void Docker_proxy_peer_with_XFF_requires_devkey()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                headers: ("X-Forwarded-For", "203.0.113.50"));
+
+            var result = evaluator.EvaluatePath(ConfigPath, ctx);
+
+            Assert.False(result.IsAllowed);
+            Assert.Equal(403, result.DenyStatusCode);
+        });
+    }
+
+    [Fact]
+    public void Docker_proxy_peer_with_X_Real_IP_requires_devkey()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                headers: ("X-Real-IP", "203.0.113.50"));
+
+            var result = evaluator.EvaluatePath(ConfigPath, ctx);
+
+            Assert.False(result.IsAllowed);
+            Assert.Equal(403, result.DenyStatusCode);
+        });
+    }
+
+    [Fact]
+    public void Docker_proxy_peer_with_XFF_and_valid_devkey_allows()
+    {
+        WithDevKey("secret-dev-key", () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                ("X-Forwarded-For", "203.0.113.50"),
+                ("X-Dev-Key", "secret-dev-key"));
+
+            Assert.True(evaluator.EvaluatePath(ConfigPath, ctx).IsAllowed);
+            Assert.True(evaluator.EvaluatePath(DevPath, ctx).IsAllowed);
+        });
+    }
+
+    [Fact]
+    public void Docker_bridge_peer_without_proxy_headers_is_allowed()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(peerIp: IPAddress.Parse("172.18.0.2"));
+
+            Assert.True(evaluator.EvaluatePath(ConfigPath, ctx).IsAllowed);
+            Assert.True(evaluator.EvaluatePath(DevPath, ctx).IsAllowed);
+        });
+    }
+
     static JacRedAccessEvaluator CreateEvaluator()
         => new(new JacRedApiKeyValidator(), new JacRedDevKeyValidator());
 

--- a/tests/JacRed.Tests/Security/JacRedAccessEvaluatorTests.cs
+++ b/tests/JacRed.Tests/Security/JacRedAccessEvaluatorTests.cs
@@ -194,6 +194,57 @@ public class JacRedAccessEvaluatorTests
         });
     }
 
+    [Fact]
+    public void Docker_proxy_peer_with_X_Forwarded_Host_requires_devkey()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                headers: ("X-Forwarded-Host", "jacred.example.com"));
+
+            var result = evaluator.EvaluatePath(ConfigPath, ctx);
+
+            Assert.False(result.IsAllowed);
+            Assert.Equal(403, result.DenyStatusCode);
+        });
+    }
+
+    [Fact]
+    public void Docker_proxy_peer_with_Forwarded_header_requires_devkey()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                headers: ("Forwarded", "for=203.0.113.50;proto=https"));
+
+            var result = evaluator.EvaluatePath(ConfigPath, ctx);
+
+            Assert.False(result.IsAllowed);
+            Assert.Equal(403, result.DenyStatusCode);
+        });
+    }
+
+    [Fact]
+    public void Docker_proxy_peer_with_X_Forwarded_Proto_requires_devkey()
+    {
+        WithDevKey(null, () =>
+        {
+            var evaluator = CreateEvaluator();
+            var ctx = CreateContext(
+                peerIp: IPAddress.Parse("172.18.0.2"),
+                headers: ("X-Forwarded-Proto", "http"));
+
+            var result = evaluator.EvaluatePath(ConfigPath, ctx);
+
+            Assert.False(result.IsAllowed);
+            Assert.Equal(403, result.DenyStatusCode);
+        });
+    }
+
     static JacRedAccessEvaluator CreateEvaluator()
         => new(new JacRedApiKeyValidator(), new JacRedDevKeyValidator());
 


### PR DESCRIPTION
- Clarified access requirements for `ConfigApi` and `DevAdmin` regarding reverse proxies in documentation.
- Updated `JacRedAccessEvaluator` to enforce `devkey` requirement for Docker and loopback proxies with identity headers.
- Added unit tests to validate access behavior for various proxy scenarios, ensuring correct handling of `X-Forwarded-For` and `X-Real-IP` headers.