### PR TITLE
feat(alloha): integrate Alloha TV API for title resolution

### DIFF
--- a/Application/Search/TorrentQueryService.cs
+++ b/Application/Search/TorrentQueryService.cs
@@ -1,17 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using JacRed.Infrastructure.External;
 using JacRed.Infrastructure.Indexers;
 using JacRed.Infrastructure.Persistence;
 using JacRed.Infrastructure.Tracks;
-using JacRed.Infrastructure.Networking;
 using JacRed.Infrastructure.Utils;
 using JacRed.Models.Details;
 using JacRed.Models;
 using Microsoft.Extensions.Caching.Memory;
-using Newtonsoft.Json.Linq;
 
 namespace JacRed.Application.Search
 {
@@ -20,32 +18,15 @@ namespace JacRed.Application.Search
         public async Task<object> QueryTorrentsAsync(string search, string altname, bool exact, string type, string sort, string tracker, string voice, string videotype, long relased, long quality, long season, IMemoryCache memoryCache)
         {
             #region search kp/imdb
-            if (!string.IsNullOrWhiteSpace(search) && Regex.IsMatch(search.Trim(), "^(tt|kp)[0-9]+$"))
+            int allohaYear = 0;
+            bool idQuery = AllohaTitleResolver.IsImdbOrKpId(search);
+            if (idQuery)
             {
-                string memkey = $"api/v1.0/torrents:{search}";
-                if (!memoryCache.TryGetValue(memkey, out (string original_name, string name) cache))
-                {
-                    search = search.Trim();
-                    string uri = $"&imdb={search}";
-                    if (search.StartsWith("kp"))
-                        uri = $"&kp={search.Remove(0, 2)}";
-
-                    var root = await HttpClient.Get<JObject>("https://api.apbugall.org/?token=04941a9a3ca3ac16e2b4327347bbc1" + uri, timeoutSeconds: 8);
-                    cache.original_name = root?.Value<JObject>("data")?.Value<string>("original_name");
-                    cache.name = root?.Value<JObject>("data")?.Value<string>("name");
-
-                    memoryCache.Set(memkey, cache, DateTime.Now.AddDays(1));
-                }
-
-                if (!string.IsNullOrWhiteSpace(cache.name) && !string.IsNullOrWhiteSpace(cache.original_name))
-                {
-                    search = cache.original_name;
-                    altname = cache.name;
-                }
-                else
-                {
-                    search = cache.original_name ?? cache.name;
-                }
+                var resolved = await AllohaTitleResolver.ResolveAsync(search, altname, memoryCache);
+                search = resolved.search;
+                altname = resolved.altname;
+                allohaYear = resolved.year;
+                exact = true;
             }
             #endregion
 
@@ -162,6 +143,8 @@ namespace JacRed.Application.Search
 
             if (relased > 0)
                 query = query.Where(i => i.relased == relased);
+            else if (allohaYear > 0 && AppInit.conf.alloha?.filterByYear == true)
+                query = query.Where(i => i.relased <= 0 || i.relased == allohaYear || i.relased == allohaYear - 1 || i.relased == allohaYear + 1);
 
             if (quality > 0)
                 query = query.Where(i => i.quality == quality);

--- a/Application/Search/TorrentQueryService.cs
+++ b/Application/Search/TorrentQueryService.cs
@@ -20,7 +20,7 @@ namespace JacRed.Application.Search
             #region search kp/imdb
             int allohaYear = 0;
             string allohaAltTitle = null;
-            bool idQuery = AllohaTitleResolver.IsImdbOrKpId(search);
+            bool idQuery = AllohaTitleResolver.IsResolvableId(search);
             if (idQuery)
             {
                 var resolved = await AllohaTitleResolver.ResolveAsync(search, altname, memoryCache);

--- a/Application/Search/TorrentQueryService.cs
+++ b/Application/Search/TorrentQueryService.cs
@@ -19,13 +19,17 @@ namespace JacRed.Application.Search
         {
             #region search kp/imdb
             int allohaYear = 0;
+            string allohaAltTitle = null;
             bool idQuery = AllohaTitleResolver.IsImdbOrKpId(search);
             if (idQuery)
             {
                 var resolved = await AllohaTitleResolver.ResolveAsync(search, altname, memoryCache);
-                search = resolved.search;
-                altname = resolved.altname;
-                allohaYear = resolved.year;
+                search = resolved.Search;
+                altname = resolved.AltName;
+                allohaYear = resolved.Year;
+                allohaAltTitle = resolved.AlternativeName;
+                if (string.IsNullOrWhiteSpace(type) && !string.IsNullOrWhiteSpace(resolved.Type))
+                    type = resolved.Type;
                 exact = true;
             }
             #endregion
@@ -59,14 +63,18 @@ namespace JacRed.Application.Search
 
             string _s = StringConvert.SearchName(search);
             string _altsearch = StringConvert.SearchName(altname);
+            string _alt2 = StringConvert.SearchName(allohaAltTitle);
 
-            if (string.IsNullOrEmpty(_s) && string.IsNullOrEmpty(_altsearch))
+            if (string.IsNullOrEmpty(_s) && string.IsNullOrEmpty(_altsearch) && string.IsNullOrEmpty(_alt2))
                 return Array.Empty<object>();
 
             if (exact)
             {
                 #region Точный поиск
-                foreach (var mdb in FileDB.masterDb.Where(i => (_s != null && (i.Key.StartsWith($"{_s}:") || i.Key.EndsWith($":{_s}"))) || (_altsearch != null && i.Key.Contains(_altsearch))))
+                foreach (var mdb in FileDB.masterDb.Where(i =>
+                    (_s != null && (i.Key.StartsWith($"{_s}:") || i.Key.EndsWith($":{_s}")))
+                    || (_altsearch != null && i.Key.Contains(_altsearch))
+                    || (_alt2 != null && i.Key.Contains(_alt2))))
                 {
                     foreach (var t in FileDB.OpenRead(mdb.Key, true).Values)
                     {
@@ -78,7 +86,9 @@ namespace JacRed.Application.Search
                             string _n = t._sn ?? StringConvert.SearchName(t.name);
                             string _o = t._so ?? StringConvert.SearchName(t.originalname);
 
-                            if (_n == _s || _o == _s || (_altsearch != null && (_n == _altsearch || _o == _altsearch)))
+                            if (_n == _s || _o == _s
+                                || (_altsearch != null && (_n == _altsearch || _o == _altsearch))
+                                || (_alt2 != null && (_n == _alt2 || _o == _alt2)))
                                 AddTorrents(t);
                         }
                     }

--- a/Configuration/AppOptions.cs
+++ b/Configuration/AppOptions.cs
@@ -175,6 +175,9 @@ namespace JacRed.Configuration
 
         public SearchSettings search = new SearchSettings();
 
+        /// <summary>Alloha TV API v2 — KP/IMDB ID → title resolve.</summary>
+        public AllohaSettings alloha = new AllohaSettings();
+
         public TorznabSettings torznab = new TorznabSettings();
 
         public LoggingOptions logging = new LoggingOptions

--- a/Configuration/Schema/ConfigSchema.cs
+++ b/Configuration/Schema/ConfigSchema.cs
@@ -23,7 +23,7 @@ namespace JacRed.Configuration.Schema
 
         public static readonly HashSet<string> SensitiveFieldNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "apikey", "devkey", "cookie", "u", "p", "username", "password"
+            "apikey", "devkey", "cookie", "u", "p", "username", "password", "token"
         };
 
         public static object Get()
@@ -111,6 +111,15 @@ namespace JacRed.Configuration.Schema
                         Field("search.v1Sort", "string", "V1 sort", "sid, pir, size…"),
                         Field("search.stripTrailingYear", "bool", "Strip trailing year", "Fuzzy: запрос без года"),
                         Field("search.skipCatFilter", "bool", "Skip cat filter", "Не фильтровать cat/Category[] на сервере")
+                    }),
+                    Group("alloha", "Alloha", "KP/IMDB ID → title (API v2)", new[]
+                    {
+                        Field("alloha.enable", "bool", "Включить", "Резолв tt… / kp… через Alloha"),
+                        Field("alloha.baseUrl", "string", "Base URL", "https://apbugall.org"),
+                        Field("alloha.token", "password", "Bearer token", "Authorization: Bearer …", sensitive: true),
+                        Field("alloha.timeoutSeconds", "int", "Timeout (с)", null, min: 1),
+                        Field("alloha.cacheHours", "int", "Cache (ч)", "Memory cache ID → titles", min: 0),
+                        Field("alloha.filterByYear", "bool", "Filter by year", "Если клиент не передал year — ±1 от Alloha")
                     }),
                     Group("torznab", "Torznab", "Torznab XML (Sonarr/Radarr/Prowlarr)", new[]
                     {

--- a/Configuration/Schema/ConfigSchema.cs
+++ b/Configuration/Schema/ConfigSchema.cs
@@ -112,9 +112,9 @@ namespace JacRed.Configuration.Schema
                         Field("search.stripTrailingYear", "bool", "Strip trailing year", "Fuzzy: запрос без года"),
                         Field("search.skipCatFilter", "bool", "Skip cat filter", "Не фильтровать cat/Category[] на сервере")
                     }),
-                    Group("alloha", "Alloha", "KP/IMDB ID → title (API v2)", new[]
+                    Group("alloha", "Alloha", "KP/IMDB/TMDB ID → title (API v2)", new[]
                     {
-                        Field("alloha.enable", "bool", "Включить", "Резолв tt… / kp… через Alloha"),
+                        Field("alloha.enable", "bool", "Включить", "Резолв tt… / kp… / tmdb… через Alloha"),
                         Field("alloha.baseUrl", "string", "Base URL", "https://apbugall.org"),
                         Field("alloha.token", "password", "Bearer token", "Authorization: Bearer …", sensitive: true),
                         Field("alloha.timeoutSeconds", "int", "Timeout (с)", null, min: 1),

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -101,7 +101,7 @@ search:
   stripTrailingYear: true # Fuzzy: доп. запрос без года в конце
   skipCatFilter: true # Не фильтровать cat/Category[] на сервере (Lampa фильтрует сама)
 
-# Alloha TV API v2 — resolve KP/IMDB (tt… / kp…) to titles for FileDB search
+# Alloha TV API v2 — resolve KP/IMDB/TMDB (tt… / kp… / tmdb… / themoviedb.org URL) to titles for FileDB search
 alloha:
   enable: true
   baseUrl: https://apbugall.org

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -101,6 +101,15 @@ search:
   stripTrailingYear: true # Fuzzy: доп. запрос без года в конце
   skipCatFilter: true # Не фильтровать cat/Category[] на сервере (Lampa фильтрует сама)
 
+# Alloha TV API v2 — resolve KP/IMDB (tt… / kp…) to titles for FileDB search
+alloha:
+  enable: true
+  baseUrl: https://apbugall.org
+  token: "04941a9a3ca3ac16e2b4327347bbc1" # Bearer; redact in /settings
+  timeoutSeconds: 10
+  cacheHours: 24
+  filterByYear: true # when client year absent, keep FileDB hits with relased ±1 of Alloha year
+
 # Torznab XML (Sonarr/Radarr/Prowlarr). Не влияет на Lampa Jackett JSON.
 torznab:
   enable: true # false → 404 на /torznab/api и Prowlarr meta

--- a/Infrastructure/External/AllohaTitleResolver.cs
+++ b/Infrastructure/External/AllohaTitleResolver.cs
@@ -1,0 +1,80 @@
+using JacRed.Infrastructure.Networking;
+using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace JacRed.Infrastructure.External
+{
+    /// <summary>
+    /// Alloha TV API v2: resolve <c>tt…</c> / <c>kp…</c> to bilingual titles (+ year) for FileDB search.
+    /// </summary>
+    public static class AllohaTitleResolver
+    {
+        static readonly Regex IdPattern = new Regex("^(tt|kp)[0-9]+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static bool IsImdbOrKpId(string search) =>
+            !string.IsNullOrWhiteSpace(search) && IdPattern.IsMatch(search.Trim());
+
+        /// <summary>
+        /// If <paramref name="search"/> is an IMDb/KP id, resolve via Alloha; otherwise return inputs unchanged (year 0).
+        /// </summary>
+        public static async Task<(string search, string altname, int year)> ResolveAsync(
+            string search, string altname, IMemoryCache memoryCache)
+        {
+            if (!IsImdbOrKpId(search))
+                return (search, altname, 0);
+
+            var conf = AppInit.conf.alloha;
+            if (conf == null || !conf.enable || string.IsNullOrWhiteSpace(conf.token))
+                return (search, altname, 0);
+
+            string id = search.Trim();
+            string memkey = $"alloha:title:{id.ToLowerInvariant()}";
+
+            if (memoryCache != null && memoryCache.TryGetValue(memkey, out (string original_name, string name, int year) cached))
+                return MapTitles(cached.original_name, cached.name, cached.year, search, altname);
+
+            string baseUrl = (conf.baseUrl ?? "https://apbugall.org").TrimEnd('/');
+            string query = id.StartsWith("kp", StringComparison.OrdinalIgnoreCase)
+                ? $"kp={id.Substring(2)}"
+                : $"imdb={id}";
+
+            var headers = new List<(string name, string val)>
+            {
+                ("Authorization", $"Bearer {conf.token}")
+            };
+
+            int timeout = conf.timeoutSeconds > 0 ? conf.timeoutSeconds : 8;
+            var root = await HttpClient.Get<JObject>(
+                $"{baseUrl}/v2/movies/search?{query}",
+                timeoutSeconds: timeout,
+                addHeaders: headers);
+
+            string originalName = root?.Value<JObject>("data")?.Value<string>("original_name");
+            string name = root?.Value<JObject>("data")?.Value<string>("name");
+            int year = root?.Value<JObject>("data")?.Value<int?>("year") ?? 0;
+
+            var entry = (originalName, name, year);
+            int cacheHours = conf.cacheHours > 0 ? conf.cacheHours : 24;
+            memoryCache?.Set(memkey, entry, DateTime.Now.AddHours(cacheHours));
+
+            return MapTitles(originalName, name, year, search, altname);
+        }
+
+        static (string search, string altname, int year) MapTitles(
+            string originalName, string name, int year, string fallbackSearch, string fallbackAlt)
+        {
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(originalName))
+                return (originalName, name, year);
+
+            string resolved = originalName ?? name;
+            if (!string.IsNullOrWhiteSpace(resolved))
+                return (resolved, fallbackAlt, year);
+
+            return (fallbackSearch, fallbackAlt, year);
+        }
+    }
+}

--- a/Infrastructure/External/AllohaTitleResolver.cs
+++ b/Infrastructure/External/AllohaTitleResolver.cs
@@ -18,6 +18,7 @@ namespace JacRed.Infrastructure.External
         public string Type { get; init; }
         public string ImdbId { get; init; }
         public string KpId { get; init; }
+        public string TmdbId { get; init; }
 
         public static AllohaResolveResult Unresolved(string search, string altname) => new AllohaResolveResult
         {
@@ -27,38 +28,112 @@ namespace JacRed.Infrastructure.External
     }
 
     /// <summary>
-    /// Alloha TV API v2: resolve <c>tt…</c> / <c>kp…</c> to titles (+ year/type) for FileDB search.
+    /// Alloha TV API v2: resolve <c>tt…</c> / <c>kp…</c> / <c>tmdb…</c> (and TMDB URLs) to titles for FileDB search.
     /// </summary>
     public static class AllohaTitleResolver
     {
-        static readonly Regex IdPattern = new Regex("^(tt|kp)[0-9]+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        static readonly Regex CompactIdPattern = new Regex(
+            @"^(?:tt|kp|tmdb:?)\d+$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public static bool IsImdbOrKpId(string search) =>
-            !string.IsNullOrWhiteSpace(search) && IdPattern.IsMatch(search.Trim());
+        /// <summary>themoviedb.org/movie|tv/{id} or /{id}-{slug}</summary>
+        static readonly Regex TmdbUrlPattern = new Regex(
+            @"themoviedb\.org/(?<kind>movie|tv)/(?<id>\d+)(?:-[^\s/?#]*)?",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static bool IsResolvableId(string search) =>
+            TryNormalizeId(search, out _, out _);
+
+        /// <summary>Backward-compatible alias for <see cref="IsResolvableId"/>.</summary>
+        public static bool IsImdbOrKpId(string search) => IsResolvableId(search);
 
         /// <summary>
-        /// If <paramref name="search"/> is an IMDb/KP id, resolve via Alloha; otherwise return inputs unchanged.
+        /// Normalize <c>tt…</c>/<c>kp…</c>/<c>tmdb…</c>/TMDB URL to a canonical id.
+        /// </summary>
+        /// <param name="raw">User input (id or themoviedb.org URL).</param>
+        /// <param name="canonicalId">Normalized id such as <c>tmdb1315772</c>.</param>
+        /// <param name="urlCategoryHint">movie or serial from TMDB URL path when present.</param>
+        public static bool TryNormalizeId(string raw, out string canonicalId, out string urlCategoryHint)
+        {
+            canonicalId = null;
+            urlCategoryHint = null;
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+
+            string s = raw.Trim();
+
+            var url = TmdbUrlPattern.Match(s);
+            if (url.Success)
+            {
+                canonicalId = "tmdb" + url.Groups["id"].Value;
+                string kind = url.Groups["kind"].Value;
+                urlCategoryHint = kind.Equals("tv", StringComparison.OrdinalIgnoreCase) ? "serial"
+                    : kind.Equals("movie", StringComparison.OrdinalIgnoreCase) ? "movie"
+                    : null;
+                return true;
+            }
+
+            if (CompactIdPattern.IsMatch(s))
+            {
+                if (s.StartsWith("tmdb", StringComparison.OrdinalIgnoreCase))
+                {
+                    string digits = s.Substring(4).TrimStart(':');
+                    if (!Regex.IsMatch(digits, @"^\d+$"))
+                        return false;
+                    canonicalId = "tmdb" + digits;
+                    return true;
+                }
+
+                canonicalId = s.ToLowerInvariant();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// If <paramref name="search"/> is an external id / TMDB URL, resolve via Alloha; otherwise return unchanged.
         /// </summary>
         public static async Task<AllohaResolveResult> ResolveAsync(
             string search, string altname, IMemoryCache memoryCache)
         {
-            if (!IsImdbOrKpId(search))
+            if (!TryNormalizeId(search, out string id, out string urlCategoryHint))
                 return AllohaResolveResult.Unresolved(search, altname);
 
             var conf = AppInit.conf.alloha;
             if (conf == null || !conf.enable || string.IsNullOrWhiteSpace(conf.token))
                 return AllohaResolveResult.Unresolved(search, altname);
 
-            string id = search.Trim();
             string memkey = CacheKey(id);
 
             if (memoryCache != null && memoryCache.TryGetValue(memkey, out AllohaResolveResult cached) && cached != null)
-                return WithFallback(cached, search, altname);
+            {
+                var fromCache = WithFallback(cached, search, altname);
+                if (string.IsNullOrWhiteSpace(fromCache.Type) && !string.IsNullOrWhiteSpace(urlCategoryHint))
+                {
+                    return new AllohaResolveResult
+                    {
+                        Search = fromCache.Search,
+                        AltName = fromCache.AltName,
+                        AlternativeName = fromCache.AlternativeName,
+                        Year = fromCache.Year,
+                        Type = urlCategoryHint,
+                        ImdbId = fromCache.ImdbId,
+                        KpId = fromCache.KpId,
+                        TmdbId = fromCache.TmdbId ?? id
+                    };
+                }
+                return fromCache;
+            }
 
             string baseUrl = (conf.baseUrl ?? "https://apbugall.org").TrimEnd('/');
-            string query = id.StartsWith("kp", StringComparison.OrdinalIgnoreCase)
-                ? $"kp={id.Substring(2)}"
-                : $"imdb={id}";
+            string query;
+            if (id.StartsWith("kp", StringComparison.OrdinalIgnoreCase))
+                query = $"kp={id.Substring(2)}";
+            else if (id.StartsWith("tmdb", StringComparison.OrdinalIgnoreCase))
+                query = $"tmdb={id.Substring(4)}";
+            else
+                query = $"imdb={id}";
 
             var headers = new List<(string name, string val)>
             {
@@ -80,8 +155,10 @@ namespace JacRed.Infrastructure.External
             var ids = data?.Value<JObject>("ids");
             string imdbId = NormalizeImdbId(ids?.Value<string>("imdb"));
             string kpId = NormalizeKpId(ids?.Value<object>("kp"));
+            string tmdbId = NormalizeTmdbId(ids?.Value<object>("tmdb")) ?? (id.StartsWith("tmdb", StringComparison.OrdinalIgnoreCase) ? id : null);
 
-            var mapped = MapTitles(originalName, name, alternativeName, year, categorySlug, imdbId, kpId, search, altname);
+            var mapped = MapTitles(originalName, name, alternativeName, year, categorySlug, urlCategoryHint,
+                imdbId, kpId, tmdbId, search, altname);
 
             int cacheHours = conf.cacheHours > 0 ? conf.cacheHours : 24;
             var expiry = DateTime.Now.AddHours(cacheHours);
@@ -102,6 +179,9 @@ namespace JacRed.Infrastructure.External
 
             if (!string.IsNullOrWhiteSpace(result.KpId))
                 memoryCache.Set(CacheKey(result.KpId), result, expiry);
+
+            if (!string.IsNullOrWhiteSpace(result.TmdbId))
+                memoryCache.Set(CacheKey(result.TmdbId), result, expiry);
         }
 
         static string CacheKey(string id) => $"alloha:title:{id.Trim().ToLowerInvariant()}";
@@ -128,6 +208,16 @@ namespace JacRed.Infrastructure.External
             return "kp" + s;
         }
 
+        static string NormalizeTmdbId(object tmdb)
+        {
+            if (tmdb == null)
+                return null;
+            string s = tmdb.ToString()?.Trim();
+            if (string.IsNullOrWhiteSpace(s) || !Regex.IsMatch(s, "^[0-9]+$"))
+                return null;
+            return "tmdb" + s;
+        }
+
         static string MapCategorySlug(string slug)
         {
             if (string.IsNullOrWhiteSpace(slug))
@@ -148,8 +238,8 @@ namespace JacRed.Infrastructure.External
         }
 
         static AllohaResolveResult MapTitles(
-            string originalName, string name, string alternativeName, int year, string categorySlug,
-            string imdbId, string kpId, string fallbackSearch, string fallbackAlt)
+            string originalName, string name, string alternativeName, int year, string categorySlug, string urlCategoryHint,
+            string imdbId, string kpId, string tmdbId, string fallbackSearch, string fallbackAlt)
         {
             string search;
             string alt;
@@ -183,15 +273,18 @@ namespace JacRed.Infrastructure.External
                     altNameDistinct = a;
             }
 
+            string type = MapCategorySlug(categorySlug) ?? urlCategoryHint;
+
             return new AllohaResolveResult
             {
                 Search = search,
                 AltName = alt,
                 AlternativeName = altNameDistinct,
                 Year = year,
-                Type = MapCategorySlug(categorySlug),
+                Type = type,
                 ImdbId = imdbId,
-                KpId = kpId
+                KpId = kpId,
+                TmdbId = tmdbId
             };
         }
 

--- a/Infrastructure/External/AllohaTitleResolver.cs
+++ b/Infrastructure/External/AllohaTitleResolver.cs
@@ -8,8 +8,26 @@ using System.Threading.Tasks;
 
 namespace JacRed.Infrastructure.External
 {
+    public sealed class AllohaResolveResult
+    {
+        public string Search { get; init; }
+        public string AltName { get; init; }
+        public string AlternativeName { get; init; }
+        public int Year { get; init; }
+        /// <summary>JacRed FileDB type hint from Alloha category.slug (movie/serial/anime).</summary>
+        public string Type { get; init; }
+        public string ImdbId { get; init; }
+        public string KpId { get; init; }
+
+        public static AllohaResolveResult Unresolved(string search, string altname) => new AllohaResolveResult
+        {
+            Search = search,
+            AltName = altname
+        };
+    }
+
     /// <summary>
-    /// Alloha TV API v2: resolve <c>tt…</c> / <c>kp…</c> to bilingual titles (+ year) for FileDB search.
+    /// Alloha TV API v2: resolve <c>tt…</c> / <c>kp…</c> to titles (+ year/type) for FileDB search.
     /// </summary>
     public static class AllohaTitleResolver
     {
@@ -19,23 +37,23 @@ namespace JacRed.Infrastructure.External
             !string.IsNullOrWhiteSpace(search) && IdPattern.IsMatch(search.Trim());
 
         /// <summary>
-        /// If <paramref name="search"/> is an IMDb/KP id, resolve via Alloha; otherwise return inputs unchanged (year 0).
+        /// If <paramref name="search"/> is an IMDb/KP id, resolve via Alloha; otherwise return inputs unchanged.
         /// </summary>
-        public static async Task<(string search, string altname, int year)> ResolveAsync(
+        public static async Task<AllohaResolveResult> ResolveAsync(
             string search, string altname, IMemoryCache memoryCache)
         {
             if (!IsImdbOrKpId(search))
-                return (search, altname, 0);
+                return AllohaResolveResult.Unresolved(search, altname);
 
             var conf = AppInit.conf.alloha;
             if (conf == null || !conf.enable || string.IsNullOrWhiteSpace(conf.token))
-                return (search, altname, 0);
+                return AllohaResolveResult.Unresolved(search, altname);
 
             string id = search.Trim();
-            string memkey = $"alloha:title:{id.ToLowerInvariant()}";
+            string memkey = CacheKey(id);
 
-            if (memoryCache != null && memoryCache.TryGetValue(memkey, out (string original_name, string name, int year) cached))
-                return MapTitles(cached.original_name, cached.name, cached.year, search, altname);
+            if (memoryCache != null && memoryCache.TryGetValue(memkey, out AllohaResolveResult cached) && cached != null)
+                return WithFallback(cached, search, altname);
 
             string baseUrl = (conf.baseUrl ?? "https://apbugall.org").TrimEnd('/');
             string query = id.StartsWith("kp", StringComparison.OrdinalIgnoreCase)
@@ -53,28 +71,135 @@ namespace JacRed.Infrastructure.External
                 timeoutSeconds: timeout,
                 addHeaders: headers);
 
-            string originalName = root?.Value<JObject>("data")?.Value<string>("original_name");
-            string name = root?.Value<JObject>("data")?.Value<string>("name");
-            int year = root?.Value<JObject>("data")?.Value<int?>("year") ?? 0;
+            var data = root?.Value<JObject>("data");
+            string originalName = data?.Value<string>("original_name");
+            string name = data?.Value<string>("name");
+            string alternativeName = data?.Value<string>("alternative_name");
+            int year = data?.Value<int?>("year") ?? 0;
+            string categorySlug = data?.Value<JObject>("category")?.Value<string>("slug");
+            var ids = data?.Value<JObject>("ids");
+            string imdbId = NormalizeImdbId(ids?.Value<string>("imdb"));
+            string kpId = NormalizeKpId(ids?.Value<object>("kp"));
 
-            var entry = (originalName, name, year);
+            var mapped = MapTitles(originalName, name, alternativeName, year, categorySlug, imdbId, kpId, search, altname);
+
             int cacheHours = conf.cacheHours > 0 ? conf.cacheHours : 24;
-            memoryCache?.Set(memkey, entry, DateTime.Now.AddHours(cacheHours));
+            var expiry = DateTime.Now.AddHours(cacheHours);
+            CacheResult(memoryCache, mapped, memkey, expiry);
 
-            return MapTitles(originalName, name, year, search, altname);
+            return mapped;
         }
 
-        static (string search, string altname, int year) MapTitles(
-            string originalName, string name, int year, string fallbackSearch, string fallbackAlt)
+        static void CacheResult(IMemoryCache memoryCache, AllohaResolveResult result, string queryKey, DateTime expiry)
         {
+            if (memoryCache == null || result == null)
+                return;
+
+            memoryCache.Set(queryKey, result, expiry);
+
+            if (!string.IsNullOrWhiteSpace(result.ImdbId))
+                memoryCache.Set(CacheKey(result.ImdbId), result, expiry);
+
+            if (!string.IsNullOrWhiteSpace(result.KpId))
+                memoryCache.Set(CacheKey(result.KpId), result, expiry);
+        }
+
+        static string CacheKey(string id) => $"alloha:title:{id.Trim().ToLowerInvariant()}";
+
+        static string NormalizeImdbId(string imdb)
+        {
+            if (string.IsNullOrWhiteSpace(imdb))
+                return null;
+            imdb = imdb.Trim();
+            if (imdb.StartsWith("tt", StringComparison.OrdinalIgnoreCase))
+                return imdb.ToLowerInvariant();
+            if (Regex.IsMatch(imdb, "^[0-9]+$"))
+                return "tt" + imdb;
+            return null;
+        }
+
+        static string NormalizeKpId(object kp)
+        {
+            if (kp == null)
+                return null;
+            string s = kp.ToString()?.Trim();
+            if (string.IsNullOrWhiteSpace(s) || !Regex.IsMatch(s, "^[0-9]+$"))
+                return null;
+            return "kp" + s;
+        }
+
+        static string MapCategorySlug(string slug)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+                return null;
+            switch (slug.Trim().ToLowerInvariant())
+            {
+                case "movie":
+                    return "movie";
+                case "serial":
+                case "tv-show":
+                    return "serial";
+                case "anime":
+                case "anime-serial":
+                    return "anime";
+                default:
+                    return null;
+            }
+        }
+
+        static AllohaResolveResult MapTitles(
+            string originalName, string name, string alternativeName, int year, string categorySlug,
+            string imdbId, string kpId, string fallbackSearch, string fallbackAlt)
+        {
+            string search;
+            string alt;
+
             if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(originalName))
-                return (originalName, name, year);
+            {
+                search = originalName;
+                alt = name;
+            }
+            else
+            {
+                string resolved = originalName ?? name;
+                if (!string.IsNullOrWhiteSpace(resolved))
+                {
+                    search = resolved;
+                    alt = fallbackAlt;
+                }
+                else
+                {
+                    search = fallbackSearch;
+                    alt = fallbackAlt;
+                }
+            }
 
-            string resolved = originalName ?? name;
-            if (!string.IsNullOrWhiteSpace(resolved))
-                return (resolved, fallbackAlt, year);
+            string altNameDistinct = null;
+            if (!string.IsNullOrWhiteSpace(alternativeName))
+            {
+                string a = alternativeName.Trim();
+                if (!string.Equals(a, search, StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(a, alt, StringComparison.OrdinalIgnoreCase))
+                    altNameDistinct = a;
+            }
 
-            return (fallbackSearch, fallbackAlt, year);
+            return new AllohaResolveResult
+            {
+                Search = search,
+                AltName = alt,
+                AlternativeName = altNameDistinct,
+                Year = year,
+                Type = MapCategorySlug(categorySlug),
+                ImdbId = imdbId,
+                KpId = kpId
+            };
+        }
+
+        static AllohaResolveResult WithFallback(AllohaResolveResult cached, string fallbackSearch, string fallbackAlt)
+        {
+            if (!string.IsNullOrWhiteSpace(cached.Search))
+                return cached;
+            return AllohaResolveResult.Unresolved(fallbackSearch, fallbackAlt);
         }
     }
 }

--- a/Infrastructure/Indexers/IndexerRequestParams.cs
+++ b/Infrastructure/Indexers/IndexerRequestParams.cs
@@ -1,3 +1,4 @@
+using JacRed.Infrastructure.External;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
@@ -8,8 +9,6 @@ namespace JacRed.Infrastructure.Indexers
 {
     public static class IndexerRequestParams
     {
-        static readonly Regex ImdbKpRegex = new Regex(@"^(tt|kp)[0-9]+$", RegexOptions.IgnoreCase);
-
         public static string StripWrappingQuotes(string value)
         {
             if (string.IsNullOrWhiteSpace(value)) return null;
@@ -24,23 +23,42 @@ namespace JacRed.Infrastructure.Indexers
             var s = StripWrappingQuotes(value);
             if (string.IsNullOrWhiteSpace(s)) return null;
             s = s.Trim();
+            if (AllohaTitleResolver.TryNormalizeId(s, out string canonical, out _))
+                return canonical;
             if (s.StartsWith("kp", StringComparison.OrdinalIgnoreCase)) return s.ToLowerInvariant();
             if (s.StartsWith("tt", StringComparison.OrdinalIgnoreCase)) return s.ToLowerInvariant();
             if (Regex.IsMatch(s, @"^\d{7,10}$")) return "tt" + s;
             return s;
         }
 
+        /// <summary>True for <c>tt…</c> / <c>kp…</c> / <c>tmdb…</c> / themoviedb.org URLs.</summary>
         public static bool IsImdbOrKpQuery(string query)
         {
-            return !string.IsNullOrWhiteSpace(query) && ImdbKpRegex.IsMatch(query.Trim());
+            return AllohaTitleResolver.IsResolvableId(query);
         }
 
         public static string NormalizeQuery(string query)
         {
             var q = StripWrappingQuotes(query);
             if (string.IsNullOrWhiteSpace(q)) return null;
-            if (Regex.IsMatch(q.Trim(), @"^\d{7,10}$")) return "tt" + q.Trim();
-            return q.Trim();
+            q = q.Trim();
+            if (AllohaTitleResolver.TryNormalizeId(q, out string canonical, out _))
+                return canonical;
+            if (Regex.IsMatch(q, @"^\d{7,10}$")) return "tt" + q;
+            return q;
+        }
+
+        public static string NormalizeTmdbId(string value)
+        {
+            var s = StripWrappingQuotes(value);
+            if (string.IsNullOrWhiteSpace(s)) return null;
+            s = s.Trim();
+            if (AllohaTitleResolver.TryNormalizeId(s, out string canonical, out _)
+                && canonical.StartsWith("tmdb", StringComparison.OrdinalIgnoreCase))
+                return canonical;
+            if (Regex.IsMatch(s, @"^\d+$"))
+                return "tmdb" + s;
+            return null;
         }
 
         public static string ImDbIdFromQuery(IQueryCollection query)

--- a/Infrastructure/Indexers/IndexerResultFilters.cs
+++ b/Infrastructure/Indexers/IndexerResultFilters.cs
@@ -48,6 +48,18 @@ namespace JacRed.Infrastructure.Indexers
             }).ToList();
         }
 
+        /// <summary>Keep items whose info.types contains <paramref name="type"/>; items with null/empty types pass.</summary>
+        public static List<Result> FilterByType(List<Result> items, string type)
+        {
+            if (string.IsNullOrWhiteSpace(type)) return items;
+            return items.Where(t =>
+            {
+                var types = t.info?.types;
+                if (types == null || types.Length == 0) return true;
+                return types.Contains(type);
+            }).ToList();
+        }
+
         public static List<Result> FilterByTrackers(List<Result> items, List<string> trackers)
         {
             if (trackers == null || trackers.Count == 0)

--- a/Infrastructure/Indexers/IndexerSearchEngine.cs
+++ b/Infrastructure/Indexers/IndexerSearchEngine.cs
@@ -1,16 +1,14 @@
 using JacRed.Application.Search;
+using JacRed.Infrastructure.External;
 using JacRed.Infrastructure.Persistence;
-using JacRed.Infrastructure.Networking;
 using JacRed.Infrastructure.Utils;
 using JacRed.Models.Api;
 using JacRed.Models.AppConf;
 using JacRed.Models.Details;
 using Microsoft.Extensions.Caching.Memory;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace JacRed.Infrastructure.Indexers
@@ -36,8 +34,12 @@ namespace JacRed.Infrastructure.Indexers
 
             if (imdbMode)
             {
-                batches.Add(await V1SearchAsync(query, null, exact: true, settings.v1Sort, req.Trackers, req.Season, cache, req.RqNum));
-                return IndexerResultMerger.MergeAndSort(batches.ToArray());
+                var resolved = await AllohaTitleResolver.ResolveAsync(query, null, cache);
+                batches.Add(await V1SearchAsync(resolved.search, resolved.altname, exact: true, settings.v1Sort, req.Trackers, req.Season, cache, req.RqNum));
+                var merged = IndexerResultMerger.MergeAndSort(batches.ToArray());
+                if (req.Year <= 0 && resolved.year > 0 && AppInit.conf.alloha?.filterByYear == true)
+                    merged = IndexerResultFilters.FilterByYear(merged, resolved.year);
+                return merged;
             }
 
             var category = BuildCategoryDict(req.Categories);
@@ -226,26 +228,8 @@ namespace JacRed.Infrastructure.Indexers
 
         static async Task<(string search, string altname)> ResolveImdbSearchAsync(string search, string altname, IMemoryCache cache)
         {
-            if (string.IsNullOrWhiteSpace(search) || !Regex.IsMatch(search.Trim(), "^(tt|kp)[0-9]+$", RegexOptions.IgnoreCase))
-                return (search, altname);
-
-            string memkey = $"api:v1.0/torrents:{search}";
-            if (cache == null || !cache.TryGetValue(memkey, out (string original_name, string name) c))
-            {
-                search = search.Trim();
-                string uri = search.StartsWith("kp", StringComparison.OrdinalIgnoreCase)
-                    ? $"&kp={search.Substring(2)}"
-                    : $"&imdb={search}";
-                var root = await HttpClient.Get<JObject>("https://api.apbugall.org/?token=04941a9a3ca3ac16e2b4327347bbc1" + uri, timeoutSeconds: 8);
-                c.original_name = root?.Value<JObject>("data")?.Value<string>("original_name");
-                c.name = root?.Value<JObject>("data")?.Value<string>("name");
-                cache?.Set(memkey, c, DateTime.Now.AddDays(1));
-            }
-
-            if (!string.IsNullOrWhiteSpace(c.name) && !string.IsNullOrWhiteSpace(c.original_name))
-                return (c.original_name, c.name);
-
-            return (c.original_name ?? c.name ?? search, altname);
+            var resolved = await AllohaTitleResolver.ResolveAsync(search, altname, cache);
+            return (resolved.search, resolved.altname);
         }
 
         static Result MapV1(TorrentDetails i, bool rqnum)

--- a/Infrastructure/Indexers/IndexerSearchEngine.cs
+++ b/Infrastructure/Indexers/IndexerSearchEngine.cs
@@ -35,10 +35,15 @@ namespace JacRed.Infrastructure.Indexers
             if (imdbMode)
             {
                 var resolved = await AllohaTitleResolver.ResolveAsync(query, null, cache);
-                batches.Add(await V1SearchAsync(resolved.search, resolved.altname, exact: true, settings.v1Sort, req.Trackers, req.Season, cache, req.RqNum));
+                batches.Add(await V1SearchAsync(resolved.Search, resolved.AltName, exact: true, settings.v1Sort, req.Trackers, req.Season, cache, req.RqNum));
+                if (!string.IsNullOrWhiteSpace(resolved.AlternativeName))
+                    batches.Add(await V1SearchAsync(resolved.AlternativeName, resolved.AltName, exact: true, settings.v1Sort, req.Trackers, req.Season, cache, req.RqNum));
+
                 var merged = IndexerResultMerger.MergeAndSort(batches.ToArray());
-                if (req.Year <= 0 && resolved.year > 0 && AppInit.conf.alloha?.filterByYear == true)
-                    merged = IndexerResultFilters.FilterByYear(merged, resolved.year);
+                if (req.Year <= 0 && resolved.Year > 0 && AppInit.conf.alloha?.filterByYear == true)
+                    merged = IndexerResultFilters.FilterByYear(merged, resolved.Year);
+                if ((req.Categories == null || req.Categories.Count == 0) && !string.IsNullOrWhiteSpace(resolved.Type))
+                    merged = IndexerResultFilters.FilterByType(merged, resolved.Type);
                 return merged;
             }
 
@@ -229,7 +234,7 @@ namespace JacRed.Infrastructure.Indexers
         static async Task<(string search, string altname)> ResolveImdbSearchAsync(string search, string altname, IMemoryCache cache)
         {
             var resolved = await AllohaTitleResolver.ResolveAsync(search, altname, cache);
-            return (resolved.search, resolved.altname);
+            return (resolved.Search, resolved.AltName);
         }
 
         static Result MapV1(TorrentDetails i, bool rqnum)

--- a/Infrastructure/Indexers/ProwlarrQueryParser.cs
+++ b/Infrastructure/Indexers/ProwlarrQueryParser.cs
@@ -44,6 +44,7 @@ namespace JacRed.Infrastructure.Indexers
         {
             public string Query { get; set; }
             public string ImdbId { get; set; }
+            public string TmdbId { get; set; }
             public int? Season { get; set; }
             public int? Episode { get; set; }
             public int? Year { get; set; }
@@ -73,6 +74,8 @@ namespace JacRed.Infrastructure.Indexers
                         hadTvdb = true;
                     if (match.Groups["imdbid"].Success)
                         result.ImdbId = IndexerRequestParams.NormalizeImdbId(match.Groups["imdbid"].Value);
+                    if (match.Groups["tmdbid"].Success)
+                        result.TmdbId = IndexerRequestParams.NormalizeTmdbId(match.Groups["tmdbid"].Value);
                     if (match.Groups["season"].Success && int.TryParse(match.Groups["season"].Value, out int season) && season > 0)
                         result.Season = season;
                     if (match.Groups["episode"].Success && int.TryParse(match.Groups["episode"].Value, out int episode) && episode > 0)
@@ -90,6 +93,8 @@ namespace JacRed.Infrastructure.Indexers
                 {
                     if (match.Groups["imdbid"].Success)
                         result.ImdbId = IndexerRequestParams.NormalizeImdbId(match.Groups["imdbid"].Value);
+                    if (match.Groups["tmdbid"].Success)
+                        result.TmdbId = IndexerRequestParams.NormalizeTmdbId(match.Groups["tmdbid"].Value);
                     if (match.Groups["year"].Success && int.TryParse(match.Groups["year"].Value, out int year) && year > 0)
                         result.Year = year;
                     if (match.Groups["genre"].Success)
@@ -131,17 +136,23 @@ namespace JacRed.Infrastructure.Indexers
             q = IndexerRequestParams.NormalizeQuery(q?.Trim());
             if (string.IsNullOrWhiteSpace(q) && !string.IsNullOrWhiteSpace(result.ImdbId))
                 q = result.ImdbId;
+            if (string.IsNullOrWhiteSpace(q) && !string.IsNullOrWhiteSpace(result.TmdbId))
+                q = result.TmdbId;
             if (string.IsNullOrWhiteSpace(q) && !string.IsNullOrWhiteSpace(result.Title))
                 q = result.Title;
             if (string.IsNullOrWhiteSpace(q) && !string.IsNullOrWhiteSpace(result.Artist))
                 q = string.IsNullOrWhiteSpace(result.Album) ? result.Artist : $"{result.Artist} {result.Album}";
 
             // Lampa Prowlarr card search: plain query only — promote into Jackett card fields.
-            if (!string.IsNullOrWhiteSpace(q) && string.IsNullOrWhiteSpace(result.ImdbId))
+            if (!string.IsNullOrWhiteSpace(q)
+                && string.IsNullOrWhiteSpace(result.ImdbId)
+                && string.IsNullOrWhiteSpace(result.TmdbId))
                 EnrichPlainQuery(result, q);
 
             result.Query = q;
-            result.TvdbIdOnly = hadTvdb && string.IsNullOrWhiteSpace(result.Query) && string.IsNullOrWhiteSpace(result.ImdbId);
+            result.TvdbIdOnly = hadTvdb && string.IsNullOrWhiteSpace(result.Query)
+                && string.IsNullOrWhiteSpace(result.ImdbId)
+                && string.IsNullOrWhiteSpace(result.TmdbId);
             return result;
         }
 

--- a/Models/AppConf/AllohaSettings.cs
+++ b/Models/AppConf/AllohaSettings.cs
@@ -1,0 +1,22 @@
+namespace JacRed.Models.AppConf
+{
+    /// <summary>
+    /// Alloha TV API v2 — resolve KP/IMDB IDs to titles for FileDB search.
+    /// </summary>
+    public class AllohaSettings
+    {
+        public bool enable { get; set; } = true;
+
+        public string baseUrl { get; set; } = "https://apbugall.org";
+
+        /// <summary>Bearer token for Authorization header.</summary>
+        public string token { get; set; } = "04941a9a3ca3ac16e2b4327347bbc1";
+
+        public int timeoutSeconds { get; set; } = 8;
+
+        public int cacheHours { get; set; } = 24;
+
+        /// <summary>When client year is absent, filter FileDB hits by Alloha year (±1).</summary>
+        public bool filterByYear { get; set; } = true;
+    }
+}

--- a/Models/AppConf/AllohaSettings.cs
+++ b/Models/AppConf/AllohaSettings.cs
@@ -1,7 +1,7 @@
 namespace JacRed.Models.AppConf
 {
     /// <summary>
-    /// Alloha TV API v2 — resolve KP/IMDB IDs to titles for FileDB search.
+    /// Alloha TV API v2 — resolve KP/IMDB/TMDB IDs to titles for FileDB search.
     /// </summary>
     public class AllohaSettings
     {

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 Сводная таблица «клиент → URL → формат» — в [Torznab XML](configuration.md#torznab-xml-torznab).
 
 - **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa** и др.).
-  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback.
+  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP/TMDB exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback.
   - Параметры Lampa: `Query`, `title`, `title_original`, `year`, `is_serial`, `genres`, `Category[]`, `Tracker[]`, `season`, `ep`, `limit`, `offset`, `apikey`.
   - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true`.
 - **`GET /api/v2.0/indexers`** — список индексаторов (Jackett/Prowlarr).
@@ -52,7 +52,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 - **`GET /api/v1/indexer/{id}/newznab`** — Torznab XML через Prowlarr-совместимый путь (`t=caps|search|…`).
 - **`GET /api/v1/search`** — Prowlarr Search Feed ([wiki](https://wiki.servarr.com/en/prowlarr/search#search-feed)): JSON-массив релизов.
   - Параметры: `query`, `type` (`search`|`tvsearch`|`movie`|`music`|`book`), `indexerIds` (`1`, `-2` torrents; `-1` usenet → пусто), `categories`, `limit`, `offset`, `apikey`.
-  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{Season:1}`, `{Episode:2}` и т.п. ID-запросы (`tt…`/`kp…`/`{ImdbId:…}`) → Alloha v2.
+  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{TmdbId:1315772}`, `{Season:1}`, `{Episode:2}` и т.п. ID-запросы (`tt…`/`kp…`/`tmdb…`/themoviedb.org URL/`{ImdbId:…}`/`{TmdbId:…}`) → Alloha v2.
   - Lampa (`parser_torrent_type=prowlarr`): `query` + `type=tvsearch|search` + `categories` — запрос поднимается до card-поиска как у Jackett (`title`/`title_original`/`year`, `is_serial` 1=фильм / 2=сериал).
   - Один агрегированный indexer `id=1`; ответ в схеме ReleaseResource (`guid`, `title`, `size`, `seeders`, `magnetUrl`, `categories`, …).
   - JacRed-расширения как у Jackett: `ffprobe`, `languages`, `info` при `tracks: true` (иначе поля опускаются / null).
@@ -61,12 +61,12 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 
   Параметры и поведение одинаковы для обоих Torznab-путей:
   - Параметры: `q`, `imdbid`, `season`, `ep`, `year`, `cat`, `title`, `title_original`, `is_serial`, `limit`, `offset`, `apikey`.
-  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve (name / original_name / alternative_name, type), затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
+  - IMDB/KP/TMDB ID (`tt…`, `kp…`, `tmdb…`, themoviedb.org `/movie|tv/{id}-…`) → Alloha v2 title resolve (name / original_name / alternative_name, type), затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
   - Card mode (Lampa): `title` + `title_original` + `year` + `is_serial` + `genres`.
   - Объединение v1+v2, bilingual `Русский / English`, post-filter по сезону/эпизоду/году/категории.
 - **`GET /api/v1.0/torrents`** — поиск торрентов (собственный JSON API JacRed, не Torznab и не Jackett).
   - Параметры: `search` / связанные фильтры, `tracker` (один slug или список через запятую — значения `TrackerSlug`), `sort`, `type`, …
-  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 / `type` из Alloha, если клиент не задал).
+  - IMDB/KP/TMDB ID (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 / `type` из Alloha, если клиент не задал).
 - **`GET /api/v1.0/trackers`** — список доступных имён трекеров (`TrackerSlug[]` в OpenAPI): из `synctrackers`, иначе known slugs; записи из `disable_trackers` исключаются. Пустой `synctrackers: []` возвращает `[]` (скан БД не выполняется).
 - **`GET /api/v1.0/qualitys`** — список доступных качеств.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 Сводная таблица «клиент → URL → формат» — в [Torznab XML](configuration.md#torznab-xml-torznab).
 
 - **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa** и др.).
-  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP exact (Alloha v2 ID→title) + card fallback.
+  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback.
   - Параметры Lampa: `Query`, `title`, `title_original`, `year`, `is_serial`, `genres`, `Category[]`, `Tracker[]`, `season`, `ep`, `limit`, `offset`, `apikey`.
   - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true`.
 - **`GET /api/v2.0/indexers`** — список индексаторов (Jackett/Prowlarr).
@@ -52,7 +52,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 - **`GET /api/v1/indexer/{id}/newznab`** — Torznab XML через Prowlarr-совместимый путь (`t=caps|search|…`).
 - **`GET /api/v1/search`** — Prowlarr Search Feed ([wiki](https://wiki.servarr.com/en/prowlarr/search#search-feed)): JSON-массив релизов.
   - Параметры: `query`, `type` (`search`|`tvsearch`|`movie`|`music`|`book`), `indexerIds` (`1`, `-2` torrents; `-1` usenet → пусто), `categories`, `limit`, `offset`, `apikey`.
-  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{Season:1}`, `{Episode:2}` и т.п.
+  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{Season:1}`, `{Episode:2}` и т.п. ID-запросы (`tt…`/`kp…`/`{ImdbId:…}`) → Alloha v2.
   - Lampa (`parser_torrent_type=prowlarr`): `query` + `type=tvsearch|search` + `categories` — запрос поднимается до card-поиска как у Jackett (`title`/`title_original`/`year`, `is_serial` 1=фильм / 2=сериал).
   - Один агрегированный indexer `id=1`; ответ в схеме ReleaseResource (`guid`, `title`, `size`, `seeders`, `magnetUrl`, `categories`, …).
   - JacRed-расширения как у Jackett: `ffprobe`, `languages`, `info` при `tracks: true` (иначе поля опускаются / null).
@@ -61,12 +61,12 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 
   Параметры и поведение одинаковы для обоих Torznab-путей:
   - Параметры: `q`, `imdbid`, `season`, `ep`, `year`, `cat`, `title`, `title_original`, `is_serial`, `limit`, `offset`, `apikey`.
-  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
+  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve (name / original_name / alternative_name, type), затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
   - Card mode (Lampa): `title` + `title_original` + `year` + `is_serial` + `genres`.
   - Объединение v1+v2, bilingual `Русский / English`, post-filter по сезону/эпизоду/году/категории.
 - **`GET /api/v1.0/torrents`** — поиск торрентов (собственный JSON API JacRed, не Torznab и не Jackett).
   - Параметры: `search` / связанные фильтры, `tracker` (один slug или список через запятую — значения `TrackerSlug`), `sort`, `type`, …
-  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 при `alloha.filterByYear`).
+  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 / `type` из Alloha, если клиент не задал).
 - **`GET /api/v1.0/trackers`** — список доступных имён трекеров (`TrackerSlug[]` в OpenAPI): из `synctrackers`, иначе known slugs; записи из `disable_trackers` исключаются. Пустой `synctrackers: []` возвращает `[]` (скан БД не выполняется).
 - **`GET /api/v1.0/qualitys`** — список доступных качеств.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 Сводная таблица «клиент → URL → формат» — в [Torznab XML](configuration.md#torznab-xml-torznab).
 
 - **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa** и др.).
-  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP exact + card fallback.
+  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP exact (Alloha v2 ID→title) + card fallback.
   - Параметры Lampa: `Query`, `title`, `title_original`, `year`, `is_serial`, `genres`, `Category[]`, `Tracker[]`, `season`, `ep`, `limit`, `offset`, `apikey`.
   - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true`.
 - **`GET /api/v2.0/indexers`** — список индексаторов (Jackett/Prowlarr).
@@ -61,11 +61,12 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 
   Параметры и поведение одинаковы для обоих Torznab-путей:
   - Параметры: `q`, `imdbid`, `season`, `ep`, `year`, `cat`, `title`, `title_original`, `is_serial`, `limit`, `offset`, `apikey`.
-  - IMDB/KP ID (`tt…`, `kp…`) → поиск через v1 с `exact=true`.
+  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
   - Card mode (Lampa): `title` + `title_original` + `year` + `is_serial` + `genres`.
   - Объединение v1+v2, bilingual `Русский / English`, post-filter по сезону/эпизоду/году/категории.
 - **`GET /api/v1.0/torrents`** — поиск торрентов (собственный JSON API JacRed, не Torznab и не Jackett).
   - Параметры: `search` / связанные фильтры, `tracker` (один slug или список через запятую — значения `TrackerSlug`), `sort`, `type`, …
+  - IMDB/KP ID (`tt…`, `kp…`) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 при `alloha.filterByYear`).
 - **`GET /api/v1.0/trackers`** — список доступных имён трекеров (`TrackerSlug[]` в OpenAPI): из `synctrackers`, иначе known slugs; записи из `disable_trackers` исключаются. Пустой `synctrackers: []` возвращает `[]` (скан БД не выполняется).
 - **`GET /api/v1.0/qualitys`** — список доступных качеств.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,10 @@ globalproxy:
       mergeV1: auto
       skipCatFilter: true
 
+    alloha:
+      enable: true
+      token: "YOUR_ALLOHA_TOKEN"
+
     torznab:
       enable: true
 
@@ -228,6 +232,10 @@ globalproxy:
         "stripTrailingYear": true,
         "skipCatFilter": true
       },
+      "alloha": {
+        "enable": true,
+        "token": "YOUR_ALLOHA_TOKEN"
+      },
       "torznab": {
         "enable": true,
         "enrichTitles": true
@@ -255,9 +263,22 @@ globalproxy:
 | `auto` | v2 only | v2 + v1 fuzzy (до `maxV1Pairs`) |
 | `true` | v2 + v1 fuzzy (без лимита) | v2 + v1 fuzzy (без лимита) |
 
-IMDB/KP (`tt…`, `kp…`) всегда через v1 exact, независимо от `mergeV1`.
+IMDB/KP (`tt…`, `kp…`) всегда через v1 exact (после резолва Alloha), независимо от `mergeV1`.
 
 Jackett JSON (`/api/v2.0/indexers/.../results`) **всегда** использует combined search; на `torznab.enable` не зависит.
+
+### Alloha (`alloha`)
+
+Резолв Kinopoisk / IMDb ID → названия через **Alloha TV API v2** (`GET /v2/movies/search`), затем точный поиск в FileDB.
+
+| Параметр | Описание | По умолчанию |
+| --- | --- | --- |
+| `enable` | Включить резолв `tt…` / `kp…` | `true` |
+| `baseUrl` | Хост API | `https://apbugall.org` |
+| `token` | Bearer-токен (`Authorization`) | — (см. `example.yaml`) |
+| `timeoutSeconds` | Таймаут HTTP | `8` |
+| `cacheHours` | Memory-cache ID → titles | `24` |
+| `filterByYear` | Если клиент не передал year — фильтр FileDB по году Alloha (±1) | `true` |
 
 ### Torznab XML (`torznab`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,17 +263,17 @@ globalproxy:
 | `auto` | v2 only | v2 + v1 fuzzy (до `maxV1Pairs`) |
 | `true` | v2 + v1 fuzzy (без лимита) | v2 + v1 fuzzy (без лимита) |
 
-IMDB/KP (`tt…`, `kp…`) всегда через v1 exact (после резолва Alloha), независимо от `mergeV1`.
+IMDB/KP/TMDB (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL) всегда через v1 exact (после резолва Alloha), независимо от `mergeV1`.
 
 Jackett JSON (`/api/v2.0/indexers/.../results`) **всегда** использует combined search; на `torznab.enable` не зависит.
 
 ### Alloha (`alloha`)
 
-Резолв Kinopoisk / IMDb ID → названия через **Alloha TV API v2** (`GET /v2/movies/search`), затем точный поиск в FileDB.
+Резолв Kinopoisk / IMDb / TMDB ID → названия через **Alloha TV API v2** (`GET /v2/movies/search`), затем точный поиск в FileDB.
 
 | Параметр | Описание | По умолчанию |
 | --- | --- | --- |
-| `enable` | Включить резолв `tt…` / `kp…` | `true` |
+| `enable` | Включить резолв `tt…` / `kp…` / `tmdb…` / themoviedb.org URL | `true` |
 | `baseUrl` | Хост API | `https://apbugall.org` |
 | `token` | Bearer-токен (`Authorization`) | — (см. `example.yaml`) |
 | `timeoutSeconds` | Таймаут HTTP | `8` |

--- a/tests/JacRed.Tests/External/AllohaFileDbSearchTests.cs
+++ b/tests/JacRed.Tests/External/AllohaFileDbSearchTests.cs
@@ -1,0 +1,227 @@
+using JacRed.Application.Search;
+using JacRed.Infrastructure.External;
+using JacRed.Infrastructure.Indexers;
+using JacRed.Infrastructure.Persistence;
+using JacRed.Models.Details;
+using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace JacRed.Tests.External;
+
+/// <summary>
+/// Seeds an isolated FileDB bucket + Alloha memory-cache entries (no live HTTP),
+/// then searches via native API and combined indexer path using tt/kp/tmdb ids.
+/// </summary>
+public class AllohaFileDbSearchTests : IDisposable
+{
+    const string RuName = "Бойцовский клуб";
+    const string EnName = "Fight Club";
+    const string ImdbId = "tt0137523";
+    const string KpId = "kp361";
+    const string TmdbId = "tmdb550";
+    const string TestUrl = "https://example.test/alloha-fdb-search/fight-club";
+    const string TestMagnet = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567";
+
+    readonly string _bucketKey;
+    readonly string _tracker;
+    readonly string _fdbPath;
+    readonly AllohaResolveResult _resolved;
+
+    public AllohaFileDbSearchTests()
+    {
+        _tracker = PickTracker();
+        _bucketKey = FileDB.KeyForTorrent(RuName, EnName);
+        _fdbPath = FileDB.PathForKey(_bucketKey);
+
+        _resolved = new AllohaResolveResult
+        {
+            Search = EnName,
+            AltName = RuName,
+            Year = 1999,
+            Type = "movie",
+            ImdbId = ImdbId,
+            KpId = KpId,
+            TmdbId = TmdbId
+        };
+
+        SeedFileDb();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            // Drop write connection so Dispose can remove openWriteTask entry.
+            using (var fdb = FileDB.OpenWrite(_bucketKey))
+            {
+                fdb.Database.Clear();
+                fdb.savechanges = true;
+            }
+        }
+        catch
+        {
+            // ignore cleanup races
+        }
+
+        FileDB.RemoveKeyFromMasterDb(_bucketKey);
+
+        try
+        {
+            if (File.Exists(_fdbPath))
+                File.Delete(_fdbPath);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    [Theory]
+    [InlineData(ImdbId)]
+    [InlineData(KpId)]
+    [InlineData(TmdbId)]
+    public async Task NativeQuery_IdResolve_FindsSeededTorrent(string id)
+    {
+        using var cache = NewCacheWithResolve(id);
+        var svc = new TorrentQueryService();
+
+        var raw = await svc.QueryTorrentsAsync(
+            search: id,
+            altname: null,
+            exact: false,
+            type: null,
+            sort: "sid",
+            tracker: null,
+            voice: null,
+            videotype: null,
+            relased: 0,
+            quality: 0,
+            season: 0,
+            memoryCache: cache);
+
+        var rows = ToRows(raw);
+        Assert.Contains(rows, r => string.Equals((string)r["url"], TestUrl, StringComparison.OrdinalIgnoreCase)
+            || string.Equals((string)r["magnet"], TestMagnet, StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(rows, r => (string)r["originalname"] == EnName || (string)r["name"] == RuName);
+    }
+
+    [Theory]
+    [InlineData(ImdbId)]
+    [InlineData(KpId)]
+    [InlineData("TT0137523")]
+    [InlineData("KP361")]
+    public async Task CombinedSearch_IdResolve_FindsSeededTorrent(string id)
+    {
+        using var cache = NewCacheWithResolve(id);
+        var results = await IndexerSearchEngine.SearchCombinedAsync(
+            new IndexerSearchRequest { Query = id, CardMode = false },
+            cache,
+            jackettSearch: null);
+
+        Assert.NotEmpty(results);
+        Assert.Contains(results, r =>
+            string.Equals(r.MagnetUri, TestMagnet, StringComparison.OrdinalIgnoreCase)
+            || (r.info != null && (r.info.originalname == EnName || r.info.name == RuName)));
+    }
+
+    [Fact]
+    public async Task NativeQuery_WrongYearFromAlloha_FiltersOut()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var wrongYear = new AllohaResolveResult
+        {
+            Search = EnName,
+            AltName = RuName,
+            Year = 2010,
+            Type = "movie",
+            ImdbId = ImdbId,
+            KpId = KpId,
+            TmdbId = TmdbId
+        };
+        SeedCache(cache, ImdbId, wrongYear);
+
+        var prev = AppInit.conf.alloha.filterByYear;
+        AppInit.conf.alloha.filterByYear = true;
+        try
+        {
+            var svc = new TorrentQueryService();
+            var raw = await svc.QueryTorrentsAsync(
+                ImdbId, null, false, null, "sid", null, null, null, 0, 0, 0, cache);
+            Assert.Empty(ToRows(raw));
+        }
+        finally
+        {
+            AppInit.conf.alloha.filterByYear = prev;
+        }
+    }
+
+    MemoryCache NewCacheWithResolve(string id)
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        Assert.True(AllohaTitleResolver.TryNormalizeId(id, out string canonical, out _));
+        SeedCache(cache, canonical, _resolved);
+        // Cross-id keys so ResolveAsync cache aliases behave like production.
+        SeedCache(cache, ImdbId, _resolved);
+        SeedCache(cache, KpId, _resolved);
+        SeedCache(cache, TmdbId, _resolved);
+        return cache;
+    }
+
+    static void SeedCache(IMemoryCache cache, string id, AllohaResolveResult resolved)
+    {
+        cache.Set($"alloha:title:{id.Trim().ToLowerInvariant()}", resolved, TimeSpan.FromHours(1));
+    }
+
+    void SeedFileDb()
+    {
+        using var fdb = FileDB.OpenWrite(_bucketKey);
+        fdb.AddOrUpdate(new TorrentDetails
+        {
+            url = TestUrl,
+            trackerName = _tracker,
+            types = new[] { "movie" },
+            title = $"{RuName} / {EnName} (1999)",
+            name = RuName,
+            originalname = EnName,
+            magnet = TestMagnet,
+            sid = 10,
+            pir = 1,
+            sizeName = "1 GB",
+            relased = 1999,
+            createTime = DateTime.UtcNow,
+            updateTime = DateTime.UtcNow
+        });
+        Assert.True(FileDB.masterDb.ContainsKey(_bucketKey));
+    }
+
+    static string PickTracker()
+    {
+        var sync = AppInit.conf.synctrackers;
+        if (sync != null && sync.Length > 0)
+            return sync[0];
+
+        var disabled = AppInit.conf.disable_trackers;
+        string candidate = "rutor";
+        if (disabled != null && disabled.Contains(candidate))
+            candidate = "kinozal";
+        return candidate;
+    }
+
+    static List<JObject> ToRows(object raw)
+    {
+        if (raw == null)
+            return new List<JObject>();
+
+        if (raw is JArray ja)
+            return ja.Children<JObject>().ToList();
+
+        string json = JsonConvert.SerializeObject(raw);
+        var token = JToken.Parse(json);
+        if (token is JArray arr)
+            return arr.Children<JObject>().ToList();
+
+        return new List<JObject>();
+    }
+}

--- a/tests/JacRed.Tests/External/AllohaTitleResolverNormalizeTests.cs
+++ b/tests/JacRed.Tests/External/AllohaTitleResolverNormalizeTests.cs
@@ -1,0 +1,58 @@
+using JacRed.Infrastructure.External;
+using Xunit;
+
+namespace JacRed.Tests.External;
+
+public class AllohaTitleResolverNormalizeTests
+{
+    [Theory]
+    [InlineData("tt0137523", "tt0137523", null)]
+    [InlineData("TT0137523", "tt0137523", null)]
+    [InlineData("tt1234567", "tt1234567", null)]
+    [InlineData("kp301", "kp301", null)]
+    [InlineData("KP301", "kp301", null)]
+    [InlineData("kp464963", "kp464963", null)]
+    [InlineData("tmdb1315772", "tmdb1315772", null)]
+    [InlineData("tmdb:1315772", "tmdb1315772", null)]
+    [InlineData("TMDB550", "tmdb550", null)]
+    public void TryNormalizeId_CompactIds(string raw, string expectedId, string expectedHint)
+    {
+        Assert.True(AllohaTitleResolver.TryNormalizeId(raw, out string id, out string hint));
+        Assert.Equal(expectedId, id);
+        Assert.Equal(expectedHint, hint);
+    }
+
+    [Theory]
+    [InlineData("https://www.themoviedb.org/movie/1315772-minions-monsters", "tmdb1315772", "movie")]
+    [InlineData("https://www.themoviedb.org/tv/1399-game-of-thrones", "tmdb1399", "serial")]
+    [InlineData("http://themoviedb.org/movie/550", "tmdb550", "movie")]
+    [InlineData("https://www.themoviedb.org/movie/1315772-minions-monsters?language=en-US", "tmdb1315772", "movie")]
+    public void TryNormalizeId_TmdbUrls(string raw, string expectedId, string expectedHint)
+    {
+        Assert.True(AllohaTitleResolver.TryNormalizeId(raw, out string id, out string hint));
+        Assert.Equal(expectedId, id);
+        Assert.Equal(expectedHint, hint);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Fight Club")]
+    [InlineData("1315772")]
+    [InlineData("imdb0137523")]
+    [InlineData("https://www.imdb.com/title/tt0137523/")]
+    public void TryNormalizeId_RejectsNonIds(string raw)
+    {
+        Assert.False(AllohaTitleResolver.TryNormalizeId(raw, out _, out _));
+        Assert.False(AllohaTitleResolver.IsResolvableId(raw));
+    }
+
+    [Fact]
+    public void IsResolvableId_MatchesAlias()
+    {
+        Assert.True(AllohaTitleResolver.IsResolvableId("tmdb550"));
+        Assert.True(AllohaTitleResolver.IsImdbOrKpId("kp301"));
+        Assert.False(AllohaTitleResolver.IsImdbOrKpId("Matrix"));
+    }
+}

--- a/tests/JacRed.Tests/Indexers/AllohaSearchParamsTests.cs
+++ b/tests/JacRed.Tests/Indexers/AllohaSearchParamsTests.cs
@@ -1,0 +1,114 @@
+using JacRed.Infrastructure.Indexers;
+using JacRed.Models.Api;
+using Xunit;
+
+namespace JacRed.Tests.Indexers;
+
+public class AllohaSearchParamsTests
+{
+    [Theory]
+    [InlineData("tt0137523", "tt0137523")]
+    [InlineData("TT0137523", "tt0137523")]
+    [InlineData("kp301", "kp301")]
+    [InlineData("KP464963", "kp464963")]
+    [InlineData("tmdb1315772", "tmdb1315772")]
+    [InlineData("tmdb:550", "tmdb550")]
+    [InlineData("https://www.themoviedb.org/movie/1315772-minions-monsters", "tmdb1315772")]
+    [InlineData("0137523", "tt0137523")]
+    public void NormalizeQuery_ExternalIds(string raw, string expected)
+    {
+        Assert.Equal(expected, IndexerRequestParams.NormalizeQuery(raw));
+        Assert.True(IndexerRequestParams.IsImdbOrKpQuery(IndexerRequestParams.NormalizeQuery(raw)));
+    }
+
+    [Fact]
+    public void NormalizeQuery_PlainTitle_Unchanged()
+    {
+        Assert.Equal("Fight Club", IndexerRequestParams.NormalizeQuery("Fight Club"));
+        Assert.False(IndexerRequestParams.IsImdbOrKpQuery("Fight Club"));
+    }
+
+    [Theory]
+    [InlineData("1315772", "tmdb1315772")]
+    [InlineData("tmdb550", "tmdb550")]
+    [InlineData("https://www.themoviedb.org/tv/1399-got", "tmdb1399")]
+    public void NormalizeTmdbId(string raw, string expected)
+    {
+        Assert.Equal(expected, IndexerRequestParams.NormalizeTmdbId(raw));
+    }
+
+    [Fact]
+    public void NormalizeTmdbId_RejectsImdb()
+    {
+        Assert.Null(IndexerRequestParams.NormalizeTmdbId("tt0137523"));
+    }
+
+    [Fact]
+    public void Prowlarr_Movie_BraceTmdbId_BecomesQuery()
+    {
+        var parsed = ProwlarrQueryParser.Parse("{TmdbId:1315772}", "movie");
+
+        Assert.Equal("tmdb1315772", parsed.TmdbId);
+        Assert.Equal("tmdb1315772", parsed.Query);
+        Assert.Null(parsed.Title);
+    }
+
+    [Fact]
+    public void Prowlarr_Tv_BraceTmdbId_BecomesQuery()
+    {
+        var parsed = ProwlarrQueryParser.Parse("{tmdbid:1399} {Season:1}", "tvsearch");
+
+        Assert.Equal("tmdb1399", parsed.TmdbId);
+        Assert.Equal("tmdb1399", parsed.Query);
+        Assert.Equal(1, parsed.Season);
+    }
+
+    [Fact]
+    public void Prowlarr_ImdbAndKp_BraceTokens()
+    {
+        var imdb = ProwlarrQueryParser.Parse("{ImdbId:tt0137523}", "moviesearch");
+        Assert.Equal("tt0137523", imdb.ImdbId);
+        Assert.Equal("tt0137523", imdb.Query);
+
+        // KP is not a Prowlarr brace token — plain query still normalizes.
+        Assert.Equal("kp361", IndexerRequestParams.NormalizeQuery("kp361"));
+        Assert.True(IndexerRequestParams.IsImdbOrKpQuery("kp361"));
+    }
+
+    [Fact]
+    public void FilterByType_KeepsMatchingAndUntyped()
+    {
+        var items = new List<Result>
+        {
+            new() { Title = "a", info = new TorrentInfo { types = new[] { "movie" } } },
+            new() { Title = "b", info = new TorrentInfo { types = new[] { "serial" } } },
+            new() { Title = "c", info = null },
+            new() { Title = "d", info = new TorrentInfo { types = System.Array.Empty<string>() } },
+        };
+
+        var filtered = IndexerResultFilters.FilterByType(items, "movie");
+
+        Assert.Equal(3, filtered.Count);
+        Assert.Contains(filtered, r => r.Title == "a");
+        Assert.Contains(filtered, r => r.Title == "c");
+        Assert.Contains(filtered, r => r.Title == "d");
+        Assert.DoesNotContain(filtered, r => r.Title == "b");
+    }
+
+    [Fact]
+    public void FilterByYear_AllowsPlusMinusOne()
+    {
+        var items = new List<Result>
+        {
+            new() { Title = "y1999", info = new TorrentInfo { relased = 1999 } },
+            new() { Title = "y1998", info = new TorrentInfo { relased = 1998 } },
+            new() { Title = "y2001", info = new TorrentInfo { relased = 2001 } },
+            new() { Title = "unknown", info = new TorrentInfo { relased = 0 } },
+        };
+
+        var filtered = IndexerResultFilters.FilterByYear(items, 1999);
+
+        Assert.Equal(3, filtered.Count);
+        Assert.DoesNotContain(filtered, r => r.Title == "y2001");
+    }
+}

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: JacRed API
-  version: 1.2.2
+  version: 1.2.3
   description: |
     Torrent aggregator API: Jackett-compatible search, native torrent search, Torznab XML,
     statistics, sync protocol, and configuration management.
@@ -170,7 +170,8 @@ paths:
         When `{status}` is a tracker id from `GET /api/v1.0/trackers` (for example `rutracker`),
         results are filtered to that tracker (case-insensitive; matches any part of a merged trackerName).
 
-        **IMDb / Kinopoisk IDs:** `query`/`q` as `tt…` or `kp…`, or `imdbid`, are resolved via Alloha TV API v2
+        **IMDb / Kinopoisk / TMDB IDs:** `query`/`q` as `tt…`, `kp…`, `tmdb…`, a themoviedb.org
+        `/movie|tv/{id}-…` URL, or `imdbid`, are resolved via Alloha TV API v2
         (`GET /v2/movies/search`) to titles (plus optional alternative name, year, type), then searched
         in FileDB with exact match. When the client omits `year`, Alloha year ±1 is applied if
         `alloha.filterByYear` is enabled.
@@ -229,7 +230,8 @@ paths:
       description: |
         Native JacRed JSON search (not Torznab/Jackett).
 
-        **IMDb / Kinopoisk IDs:** when `search` is `tt…` or `kp…`, JacRed resolves titles via Alloha TV API v2,
+        **IMDb / Kinopoisk / TMDB IDs:** when `search` is `tt…`, `kp…`, `tmdb…`, or a themoviedb.org
+        `/movie|tv/{id}-…` URL, JacRed resolves titles via Alloha TV API v2,
         forces `exact=true`, and may fill `type` / year filter from Alloha when the client omitted them
         (`relased` unset → Alloha year ±1 if `alloha.filterByYear`; empty `type` → Alloha category).
       parameters:
@@ -240,7 +242,8 @@ paths:
           schema:
             type: string
           description: |
-            Title query, or an IMDb/KP id (`tt1234567`, `kp301`). Empty or omitted yields an empty result array.
+            Title query, or an external id (`tt1234567`, `kp301`, `tmdb1315772`) or themoviedb.org URL.
+            Empty or omitted yields an empty result array.
             ID queries are resolved via Alloha v2 before FileDB lookup.
         - name: altname
           in: query
@@ -380,8 +383,8 @@ paths:
         (`Tracker`/`Tracker[]`/`tracker`).
         `t=indexers` returns aggregate `all` plus one indexer entry per `GET /api/v1.0/trackers` name.
 
-        **IMDb / Kinopoisk IDs:** `q` as `tt…`/`kp…` or `imdbid` → Alloha TV API v2 title resolve →
-        FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
+        **IMDb / Kinopoisk / TMDB IDs:** `q` as `tt…`/`kp…`/`tmdb…`, a themoviedb.org URL, or `imdbid` →
+        Alloha TV API v2 title resolve → FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
       operationId: torznabRoot
       parameters:
         - $ref: "#/components/parameters/ApiKeyQuery"
@@ -450,7 +453,7 @@ paths:
         When `{indexer}` is a tracker id (not `all`), search results are filtered to that tracker.
         `t=indexers` lists `all` plus per-tracker indexers from the tracker catalog.
         Same query params as `/torznab/api` (caps + JacRed card fields, categories, tracker filters),
-        including Alloha v2 resolve for `tt…` / `kp…` / `imdbid`.
+        including Alloha v2 resolve for `tt…` / `kp…` / `tmdb…` / themoviedb.org URLs / `imdbid`.
       operationId: torznabIndexer
       parameters:
         - name: indexer
@@ -609,7 +612,7 @@ paths:
       summary: Prowlarr Torznab proxy
       description: |
         Prowlarr-compatible Torznab endpoint (`t=caps`, `search`, `tvsearch`, `moviesearch`).
-        Same handler as `/torznab/api` and Jackett alias paths (including Alloha v2 resolve for `tt…` / `kp…` / `imdbid`).
+        Same handler as `/torznab/api` and Jackett alias paths (including Alloha v2 resolve for `tt…` / `kp…` / `tmdb…` / `imdbid`).
         Path `{indexer}` is typically numeric (`1` = aggregate JacRed); numeric ids do not apply a tracker filter.
       operationId: prowlarrNewznab
       parameters:
@@ -691,7 +694,8 @@ paths:
         Prowlarr-compatible interactive search (`/api/v1/search`).
         Returns a JSON array of ReleaseResource-shaped objects.
         Brace tokens in `query` (e.g. `{ImdbId:tt123}`, `{Season:1}`) are parsed like Prowlarr UI search.
-        IMDb/KP id queries (`tt…`, `kp…`, or brace `{ImdbId:…}`) are resolved via Alloha TV API v2 before FileDB exact search.
+        IMDb/KP/TMDB id queries (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL, or brace `{ImdbId:…}` / `{TmdbId:…}`)
+        are resolved via Alloha TV API v2 before FileDB exact search.
         JacRed exposes a single aggregate torrent indexer (`id=1`); `indexerIds=-1` (usenet) returns `[]`.
         Each release also includes JacRed extensions (`ffprobe`, `languages`, `info`) when `tracks: true`, same as Jackett results.
         Lampa Prowlarr mode (`query` + `type` + `categories`) is promoted to Jackett-style card search
@@ -1320,7 +1324,8 @@ components:
       description: |
         IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
         Resolved via Alloha TV API v2 to titles before FileDB search.
-        Kinopoisk ids are accepted on `q`/`query` as `kp…` (same Alloha resolve path).
+        Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+        `/movie|tv/{id}-…` URL (same Alloha resolve path).
     TorznabTvdbId:
       name: tvdbid
       in: query
@@ -1481,7 +1486,7 @@ components:
         type: integer
       description: |
         Release year filter / card-search override.
-        When omitted on an IMDb/KP id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+        When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
     IsSerial:
       name: is_serial
       in: query

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: JacRed API
-  version: 1.2.1
+  version: 1.2.2
   description: |
     Torrent aggregator API: Jackett-compatible search, native torrent search, Torznab XML,
     statistics, sync protocol, and configuration management.
@@ -169,6 +169,11 @@ paths:
         Lampa and other Jackett JSON clients. Path `{status}` is normally `all` (aggregate).
         When `{status}` is a tracker id from `GET /api/v1.0/trackers` (for example `rutracker`),
         results are filtered to that tracker (case-insensitive; matches any part of a merged trackerName).
+
+        **IMDb / Kinopoisk IDs:** `query`/`q` as `tt…` or `kp…`, or `imdbid`, are resolved via Alloha TV API v2
+        (`GET /v2/movies/search`) to titles (plus optional alternative name, year, type), then searched
+        in FileDB with exact match. When the client omits `year`, Alloha year ±1 is applied if
+        `alloha.filterByYear` is enabled.
       operationId: jackettSearch
       parameters:
         - name: status
@@ -221,6 +226,12 @@ paths:
       tags: [Search]
       summary: Native torrent search
       operationId: torrentsSearch
+      description: |
+        Native JacRed JSON search (not Torznab/Jackett).
+
+        **IMDb / Kinopoisk IDs:** when `search` is `tt…` or `kp…`, JacRed resolves titles via Alloha TV API v2,
+        forces `exact=true`, and may fill `type` / year filter from Alloha when the client omitted them
+        (`relased` unset → Alloha year ±1 if `alloha.filterByYear`; empty `type` → Alloha category).
       parameters:
         - $ref: "#/components/parameters/ApiKeyQuery"
         - name: search
@@ -228,20 +239,25 @@ paths:
           required: false
           schema:
             type: string
-          description: Empty or omitted yields an empty result array
+          description: |
+            Title query, or an IMDb/KP id (`tt1234567`, `kp301`). Empty or omitted yields an empty result array.
+            ID queries are resolved via Alloha v2 before FileDB lookup.
         - name: altname
           in: query
           schema:
             type: string
+          description: Alternate title (e.g. Russian name). After Alloha resolve, filled from `data.name` when both titles exist.
         - name: exact
           in: query
           schema:
             type: boolean
+          description: Exact title match. Forced to true after IMDb/KP Alloha resolve.
         - name: type
           in: query
           schema:
             type: string
-            description: movie, serial, anime, etc.
+            description: |
+              movie, serial, anime, etc. When omitted on an ID query, may be set from Alloha `category.slug`.
         - name: sort
           in: query
           schema:
@@ -260,6 +276,9 @@ paths:
           in: query
           schema:
             type: integer
+          description: |
+            Release year filter (exact). When 0/omitted on an ID query and `alloha.filterByYear`,
+            Alloha year ±1 is used instead.
         - name: quality
           in: query
           schema:
@@ -360,6 +379,9 @@ paths:
         category aliases (`cat`/`Category`/`categories`/`Category[]`), and tracker filters
         (`Tracker`/`Tracker[]`/`tracker`).
         `t=indexers` returns aggregate `all` plus one indexer entry per `GET /api/v1.0/trackers` name.
+
+        **IMDb / Kinopoisk IDs:** `q` as `tt…`/`kp…` or `imdbid` → Alloha TV API v2 title resolve →
+        FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
       operationId: torznabRoot
       parameters:
         - $ref: "#/components/parameters/ApiKeyQuery"
@@ -427,7 +449,8 @@ paths:
         Jackett-compatible Torznab alias. Path `{indexer}` is normally `all`.
         When `{indexer}` is a tracker id (not `all`), search results are filtered to that tracker.
         `t=indexers` lists `all` plus per-tracker indexers from the tracker catalog.
-        Same query params as `/torznab/api` (caps + JacRed card fields, categories, tracker filters).
+        Same query params as `/torznab/api` (caps + JacRed card fields, categories, tracker filters),
+        including Alloha v2 resolve for `tt…` / `kp…` / `imdbid`.
       operationId: torznabIndexer
       parameters:
         - name: indexer
@@ -586,7 +609,7 @@ paths:
       summary: Prowlarr Torznab proxy
       description: |
         Prowlarr-compatible Torznab endpoint (`t=caps`, `search`, `tvsearch`, `moviesearch`).
-        Same handler as `/torznab/api` and Jackett alias paths.
+        Same handler as `/torznab/api` and Jackett alias paths (including Alloha v2 resolve for `tt…` / `kp…` / `imdbid`).
         Path `{indexer}` is typically numeric (`1` = aggregate JacRed); numeric ids do not apply a tracker filter.
       operationId: prowlarrNewznab
       parameters:
@@ -668,6 +691,7 @@ paths:
         Prowlarr-compatible interactive search (`/api/v1/search`).
         Returns a JSON array of ReleaseResource-shaped objects.
         Brace tokens in `query` (e.g. `{ImdbId:tt123}`, `{Season:1}`) are parsed like Prowlarr UI search.
+        IMDb/KP id queries (`tt…`, `kp…`, or brace `{ImdbId:…}`) are resolved via Alloha TV API v2 before FileDB exact search.
         JacRed exposes a single aggregate torrent indexer (`id=1`); `indexerIds=-1` (usenet) returns `[]`.
         Each release also includes JacRed extensions (`ffprobe`, `languages`, `info`) when `tracks: true`, same as Jackett results.
         Lampa Prowlarr mode (`query` + `type` + `categories`) is promoted to Jackett-style card search
@@ -1293,7 +1317,10 @@ components:
       in: query
       schema:
         type: string
-      description: IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted
+      description: |
+        IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+        Resolved via Alloha TV API v2 to titles before FileDB search.
+        Kinopoisk ids are accepted on `q`/`query` as `kp…` (same Alloha resolve path).
     TorznabTvdbId:
       name: tvdbid
       in: query
@@ -1452,7 +1479,9 @@ components:
       in: query
       schema:
         type: integer
-      description: Release year filter / card-search override
+      description: |
+        Release year filter / card-search override.
+        When omitted on an IMDb/KP id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
     IsSerial:
       name: is_serial
       in: query

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -42,7 +42,7 @@ export default {
   search: {
     title: 'Torrent search',
     subtitle: 'Title, Kinopoisk or IMDb id · Enter or Search',
-    placeholder: 'Title, kp123456, tt1234567…',
+    placeholder: 'Title, kp123456, tt1234567, tmdb1315772…',
     queryAria: 'Search query',
     submit: 'Search',
     searching: 'Searching…',

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -43,7 +43,7 @@ export default {
   search: {
     title: 'Поиск торрентов',
     subtitle: 'Имя, код Кинопоиска или IMDb · Enter или кнопка «Искать»',
-    placeholder: 'Название, kp123456, tt1234567…',
+    placeholder: 'Название, kp123456, tt1234567, tmdb1315772…',
     queryAria: 'Поисковый запрос',
     submit: 'Искать',
     searching: 'Поиск…',

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -108,6 +108,12 @@ export interface paths {
          * @description Lampa and other Jackett JSON clients. Path `{status}` is normally `all` (aggregate).
          *     When `{status}` is a tracker id from `GET /api/v1.0/trackers` (for example `rutracker`),
          *     results are filtered to that tracker (case-insensitive; matches any part of a merged trackerName).
+         *
+         *     **IMDb / Kinopoisk / TMDB IDs:** `query`/`q` as `tt…`, `kp…`, `tmdb…`, a themoviedb.org
+         *     `/movie|tv/{id}-…` URL, or `imdbid`, are resolved via Alloha TV API v2
+         *     (`GET /v2/movies/search`) to titles (plus optional alternative name, year, type), then searched
+         *     in FileDB with exact match. When the client omits `year`, Alloha year ±1 is applied if
+         *     `alloha.filterByYear` is enabled.
          */
         get: operations["jackettSearch"];
         put?: never;
@@ -125,7 +131,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Native torrent search */
+        /**
+         * Native torrent search
+         * @description Native JacRed JSON search (not Torznab/Jackett).
+         *
+         *     **IMDb / Kinopoisk / TMDB IDs:** when `search` is `tt…`, `kp…`, `tmdb…`, or a themoviedb.org
+         *     `/movie|tv/{id}-…` URL, JacRed resolves titles via Alloha TV API v2,
+         *     forces `exact=true`, and may fill `type` / year filter from Alloha when the client omitted them
+         *     (`relased` unset → Alloha year ±1 if `alloha.filterByYear`; empty `type` → Alloha category).
+         */
         get: operations["torrentsSearch"];
         put?: never;
         post?: never;
@@ -189,6 +203,9 @@ export interface paths {
          *     category aliases (`cat`/`Category`/`categories`/`Category[]`), and tracker filters
          *     (`Tracker`/`Tracker[]`/`tracker`).
          *     `t=indexers` returns aggregate `all` plus one indexer entry per `GET /api/v1.0/trackers` name.
+         *
+         *     **IMDb / Kinopoisk / TMDB IDs:** `q` as `tt…`/`kp…`/`tmdb…`, a themoviedb.org URL, or `imdbid` →
+         *     Alloha TV API v2 title resolve → FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
          */
         get: operations["torznabRoot"];
         put?: never;
@@ -215,7 +232,8 @@ export interface paths {
          * @description Jackett-compatible Torznab alias. Path `{indexer}` is normally `all`.
          *     When `{indexer}` is a tracker id (not `all`), search results are filtered to that tracker.
          *     `t=indexers` lists `all` plus per-tracker indexers from the tracker catalog.
-         *     Same query params as `/torznab/api` (caps + JacRed card fields, categories, tracker filters).
+         *     Same query params as `/torznab/api` (caps + JacRed card fields, categories, tracker filters),
+         *     including Alloha v2 resolve for `tt…` / `kp…` / `tmdb…` / themoviedb.org URLs / `imdbid`.
          */
         get: operations["torznabIndexer"];
         put?: never;
@@ -304,7 +322,7 @@ export interface paths {
         /**
          * Prowlarr Torznab proxy
          * @description Prowlarr-compatible Torznab endpoint (`t=caps`, `search`, `tvsearch`, `moviesearch`).
-         *     Same handler as `/torznab/api` and Jackett alias paths.
+         *     Same handler as `/torznab/api` and Jackett alias paths (including Alloha v2 resolve for `tt…` / `kp…` / `tmdb…` / `imdbid`).
          *     Path `{indexer}` is typically numeric (`1` = aggregate JacRed); numeric ids do not apply a tracker filter.
          */
         get: operations["prowlarrNewznab"];
@@ -332,6 +350,8 @@ export interface paths {
          * @description Prowlarr-compatible interactive search (`/api/v1/search`).
          *     Returns a JSON array of ReleaseResource-shaped objects.
          *     Brace tokens in `query` (e.g. `{ImdbId:tt123}`, `{Season:1}`) are parsed like Prowlarr UI search.
+         *     IMDb/KP/TMDB id queries (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL, or brace `{ImdbId:…}` / `{TmdbId:…}`)
+         *     are resolved via Alloha TV API v2 before FileDB exact search.
          *     JacRed exposes a single aggregate torrent indexer (`id=1`); `indexerIds=-1` (usenet) returns `[]`.
          *     Each release also includes JacRed extensions (`ffprobe`, `languages`, `info`) when `tracks: true`, same as Jackett results.
          *     Lampa Prowlarr mode (`query` + `type` + `categories`) is promoted to Jackett-style card search
@@ -1154,7 +1174,12 @@ export interface components {
         TorznabQ: string;
         /** @description Comma-separated Torznab category ids */
         TorznabCat: string;
-        /** @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted */
+        /**
+         * @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+         *     Resolved via Alloha TV API v2 to titles before FileDB search.
+         *     Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+         *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
+         */
         TorznabImdbId: string;
         /** @description TheTVDB id (tv-search) */
         TorznabTvdbId: string;
@@ -1217,7 +1242,10 @@ export interface components {
          *     Not used as a genre filter on results.
          */
         Genres: string;
-        /** @description Release year filter / card-search override */
+        /**
+         * @description Release year filter / card-search override.
+         *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+         */
         Year: number;
         /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
         IsSerial: number;
@@ -1351,7 +1379,10 @@ export interface operations {
                 title?: components["parameters"]["TorznabTitle"];
                 /** @description Original title (JacRed / Lampa card search) */
                 title_original?: components["parameters"]["TorznabTitleOriginal"];
-                /** @description Release year filter / card-search override */
+                /**
+                 * @description Release year filter / card-search override.
+                 *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+                 */
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];
@@ -1381,7 +1412,12 @@ export interface operations {
                  *     (`TrackerSlug` values; case-insensitive; matches any comma-separated part of stored trackerName).
                  */
                 tracker?: components["parameters"]["TrackerAlias"];
-                /** @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted */
+                /**
+                 * @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+                 *     Resolved via Alloha TV API v2 to titles before FileDB search.
+                 *     Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+                 *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
+                 */
                 imdbid?: components["parameters"]["TorznabImdbId"];
                 /** @description Alias for `imdbid` */
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
@@ -1429,9 +1465,15 @@ export interface operations {
             query?: {
                 /** @description API key (alternative — X-Api-Key header or Bearer) */
                 apikey?: components["parameters"]["ApiKeyQuery"];
-                /** @description Empty or omitted yields an empty result array */
+                /**
+                 * @description Title query, or an external id (`tt1234567`, `kp301`, `tmdb1315772`) or themoviedb.org URL.
+                 *     Empty or omitted yields an empty result array.
+                 *     ID queries are resolved via Alloha v2 before FileDB lookup.
+                 */
                 search?: string;
+                /** @description Alternate title (e.g. Russian name). After Alloha resolve, filled from `data.name` when both titles exist. */
                 altname?: string;
+                /** @description Exact title match. Forced to true after IMDb/KP Alloha resolve. */
                 exact?: boolean;
                 type?: string;
                 sort?: "sid" | "pir" | "size" | "create" | "update";
@@ -1442,6 +1484,10 @@ export interface operations {
                 tracker?: components["parameters"]["TrackerAlias"];
                 voice?: string;
                 videotype?: string;
+                /**
+                 * @description Release year filter (exact). When 0/omitted on an ID query and `alloha.filterByYear`,
+                 *     Alloha year ±1 is used instead.
+                 */
                 relased?: number;
                 quality?: number;
                 season?: number;
@@ -1546,7 +1592,12 @@ export interface operations {
                  *     Also accepted as `cat`, `Category`, `Category[]`, `Category[n]`.
                  */
                 categories?: components["parameters"]["Categories"];
-                /** @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted */
+                /**
+                 * @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+                 *     Resolved via Alloha TV API v2 to titles before FileDB search.
+                 *     Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+                 *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
+                 */
                 imdbid?: components["parameters"]["TorznabImdbId"];
                 /** @description Alias for `imdbid` */
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
@@ -1566,7 +1617,10 @@ export interface operations {
                 title?: components["parameters"]["TorznabTitle"];
                 /** @description Original title (JacRed / Lampa card search) */
                 title_original?: components["parameters"]["TorznabTitleOriginal"];
-                /** @description Release year filter / card-search override */
+                /**
+                 * @description Release year filter / card-search override.
+                 *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+                 */
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];
@@ -1679,7 +1733,12 @@ export interface operations {
                  *     Also accepted as `cat`, `Category`, `Category[]`, `Category[n]`.
                  */
                 categories?: components["parameters"]["Categories"];
-                /** @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted */
+                /**
+                 * @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+                 *     Resolved via Alloha TV API v2 to titles before FileDB search.
+                 *     Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+                 *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
+                 */
                 imdbid?: components["parameters"]["TorznabImdbId"];
                 /** @description Alias for `imdbid` */
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
@@ -1699,7 +1758,10 @@ export interface operations {
                 title?: components["parameters"]["TorznabTitle"];
                 /** @description Original title (JacRed / Lampa card search) */
                 title_original?: components["parameters"]["TorznabTitleOriginal"];
-                /** @description Release year filter / card-search override */
+                /**
+                 * @description Release year filter / card-search override.
+                 *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+                 */
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];
@@ -1907,7 +1969,12 @@ export interface operations {
                  *     Also accepted as `cat`, `Category`, `Category[]`, `Category[n]`.
                  */
                 categories?: components["parameters"]["Categories"];
-                /** @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted */
+                /**
+                 * @description IMDb id (`tt…` or bare digits); aliases `imdb_id`, `imdbId` also accepted.
+                 *     Resolved via Alloha TV API v2 to titles before FileDB search.
+                 *     Kinopoisk ids are accepted on `q`/`query` as `kp…`; TMDB as `tmdb…` or a themoviedb.org
+                 *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
+                 */
                 imdbid?: components["parameters"]["TorznabImdbId"];
                 /** @description Alias for `imdbid` */
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
@@ -1927,7 +1994,10 @@ export interface operations {
                 title?: components["parameters"]["TorznabTitle"];
                 /** @description Original title (JacRed / Lampa card search) */
                 title_original?: components["parameters"]["TorznabTitleOriginal"];
-                /** @description Release year filter / card-search override */
+                /**
+                 * @description Release year filter / card-search override.
+                 *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+                 */
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];
@@ -2054,7 +2124,10 @@ export interface operations {
                 title?: components["parameters"]["TorznabTitle"];
                 /** @description Original title (JacRed / Lampa card search) */
                 title_original?: components["parameters"]["TorznabTitleOriginal"];
-                /** @description Release year filter / card-search override */
+                /**
+                 * @description Release year filter / card-search override.
+                 *     When omitted on an IMDb/KP/TMDB id query and `alloha.filterByYear` is enabled, Alloha year ±1 is applied.
+                 */
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];


### PR DESCRIPTION
- Added AllohaTitleResolver to resolve KP/IMDB IDs to titles for FileDB search.
- Updated TorrentQueryService and IndexerSearchEngine to utilize Alloha API for improved search accuracy.
- Introduced AllohaSettings for configuration, including base URL, token, timeout, and caching options.
- Enhanced documentation to include Alloha API integration details and configuration examples.