### PR TITLE
feat(ai): add JacRed tracker parser cursor agent

### DIFF
--- a/.cursor/agents/jacred-tracker-parser.md
+++ b/.cursor/agents/jacred-tracker-parser.md
@@ -1,0 +1,46 @@
+---
+name: jacred-tracker-parser
+description: >-
+  JacRed tracker specialist for analyzing torrent/anime sites and implementing
+  parsers across the full catalog (Rutracker, Rutor, Kinozal, Knaben, Anistar,
+  Anibelka, Korsars, Ultradox, Anifilm, Leproduction, Viruseproject, Lostfilm,
+  RuDub, SubsPlease, and the rest). Use proactively when adding or debugging a
+  tracker, probing a site/API, choosing auth/magnet policy, quality gates,
+  Batch packs, FlareSolverr, crontab, fixtures, or dry-run scripts.
+---
+
+You are the JacRed tracker-parser specialist for this repository (`jacred`).
+
+**Follow the project skill first:** read and obey
+[`.cursor/skills/jacred-tracker-parser/SKILL.md`](../skills/jacred-tracker-parser/SKILL.md).
+For the full slug/auth/magnet catalog, read
+[`.cursor/skills/jacred-tracker-parser/reference.md`](../skills/jacred-tracker-parser/reference.md).
+
+Turn a real tracker into a maintainable integration: site analysis → auth /
+quality / magnet policy → Parser + SyncService + cron → wiring → fixtures /
+dry-run / tests → docs + crontab. Prefer cloning the closest existing slug
+cluster over inventing new shapes.
+
+## When invoked
+
+1. Identify site URL, proposed slug, goals (quality filter, Batch, auth, CF).
+2. Probe the live site (+ Jackett def if any) before coding.
+3. Pick the closest JacRed pattern from the skill reference catalog.
+4. Plan briefly, then implement end-to-end (no half-wired trackers).
+5. Add fixtures + `scripts/dry_run_{slug}_parser.py` when HTML/API is scrapeable; run tests.
+6. Update docs auth/cron tables and OpenAPI `TrackerSlug` + `npm run gen:api`.
+
+## Core constraints (always)
+
+- Runtime config is **CWD** `init.yaml` / `init.conf`, not `Data/init.yaml` (template).
+- Never commit live cookies/passwords; empty packaged init; placeholders in example only.
+- Do not edit the user’s `.cursor/plans/*.plan.md` unless asked.
+- Successor sites get a **new slug** (do not retarget predecessors).
+- Icon from **that** site’s favicon; FDB URLs must be unique per release; prefer site JSON APIs when present.
+- Critical auth/magnet: Anibelka anon-only; Rutracker Flare ≠ Anistar cookie; Ultradox Referer; RuDub/Mazepa `MagnetNoTrackers`.
+
+## Output
+
+State slug, auth, sync cluster, magnet policy, quality gate, cron endpoints.
+After implement: dry-run + `dotnet test --filter FullyQualifiedName~{Name}`; report pass counts.
+Match existing SyncService/Parser style (`TrackerSyncHelpers`, `ParserLog`, `FileDB.AddOrUpdate`).

--- a/.cursor/skills/jacred-tracker-parser/SKILL.md
+++ b/.cursor/skills/jacred-tracker-parser/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: jacred-tracker-parser
+description: >-
+  Adds and debugs JacRed torrent/anime tracker parsers (site probe, auth, magnet
+  policy, SyncService, cron, fixtures, dry-run, OpenAPI wiring). Use when adding
+  a tracker, scraping a listing/API, quality gates (1080-only), Batch packs,
+  FlareSolverr, crontab, or when the user mentions tracker slug, ParseShows,
+  limit_page, MagnetNoTrackers, or Jackett defs.
+---
+
+# JacRed tracker parser
+
+Project playbook for integrating a real tracker into JacRed. Pair with the
+specialist subagent [`.cursor/agents/jacred-tracker-parser.md`](../../agents/jacred-tracker-parser.md).
+Full slug catalog: [reference.md](reference.md).
+
+## Workflow
+
+Copy and track:
+
+```
+Tracker Progress:
+- [ ] 1. Probe site (encoding, auth, API vs HTML, pagination, download path)
+- [ ] 2. Choose sync cluster + magnet/auth policy (see reference.md)
+- [ ] 3. Implement Parser + SyncService + Controller
+- [ ] 4. Wire DI/config/schema/FileDB/crontab/OpenAPI/docs/icon
+- [ ] 5. Fixtures + dry_run_{slug}_parser.py + fixture tests
+- [ ] 6. Run dry-run + dotnet test --filter FullyQualifiedName~{Name}
+```
+
+Do not ship half-wired trackers. Do not edit the user’s `.cursor/plans/*.plan.md`
+unless asked.
+
+## Site probe (before code)
+
+1. Fetch listing/home + one detail/show page (and site JS if downloads are AJAX).
+2. Check Jackett def if any; **verify live** (paths drift).
+3. Record: encoding, auth, magnet vs `.torrent`, quality ladder, pagination, host mirrors.
+4. Passkey risk? Prefer `BencodeTo.MagnetNoTrackers`.
+5. Multi-torrent page? Stable unique FDB `url` (`?ep=` / `?id=` / `#quality`).
+
+Prefer official JSON when the site’s own JS uses it (SubsPlease/Knaben/Bitru/Aniliberty).
+
+## Sync cluster (pick closest clone)
+
+| Cluster | Clone from | Cron shape |
+|---------|------------|------------|
+| Rutor trio (+ ParseLatest) | rutor, korsars, anibelka, ultradox, rutracker | Hourly parse + daily tasks |
+| Page-range / `limit_page` | baibako, rudub, anidub, anistar, leproduction | `parseFrom`/`parseTo` or `limit_page` |
+| API latest + backfill | knaben, bitru, subsplease | Hourly latest + checkpointed crawl |
+| Special | lostfilm, mazepa | Dedicated endpoints |
+
+Details per slug: [reference.md](reference.md).
+
+## File set
+
+| Piece | Path |
+|-------|------|
+| Parser / Sync / Categories | `Infrastructure/Trackers/{Name}/` |
+| Cron | `Controllers/Cron/{Name}Controller.cs` → `/cron/{slug}/…` |
+| Details (optional) | `Models/Details/{Name}Details.cs` |
+| Icon | `web/public/img/ico/{slug}.ico` (that site’s favicon) |
+| Fixtures / tests | `tests/JacRed.Tests/Fixtures/{Name}/`, `{Name}ParserFixtureTests.cs` |
+| Dry-run | `scripts/dry_run_{slug}_parser.py` |
+
+### Wiring checklist
+
+- `AppOptions`, `ConfigSchema` (slugs + block names), `AppConfigurationProvider` log case
+- `TrackerServiceCollectionExtensions` DI
+- `FileDB.UrlParsing` when URL id is non-obvious
+- `Data/example.yaml|conf`, `Data/init.yaml|conf` (`synctrackers` + block; **no secrets**)
+- `Data/crontab` via `run-job.sh` (stagger minutes; raise `max_time` for long crawls)
+- `web/public/openapi.yaml` `TrackerSlug` → `cd web && npm run gen:api`
+- Docs: `docs/trackers-and-parsing.md`, `docs/configuration.md` (auth), `docs/api.md` (cron), README count
+
+**Runtime config:** binary loads `./init.yaml` from **CWD**, not `Data/init.yaml` (template only).
+
+## Magnet / auth rules (critical)
+
+- **Anibelka:** anonymous only — never cookie/login (passkeys).
+- **Rutracker:** FlareSolverr Warmup; Anistar does **not** use that path (static CF cookie).
+- **Ultradox:** google/yandex-like Referer or 503; magnets on detail pages.
+- **RuDub / Mazepa:** `MagnetNoTrackers` when auth announce has passkey.
+- **Successor sites:** new slug (e.g. `rudub`); never retarget predecessor (`baibako`).
+
+## Quality / Batch
+
+- Gate only when requested (rudub 1080/2160, lostfilm 1080/2160, subsplease `res==1080`).
+- Batch/season packs via catalog/show crawl, not only latest window; mark `[Batch]`.
+- JSON APIs: keep max useful fields + rich checkpoint even when filtering resolution.
+
+## Verify
+
+```bash
+python3 scripts/dry_run_{slug}_parser.py
+dotnet test tests/JacRed.Tests/JacRed.Tests.csproj --filter FullyQualifiedName~{Name}
+```
+
+Report: slug, auth, sync cluster, magnet policy, quality gate, cron endpoints, test counts.
+
+## Anti-patterns
+
+- Half-wired tracker (missing OpenAPI / synctrackers / crontab / docs)
+- Copied sibling `.ico`
+- HTML scrape when a stable JSON API exists
+- Colliding FDB URLs on multi-episode pages
+- Committing live cookies/passwords
+- Assuming `Data/init.yaml` is what the running process loads
+
+## Related
+
+- Subagent: [`.cursor/agents/jacred-tracker-parser.md`](../../agents/jacred-tracker-parser.md)
+- Catalog: [reference.md](reference.md)
+- Rutracker CF: `Infrastructure/Trackers/Rutracker/README.md`
+- Ops docs: `docs/trackers-and-parsing.md`, `docs/configuration.md`, `docs/api.md`

--- a/.cursor/skills/jacred-tracker-parser/reference.md
+++ b/.cursor/skills/jacred-tracker-parser/reference.md
@@ -1,0 +1,79 @@
+# JacRed tracker catalog (reference)
+
+Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for workflow.
+
+## Sync clusters
+
+| Pattern | Slugs | Notes |
+|---------|-------|-------|
+| Rutor trio (+ ParseLatest) | rutor, kinozal, nnmclub, megapeer, toloka, torrentby, rutracker, anibelka, korsars, ultradox | Tasks → `Data/temp/{slug}_taskParse.json` |
+| Page-range | baibako (0-based), anidub, animelayer, aniliberty, selezen, rudub (+ `limit_page`) | rudub cap ~100 pages |
+| `limit_page` cats | anistar, leproduction, viruseproject; anifilm (`fullparse`) | Page-only; rarely in background-jobs |
+| API latest + backfill | knaben, bitru, subsplease | Checkpoints under `Data/temp/` |
+| Special | mazepa (all forums), lostfilm (`/new/` + season packs) | |
+
+## Auth
+
+| Auth | Slugs | Gotcha |
+|------|-------|--------|
+| CF + FlareSolverr | rutracker | Warmup ~5m before parse; not for Anistar |
+| Static CF/session cookie | anistar | Manual/`cf_clearance` export |
+| Login and/or cookie | kinozal, baibako, rudub, animelayer, anifilm, korsars (`bb_data`), selezen, toloka, mazepa, lostfilm | Prefer config cookie when set |
+| Anon only | anibelka | Never login — passkeys in torrents |
+| Anon + Referer trick | ultradox | google/yandex Referer; own origin → 503 |
+| Public anon API/HTML | knaben, bitru, aniliberty, subsplease, leproduction, viruseproject, rutor, nnmclub, torrentby, anidub | |
+
+**cp1251:** kinozal, nnmclub, megapeer, baibako, rudub, anistar.
+
+## Magnet policy
+
+| Policy | Slugs |
+|--------|-------|
+| `MagnetNoTrackers` | rudub, mazepa |
+| t→M anon (full Magnet OK) | anibelka |
+| t→M after login | baibako, animelayer, anistar, anifilm, toloka, lostfilm, megapeer, viruseproject, bitru, knaben fallback |
+| Magnet HTML/API | rutor, nnmclub, torrentby, rutracker, korsars, selezen, anidub, aniliberty, leproduction, ultradox (detail), kinozal (hash→magnet), subsplease (`xl=`) |
+
+## Per-slug one-liners
+
+- **rutracker** — CF Flare · trio · magnet · warmup + `alias`
+- **rutor** — anon · trio · magnet list · classic template
+- **kinozal** — login/cookie · trio · hash→magnet · cp1251, domain churn
+- **nnmclub** — anon (+onion alias) · trio · magnet · cp1251
+- **megapeer** — anon · trio · t→M · cp1251 + cat Referer
+- **bitru** — anon API · parse+backfill · t→M · cursor files
+- **toloka** — login · trio · t→M
+- **mazepa** — login · full crawl · NoTrk
+- **torrentby** — anon · trio · magnet
+- **selezen** — login/cookie · page-range · magnet · WAF-minimal headers
+- **lostfilm** — cookie · /new/ + packs · t→M · 1080/2160, `#quality`
+- **baibako** — login/cookie · page-range 0-based · t→M · do not retarget for RuDub
+- **rudub** — login/cookie · `limit_page` · NoTrk · 1080/2160, cp1251, mirrors
+- **animelayer** — login/cookie · page-range · t→M · re-login on empty
+- **anidub** — anon · page-range 1-based · magnet prefer
+- **anistar** — static CF cookie · `limit_page` cats · t→M · no JacRed Flare
+- **anibelka** — anon only · trio · t→M
+- **aniliberty** — anon · JSON torrents API · magnet
+- **anifilm** — login/CSRF or cookie · cats + `fullparse` · t→M · prefer 1080
+- **leproduction** — anon · `limit_page` cats · magnet
+- **viruseproject** — anon · `limit_page` cats · t→M
+- **korsars** — login or `bb_data` · trio · magnet · `rqHost`/`alias`
+- **ultradox** — Referer trick · trio · magnet on detail
+- **knaben** — anon API · parse+backfill+status · `knaben_backfill.json`, window ≤10000
+- **subsplease** — anon API · parse+ParseShows(limit=50)+status · 1080 + Batch via `f=show`; `subsplease_shows.json`
+
+## Dry-run scripts
+
+Present: `anibelka`, `anifilm`, `anistar`, `bitru_api`, `kinozal`, `korsars`, `leproduction`, `lostfilm`, `nnmclub`, `rudub`, `rutor`, `rutracker`, `subsplease`, `torrentby`, `ultradox`, `viruseproject`.
+
+Often missing: anidub, aniliberty, animelayer, baibako, knaben, mazepa, megapeer, selezen, toloka.
+
+## Crontab
+
+- Source of truth: `Data/crontab` + `Data/run-job.sh`
+- Avoid stacking on rutor `1,16,31,46` and ultradox `13,28,43,58`
+- CF warmup before rutracker; long crawls → `max_time` 900–1800s
+
+## Docs touch list
+
+`docs/trackers-and-parsing.md`, `docs/configuration.md` (auth), `docs/api.md` (cron + OpenAPI version), `docs/troubleshooting.md`, `docs/docker.md`, README tracker count.


### PR DESCRIPTION
- Introduced the JacRed tracker parser agent with detailed instructions for integrating and debugging torrent/anime site parsers.
- Added a comprehensive reference catalog for JacRed trackers, outlining sync clusters, authentication methods, magnet policies, and dry-run scripts.
- Created a skill document to guide users through the workflow of adding and managing JacRed trackers, ensuring best practices are followed.