### PR TITLE
fix(search): treat status:healthy as aggregate indexer

### DIFF
--- a/Infrastructure/Indexers/TrackerNameMatching.cs
+++ b/Infrastructure/Indexers/TrackerNameMatching.cs
@@ -62,8 +62,9 @@ namespace JacRed.Infrastructure.Indexers
         }
 
         /// <summary>
-        /// When route <c>{indexer}</c> / <c>{status}</c> is a specific tracker (not empty/"all"/numeric Prowlarr id),
-        /// ensure it is included in the request tracker filter.
+        /// When route <c>{indexer}</c> / <c>{status}</c> is a specific tracker (not empty/"all"/
+        /// Jackett's virtual "status:healthy" selector/numeric Prowlarr id), ensure it is included
+        /// in the request tracker filter.
         /// </summary>
         public static void ApplyIndexerPathFilter(IndexerSearchRequest req, string indexer)
         {
@@ -84,6 +85,7 @@ namespace JacRed.Infrastructure.Indexers
 
         public static bool IsAllIndexer(string indexer) =>
             string.IsNullOrWhiteSpace(indexer) ||
-            indexer.Equals("all", StringComparison.OrdinalIgnoreCase);
+            indexer.Equals("all", StringComparison.OrdinalIgnoreCase) ||
+            indexer.Equals("status:healthy", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/JacRed.Tests/Indexers/TrackerNameMatchingTests.cs
+++ b/tests/JacRed.Tests/Indexers/TrackerNameMatchingTests.cs
@@ -67,6 +67,17 @@ public class TrackerNameMatchingTests
     }
 
     [Fact]
+    public void ApplyIndexerPathFilter_IgnoresHealthyStatus()
+    {
+        var req = new IndexerSearchRequest();
+
+        TrackerNameMatching.ApplyIndexerPathFilter(req, "status:healthy");
+
+        Assert.True(req.Trackers == null || req.Trackers.Count == 0);
+        Assert.Null(req.Tracker);
+    }
+
+    [Fact]
     public void FilterByTrackers_UsesSharedMatcher()
     {
         var items = new List<Result>


### PR DESCRIPTION
## Summary
- treat Jackett's virtual `status:healthy` indexer selector as an aggregate search
- prevent `status:healthy` from being added as a tracker-name filter
- add a regression test for the Lampa "only available trackers" request path

## Problem
Lampa sends `/api/v2.0/indexers/status:healthy/results` when "only available trackers" is enabled. JacRed searches its local database rather than querying live indexer health, so interpreting `status:healthy` as a tracker slug filters out every result.

## Test plan
- [x] regression test fails before the implementation change
- [x] targeted regression test passes after the change
- [x] full test suite passes (`581` tests)
- [x] deployed behavior verified against JacRed 3.6.3: `status:healthy` and `all` returned the same 101-result set
