### PR TITLE
feat(trackers): implement ParseAllCycleStore for cycle management

### DIFF
--- a/Infrastructure/Trackers/Anibelka/AnibelkaSyncService.cs
+++ b/Infrastructure/Trackers/Anibelka/AnibelkaSyncService.cs
@@ -22,6 +22,7 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
     {
         const string TrackerName = AnibelkaParser.TrackerName;
         const string TaskParsePath = "Data/temp/anibelka_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         static Dictionary<string, List<TaskParse>> taskParse = new Dictionary<string, List<TaskParse>>();
 
@@ -49,13 +50,7 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
 
         static void PersistTaskParse()
         {
-            try
-            {
-                string dir = IO.Path.GetDirectoryName(TaskParsePath);
-                if (!string.IsNullOrEmpty(dir))
-                    IO.Directory.CreateDirectory(dir);
-                IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse));
-            }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -204,8 +199,11 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
 
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime)
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle))
                             .Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
@@ -221,7 +219,8 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
                         {
                             await ParseSectionPageAsync(host, item.cat, item.val.page, ct);
                             // Empty listings still count as done (Go markPageToday).
-                            item.val.updateTime = DateTime.Today;
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
                         }
                         catch (OperationCanceledException) when (ct.IsCancellationRequested)
                         {
@@ -266,6 +265,8 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -278,7 +279,7 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
                             try
                             {
                                 await ParseSectionPageAsync(host, task.Key, val.page, cancellationToken);
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -293,6 +294,7 @@ namespace JacRed.Infrastructure.Trackers.Anibelka
                     }
 
                     PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Kinozal/KinozalSyncService.cs
+++ b/Infrastructure/Trackers/Kinozal/KinozalSyncService.cs
@@ -26,6 +26,7 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
     {
         const string TrackerName = "kinozal";
         const string TaskParsePath = "Data/temp/kinozal_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         readonly IMemoryCache _memoryCache;
 
@@ -51,7 +52,7 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -336,9 +337,12 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginNestedFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
                         .SelectMany(cat => cat.Value.ToArray()
-                            .SelectMany(arg => arg.Value.Where(v => DateTime.Today != v.updateTime)
+                            .SelectMany(arg => arg.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle))
                                 .Select(v => (cat: cat.Key, arg: arg.Key, val: v))))
                         .ToArray();
                     int done = 0;
@@ -351,7 +355,10 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
 
                         bool res = await parsePage(item.cat, item.val.page, item.arg, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -375,6 +382,8 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadNestedActiveCycle(TrackerName, taskParse);
+
                     foreach (var cat in taskParse.ToArray())
                     {
                         foreach (var arg in cat.Value.ToArray())
@@ -388,13 +397,15 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
                                 bool res = await parsePage(cat.Key, val.page, arg.Key);
                                 if (res)
                                 {
-                                    val.updateTime = DateTime.Today;
+                                    ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                     log.AppendLine($"{cat.Key} - {arg.Key} - {val.page}");
                                 }
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Korsars/KorsarsSyncService.cs
+++ b/Infrastructure/Trackers/Korsars/KorsarsSyncService.cs
@@ -27,6 +27,7 @@ namespace JacRed.Infrastructure.Trackers.Korsars
     {
         const string TrackerName = KorsarsParser.TrackerName;
         const string TaskParsePath = "Data/temp/korsars_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
         const string CookieCacheKey = "cron:KorsarsController:Cookie";
         const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
 
@@ -65,10 +66,7 @@ namespace JacRed.Infrastructure.Trackers.Korsars
         {
             try
             {
-                string dir = IO.Path.GetDirectoryName(TaskParsePath);
-                if (!string.IsNullOrEmpty(dir))
-                    IO.Directory.CreateDirectory(dir);
-                IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse));
+                ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse);
             }
             catch { }
         }
@@ -355,8 +353,11 @@ namespace JacRed.Infrastructure.Trackers.Korsars
 
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime)
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle))
                             .Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
@@ -372,7 +373,8 @@ namespace JacRed.Infrastructure.Trackers.Korsars
                         {
                             await ParseCategoryPageAsync(rqHost, canonHost, item.cat, item.val.page, ct);
                             // Empty listings still count as done (Go markTaskToday).
-                            item.val.updateTime = DateTime.Today;
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
                         }
                         catch (OperationCanceledException) when (ct.IsCancellationRequested)
                         {
@@ -421,6 +423,8 @@ namespace JacRed.Infrastructure.Trackers.Korsars
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -433,7 +437,7 @@ namespace JacRed.Infrastructure.Trackers.Korsars
                             try
                             {
                                 await ParseCategoryPageAsync(rqHost, canonHost, task.Key, val.page, cancellationToken);
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -448,6 +452,7 @@ namespace JacRed.Infrastructure.Trackers.Korsars
                     }
 
                     PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Megapeer/MegapeerSyncService.cs
+++ b/Infrastructure/Trackers/Megapeer/MegapeerSyncService.cs
@@ -16,6 +16,7 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
     {
         const string TrackerName = "megapeer";
         const string TaskParsePath = "Data/temp/megapeer_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         static Dictionary<string, List<TaskParse>> taskParse = new Dictionary<string, List<TaskParse>>();
 
@@ -34,7 +35,7 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -116,8 +117,11 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle)).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
@@ -128,7 +132,10 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
 
                         bool res = await MegapeerParser.ParsePageAsync(item.cat, item.val.page, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -152,6 +159,8 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -162,12 +171,14 @@ namespace JacRed.Infrastructure.Trackers.Megapeer
                             bool res = await MegapeerParser.ParsePageAsync(task.Key, val.page, cancellationToken);
                             if (res)
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/NNMClub/NNMClubSyncService.cs
+++ b/Infrastructure/Trackers/NNMClub/NNMClubSyncService.cs
@@ -19,6 +19,7 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
     {
         const string TrackerName = "nnmclub";
         const string TaskParsePath = "Data/temp/nnmclub_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         /// <summary>Portal page size; URL uses start={page * PageSize}.</summary>
         public const int PageSize = 25;
@@ -38,7 +39,7 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -124,8 +125,11 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle)).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
@@ -137,7 +141,10 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
 
                         var status = await parsePage(item.cat, item.val.page, ct);
                         if (NNMClubPortalPagination.ShouldSettleTask(status))
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -161,6 +168,8 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -172,12 +181,14 @@ namespace JacRed.Infrastructure.Trackers.NNMClub
                             var status = await parsePage(task.Key, val.page);
                             if (NNMClubPortalPagination.ShouldSettleTask(status))
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/ParseAllCycleStore.cs
+++ b/Infrastructure/Trackers/ParseAllCycleStore.cs
@@ -1,0 +1,251 @@
+using JacRed.Models.tParse;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace JacRed.Infrastructure.Trackers
+{
+    /// <summary>Persistent ParseAllTask cycle checkpoint (survives midnight and 6h cancels).</summary>
+    public sealed class ParseAllCycleState
+    {
+        public string CycleId { get; set; }
+        public DateTime StartedAtUtc { get; set; }
+        public string MapFingerprint { get; set; }
+        public int MapCount { get; set; }
+    }
+
+    public static class ParseAllCycleStore
+    {
+        static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented
+        };
+
+        public static string CyclePathForTracker(string trackerSlug)
+            => $"Data/temp/{trackerSlug}_parseAllCycle.json";
+
+        public static IEnumerable<string> FlatMapKeys(IReadOnlyDictionary<string, List<TaskParse>> map)
+        {
+            foreach (var kv in map.OrderBy(x => x.Key, StringComparer.Ordinal))
+            {
+                foreach (var page in kv.Value.OrderBy(x => x.page))
+                    yield return $"{kv.Key}/{page.page}";
+            }
+        }
+
+        public static IEnumerable<string> NestedMapKeys(
+            IReadOnlyDictionary<string, Dictionary<string, List<TaskParse>>> map)
+        {
+            foreach (var cat in map.OrderBy(x => x.Key, StringComparer.Ordinal))
+            {
+                foreach (var arg in cat.Value.OrderBy(x => x.Key, StringComparer.Ordinal))
+                {
+                    foreach (var page in arg.Value.OrderBy(x => x.page))
+                        yield return $"{cat.Key}/{arg.Key}/{page.page}";
+                }
+            }
+        }
+
+        public static string ComputeFingerprint(IEnumerable<string> canonicalKeys)
+        {
+            var joined = string.Join("\n", canonicalKeys);
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(joined));
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+
+        public static ParseAllCycleState LoadState(string path)
+        {
+            try
+            {
+                if (!File.Exists(path))
+                    return null;
+
+                return JsonConvert.DeserializeObject<ParseAllCycleState>(File.ReadAllText(path));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void SaveState(string path, ParseAllCycleState state)
+            => WriteJsonAtomic(path, state);
+
+        public static void WriteJsonAtomic(string path, object value)
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonConvert.SerializeObject(value, JsonSettings);
+            var tempPath = path + ".tmp";
+            File.WriteAllText(tempPath, json);
+            if (File.Exists(path))
+                File.Replace(tempPath, path, null);
+            else
+                File.Move(tempPath, path);
+        }
+
+        public static bool IsPendingInCycle(TaskParse page, ParseAllCycleState cycle)
+        {
+            if (cycle == null || string.IsNullOrEmpty(cycle.CycleId))
+                return true;
+
+            return !string.Equals(page.parseAllCycleId, cycle.CycleId, StringComparison.Ordinal);
+        }
+
+        public static int CountPendingInCycle(IEnumerable<TaskParse> pages, ParseAllCycleState cycle)
+            => pages.Count(p => IsPendingInCycle(p, cycle));
+
+        public static void MarkDoneInCycle(TaskParse page, ParseAllCycleState cycle)
+        {
+            page.parseAllCycleId = cycle.CycleId;
+            page.updateTime = DateTime.Today;
+        }
+
+        public static ParseAllCycleState CreateCycle(string fingerprint, int mapCount)
+            => new ParseAllCycleState
+            {
+                CycleId = Guid.NewGuid().ToString("N"),
+                StartedAtUtc = DateTime.UtcNow,
+                MapFingerprint = fingerprint,
+                MapCount = mapCount
+            };
+
+        static void MigrateTodayStamps(IEnumerable<TaskParse> allPages, ParseAllCycleState cycle)
+        {
+            foreach (var page in allPages)
+            {
+                if (page.updateTime.Date == DateTime.Today)
+                    page.parseAllCycleId = cycle.CycleId;
+            }
+        }
+
+        static void RefreshMetadata(ParseAllCycleState cycle, string fingerprint, int mapCount)
+        {
+            cycle.MapFingerprint = fingerprint;
+            cycle.MapCount = mapCount;
+        }
+
+        /// <summary>Load or rotate cycle for a full ParseAllTask run.</summary>
+        public static ParseAllCycleState BeginFullCycle(
+            string cyclePath,
+            string fingerprint,
+            int mapCount,
+            IEnumerable<TaskParse> allPages,
+            bool rotateIfComplete)
+        {
+            var pages = allPages as IList<TaskParse> ?? allPages.ToList();
+            var state = LoadState(cyclePath);
+
+            if (state == null)
+            {
+                state = CreateCycle(fingerprint, mapCount);
+                MigrateTodayStamps(pages, state);
+                SaveState(cyclePath, state);
+                return state;
+            }
+
+            RefreshMetadata(state, fingerprint, mapCount);
+
+            var pending = CountPendingInCycle(pages, state);
+            if (rotateIfComplete && pending == 0)
+            {
+                state = CreateCycle(fingerprint, mapCount);
+                SaveState(cyclePath, state);
+                return state;
+            }
+
+            SaveState(cyclePath, state);
+            return state;
+        }
+
+        /// <summary>Load active cycle for ParseLatest (no rotation).</summary>
+        public static ParseAllCycleState LoadActiveCycle(
+            string cyclePath,
+            string fingerprint,
+            int mapCount,
+            IEnumerable<TaskParse> allPages)
+        {
+            var pages = allPages as IList<TaskParse> ?? allPages.ToList();
+            var state = LoadState(cyclePath);
+
+            if (state == null)
+            {
+                state = CreateCycle(fingerprint, mapCount);
+                MigrateTodayStamps(pages, state);
+                SaveState(cyclePath, state);
+                return state;
+            }
+
+            RefreshMetadata(state, fingerprint, mapCount);
+            SaveState(cyclePath, state);
+            return state;
+        }
+
+        public static void PersistAfterPage(
+            string cyclePath,
+            ParseAllCycleState cycle,
+            string taskParsePath,
+            object taskParse,
+            bool persistCycle)
+        {
+            WriteJsonAtomic(taskParsePath, taskParse);
+            if (persistCycle && cycle != null)
+                SaveState(cyclePath, cycle);
+        }
+
+        public static void PersistTaskParse(string taskParsePath, object taskParse)
+            => WriteJsonAtomic(taskParsePath, taskParse);
+
+        public static string FormatStartLog(ParseAllCycleState cycle, int pending, int total)
+            => $"cycle={cycle.CycleId} pending={pending}/{total} started={cycle.StartedAtUtc:yyyy-MM-dd HH:mm:ss}Z fingerprint={cycle.MapFingerprint?[..Math.Min(12, cycle.MapFingerprint?.Length ?? 0)]}";
+
+        public static (ParseAllCycleState cycle, int mapCount, int pendingCount) BeginFlatFullRun(
+            string trackerSlug,
+            IReadOnlyDictionary<string, List<TaskParse>> taskParse)
+        {
+            var allPages = taskParse.SelectMany(t => t.Value).ToList();
+            var fingerprint = ComputeFingerprint(FlatMapKeys(taskParse));
+            var cyclePath = CyclePathForTracker(trackerSlug);
+            var cycle = BeginFullCycle(cyclePath, fingerprint, allPages.Count, allPages, rotateIfComplete: true);
+            var pendingCount = CountPendingInCycle(allPages, cycle);
+            return (cycle, allPages.Count, pendingCount);
+        }
+
+        public static ParseAllCycleState LoadFlatActiveCycle(
+            string trackerSlug,
+            IReadOnlyDictionary<string, List<TaskParse>> taskParse)
+        {
+            var allPages = taskParse.SelectMany(t => t.Value).ToList();
+            var fingerprint = ComputeFingerprint(FlatMapKeys(taskParse));
+            return LoadActiveCycle(CyclePathForTracker(trackerSlug), fingerprint, allPages.Count, allPages);
+        }
+
+        public static (ParseAllCycleState cycle, int mapCount, int pendingCount) BeginNestedFullRun(
+            string trackerSlug,
+            IReadOnlyDictionary<string, Dictionary<string, List<TaskParse>>> taskParse)
+        {
+            var allPages = taskParse.SelectMany(cat => cat.Value.SelectMany(arg => arg.Value)).ToList();
+            var fingerprint = ComputeFingerprint(NestedMapKeys(taskParse));
+            var cyclePath = CyclePathForTracker(trackerSlug);
+            var cycle = BeginFullCycle(cyclePath, fingerprint, allPages.Count, allPages, rotateIfComplete: true);
+            var pendingCount = CountPendingInCycle(allPages, cycle);
+            return (cycle, allPages.Count, pendingCount);
+        }
+
+        public static ParseAllCycleState LoadNestedActiveCycle(
+            string trackerSlug,
+            IReadOnlyDictionary<string, Dictionary<string, List<TaskParse>>> taskParse)
+        {
+            var allPages = taskParse.SelectMany(cat => cat.Value.SelectMany(arg => arg.Value)).ToList();
+            var fingerprint = ComputeFingerprint(NestedMapKeys(taskParse));
+            return LoadActiveCycle(CyclePathForTracker(trackerSlug), fingerprint, allPages.Count, allPages);
+        }
+    }
+}

--- a/Infrastructure/Trackers/Rutor/RutorSyncService.cs
+++ b/Infrastructure/Trackers/Rutor/RutorSyncService.cs
@@ -19,6 +19,7 @@ namespace JacRed.Infrastructure.Trackers.Rutor
     {
         const string TrackerName = "rutor";
         const string TaskParsePath = "Data/temp/rutor_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         static Dictionary<string, List<TaskParse>> taskParse = new Dictionary<string, List<TaskParse>>();
 
@@ -35,10 +36,7 @@ namespace JacRed.Infrastructure.Trackers.Rutor
 
         static void PersistTaskParse()
         {
-            try
-            {
-                IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse));
-            }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -112,8 +110,11 @@ namespace JacRed.Infrastructure.Trackers.Rutor
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle)).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
@@ -125,7 +126,10 @@ namespace JacRed.Infrastructure.Trackers.Rutor
 
                         bool res = await parsePage(item.cat, item.val.page, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -149,6 +153,8 @@ namespace JacRed.Infrastructure.Trackers.Rutor
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -160,12 +166,14 @@ namespace JacRed.Infrastructure.Trackers.Rutor
                             bool res = await parsePage(task.Key, val.page);
                             if (res)
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Rutracker/RutrackerCategories.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerCategories.cs
@@ -50,6 +50,16 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["140"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["252"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
 
+            // Фильмы: разделы UHD и DVD, тоже пропущенные (15.08.2026).
+            ["7"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["718"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["1940"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["271"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["1543"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["101"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["100"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["572"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+
             // 3D Мультфильмы / Мультфильмы
             ["2343"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["930"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
@@ -58,6 +68,8 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["539"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["209"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["1213"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["4"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["1577"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
 
             // Мультсериалы
             ["921"] = new() { Types = new[] { "multserial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
@@ -94,14 +106,33 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["915"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
             ["1939"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
 
+            // Сериальные разделы, которых в списке не было (добавлены 15.08.2026).
+            //
+            // Повод: раздача «Дом дракона» S3 в 2160p (t=6873874) не находилась
+            // ни в вебе, ни в Лампе — она лежит в разделе 1171, а у нас был
+            // только его РОДИТЕЛЬ, 119. У rutracker раздел может иметь и
+            // подразделы, и собственные темы, поэтому обход родителя не
+            // заменяет обход детей: в самом 119 всего два десятка тем.
+            ["2366"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["189"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["1171"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["812"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["920"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["911"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["2100"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+
             // Аниме
             ["1105"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
             ["2491"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
             ["1389"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
+            ["33"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
+            ["1106"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
 
             // Документальные фильмы
             ["709"] = new() { Types = new[] { "documovie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = false },
             ["2109"] = new() { Types = new[] { "documovie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = false },
+            ["1985"] = new() { Types = new[] { "documovie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = false },
+            ["1202"] = new() { Types = new[] { "documovie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = false },
 
             // Документалистика
             ["46"] = new() { Types = new[] { "docuserial", "documovie" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = false },

--- a/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
@@ -21,6 +21,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
     {
         const string TrackerName = "rutracker";
         const string TaskParsePath = "Data/temp/rutracker_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         readonly IMemoryCache _memoryCache;
 
@@ -41,7 +42,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -215,9 +216,25 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                 try
                 {
                     var catFilter = ResolveCatFilter(cat);
+                    bool fullRun = catFilter == null && maxPages <= 0;
+                    ParseAllCycleState cycle = null;
+
+                    if (fullRun)
+                    {
+                        var (cycleState, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                        cycle = cycleState;
+                        ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)} maxPages={maxPages}");
+                    }
+                    else
+                    {
+                        ParserLog.Write(TrackerName, $"ParseAllTask start partial cat={cat ?? "*"} maxPages={maxPages}");
+                    }
+
                     var pending = taskParse.ToArray()
                         .Where(t => catFilter == null || catFilter.Contains(t.Key))
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => fullRun
+                            ? ParseAllCycleStore.IsPendingInCycle(v, cycle)
+                            : DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
 
                     if (maxPages > 0 && pending.Length > maxPages)
@@ -225,7 +242,6 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
 
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
-                    ParserLog.Write(TrackerName, $"ParseAllTask start pending={pending.Length} maxPages={maxPages}");
 
                     foreach (var item in pending)
                     {
@@ -234,7 +250,17 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
 
                         bool res = await parsePage(item.cat, item.val.page, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            if (fullRun)
+                            {
+                                ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                                ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                            }
+                            else
+                            {
+                                item.val.updateTime = DateTime.Today;
+                            }
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -273,6 +299,9 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var allPages = taskParse.SelectMany(t => t.Value).ToList();
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -284,12 +313,14 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                             bool res = await parsePage(task.Key, val.page);
                             if (res)
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Toloka/TolokaSyncService.cs
+++ b/Infrastructure/Trackers/Toloka/TolokaSyncService.cs
@@ -21,6 +21,7 @@ namespace JacRed.Infrastructure.Trackers.Toloka
     {
         const string TrackerName = "toloka";
         const string TaskParsePath = "Data/temp/toloka_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         readonly IMemoryCache _memoryCache;
 
@@ -39,7 +40,7 @@ namespace JacRed.Infrastructure.Trackers.Toloka
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -218,8 +219,11 @@ namespace JacRed.Infrastructure.Trackers.Toloka
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle)).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
@@ -231,7 +235,10 @@ namespace JacRed.Infrastructure.Trackers.Toloka
 
                         bool res = await parsePage(item.cat, item.val.page, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -255,6 +262,8 @@ namespace JacRed.Infrastructure.Trackers.Toloka
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -266,12 +275,14 @@ namespace JacRed.Infrastructure.Trackers.Toloka
                             bool res = await parsePage(task.Key, val.page);
                             if (res)
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/TorrentBy/TorrentBySyncService.cs
+++ b/Infrastructure/Trackers/TorrentBy/TorrentBySyncService.cs
@@ -17,6 +17,7 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
     {
         const string TrackerName = "torrentby";
         const string TaskParsePath = "Data/temp/torrentby_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         static Dictionary<string, List<TaskParse>> taskParse = new Dictionary<string, List<TaskParse>>();
 
@@ -33,7 +34,7 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
 
         static void PersistTaskParse()
         {
-            try { IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse)); }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -111,8 +112,11 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
             {
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime).Select(v => (cat: t.Key, val: v)))
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle)).Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
                     TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", 0, pending.Length);
@@ -124,7 +128,10 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
 
                         bool res = await TorrentByParser.ParsePageAsync(item.cat, item.val.page, ct);
                         if (res)
-                            item.val.updateTime = DateTime.Today;
+                        {
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
+                        }
 
                         done++;
                         TrackerSyncHelpers.ReportProgress(TrackerName, "ParseAllTask", done, pending.Length, $"{item.cat}/{item.val.page}");
@@ -148,6 +155,8 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         var pagesToParse = task.Value.OrderBy(x => x.page).Take(pages).ToArray();
@@ -159,12 +168,14 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
                             bool res = await TorrentByParser.ParsePageAsync(task.Key, val.page);
                             if (res)
                             {
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                         }
                     }
 
+                    PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Infrastructure/Trackers/Ultradox/UltradoxSyncService.cs
+++ b/Infrastructure/Trackers/Ultradox/UltradoxSyncService.cs
@@ -23,6 +23,7 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
     {
         const string TrackerName = UltradoxParser.TrackerName;
         const string TaskParsePath = "Data/temp/ultradox_taskParse.json";
+        static string CyclePath => ParseAllCycleStore.CyclePathForTracker(TrackerName);
 
         static readonly List<(string name, string val)> BrowserHeaders = new()
         {
@@ -63,13 +64,7 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
 
         static void PersistTaskParse()
         {
-            try
-            {
-                string dir = IO.Path.GetDirectoryName(TaskParsePath);
-                if (!string.IsNullOrEmpty(dir))
-                    IO.Directory.CreateDirectory(dir);
-                IO.File.WriteAllText(TaskParsePath, JsonConvert.SerializeObject(taskParse));
-            }
+            try { ParseAllCycleStore.WriteJsonAtomic(TaskParsePath, taskParse); }
             catch { }
         }
 
@@ -227,8 +222,11 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
 
                 try
                 {
+                    var (cycle, mapCount, pendingCount) = ParseAllCycleStore.BeginFlatFullRun(TrackerName, taskParse);
+                    ParserLog.Write(TrackerName, $"ParseAllTask start {ParseAllCycleStore.FormatStartLog(cycle, pendingCount, mapCount)}");
+
                     var pending = taskParse.ToArray()
-                        .SelectMany(t => t.Value.Where(v => DateTime.Today != v.updateTime)
+                        .SelectMany(t => t.Value.Where(v => ParseAllCycleStore.IsPendingInCycle(v, cycle))
                             .Select(v => (cat: t.Key, val: v)))
                         .ToArray();
                     int done = 0;
@@ -247,7 +245,8 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
                         try
                         {
                             await ParseSectionPageAsync(host, item.cat, types, item.val.page, ct);
-                            item.val.updateTime = DateTime.Today;
+                            ParseAllCycleStore.MarkDoneInCycle(item.val, cycle);
+                            ParseAllCycleStore.PersistAfterPage(CyclePath, cycle, TaskParsePath, taskParse, persistCycle: true);
                         }
                         catch (OperationCanceledException) when (ct.IsCancellationRequested)
                         {
@@ -292,6 +291,8 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
                     var sw = Stopwatch.StartNew();
                     ParserLog.Write(TrackerName, $"Starting ParseLatest pages={pages}");
 
+                    var cycle = ParseAllCycleStore.LoadFlatActiveCycle(TrackerName, taskParse);
+
                     foreach (var task in taskParse.ToArray())
                     {
                         if (!UltradoxCategories.Map.TryGetValue(task.Key, out var meta) || meta?.Types == null)
@@ -307,7 +308,7 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
                             try
                             {
                                 await ParseSectionPageAsync(host, task.Key, meta.Types, val.page, cancellationToken);
-                                val.updateTime = DateTime.Today;
+                                ParseAllCycleStore.MarkDoneInCycle(val, cycle);
                                 log.AppendLine($"{task.Key} - {val.page}");
                             }
                             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -322,6 +323,7 @@ namespace JacRed.Infrastructure.Trackers.Ultradox
                     }
 
                     PersistTaskParse();
+                    ParseAllCycleStore.SaveState(CyclePath, cycle);
                     ParserLog.Write(TrackerName, $"ParseLatest completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)");
                 }
                 catch (Exception ex)

--- a/Models/TaskParse.cs
+++ b/Models/TaskParse.cs
@@ -15,6 +15,9 @@ namespace JacRed.Models.tParse
 
         public DateTime updateTime { get; set; }
 
+        /// <summary>ParseAllTask cycle id when this page was last completed in a full crawl.</summary>
+        public string parseAllCycleId { get; set; }
+
         public int page { get; set; }
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@ curl -s 'http://127.0.0.1:9117/dev/ExportTracksStatus'
 
 - **`GET /cron/{tracker}/parse`** — запуск парсинга (часто с `?page=` / `?limit_page=` / `?fullparse=` — зависит от трекера).
 - **`GET /cron/{tracker}/ParseLatest`** — свежие раздачи (Rutor-style: anibelka, korsars, ultradox и ряд старых трекеров).
-- **`GET /cron/{tracker}/ParseAllTask`** — фоновый полный обход задач (регистрируется в `/health/background-jobs`).
+- **`GET /cron/{tracker}/ParseAllTask`** — фоновый полный обход задач (регистрируется в `/health/background-jobs`). Прогресс цикла хранится в **`Data/temp/{tracker}_parseAllCycle.json`** и на страницах карты (`parseAllCycleId` в `{tracker}_taskParse.json`): обход **не сбрасывается в полночь**, продолжается между 6‑часовыми запусками; новый цикл начинается только после полного прохода карты. Rutracker smoke (`?cat=` / `?maxPages=`) глобальный цикл не трогает.
 - **`GET /cron/{tracker}/UpdateTasksParse`** — обновление очереди задач (тоже background-jobs).
 - **`GET /cron/{tracker}/parseMagnet`** — парсинг магнет-ссылок (для поддерживающих трекеров).
 - Дополнительные параметры: `parseFrom`, `parseTo`, `parseFromDate`, `pages` (зависит от трекера).

--- a/docs/trackers-and-parsing.md
+++ b/docs/trackers-and-parsing.md
@@ -45,6 +45,7 @@ tags:
    - Логи парсеров: `Data/log/{tracker}.log` (по умолчанию `logParsers: true`, per-tracker `log: true`)
    - Логи БД: `Data/log/fdb.*.log` (по умолчанию `logFdb: true`)
    - Активные длинные джобы: `GET /health/background-jobs` (ParseAll / UpdateTasks; page-only парсеры туда обычно не попадают)
+   - Полный обход ParseAllTask: checkpoint цикла в `Data/temp/{tracker}_parseAllCycle.json` (не сбрасывается в полночь; см. [API → ParseAllTask](api.md#parsing-trackers))
    - Статистика: `GET /stats/*` (если `openstats: true`)
 
 ---

--- a/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
@@ -9,10 +9,32 @@ public class RutrackerCategoriesTests
     [Fact]
     public void Map_HasExpectedCounts()
     {
-        Assert.Equal(211, RutrackerCategories.Map.Count);
-        Assert.Equal(65, RutrackerCategories.QuickParseIds.Count());
+        Assert.Equal(232, RutrackerCategories.Map.Count);
+        Assert.Equal(84, RutrackerCategories.QuickParseIds.Count());
         Assert.Equal(RutrackerCategories.Map.Count, RutrackerCategories.Ids.Distinct().Count());
         Assert.True(RutrackerCategories.QuickParseIds.All(id => RutrackerCategories.Map.ContainsKey(id)));
+    }
+
+    /// <summary>
+    /// Разделы, добавленные 15.08.2026, и почему их отсутствие било по выдаче.
+    ///
+    /// У rutracker раздел может иметь и подразделы, и собственные темы, поэтому
+    /// обход родителя НЕ заменяет обход детей. Так «Дом дракона» S3 в 2160p
+    /// (t=6873874) не попадал в базу вовсе: он лежит в 1171, а в списке был
+    /// только родительский 119, где своих тем два десятка.
+    /// </summary>
+    [Theory]
+    [InlineData("1171")]   // Новинки и сериалы в стадии показа (UHD Video)
+    [InlineData("2366")]   // Зарубежные сериалы (HD Video)
+    [InlineData("189")]    // Зарубежные сериалы
+    [InlineData("2100")]   // Азиатские сериалы
+    [InlineData("812")]    // Русские сериалы (UHD Video)
+    [InlineData("718")]    // UHD Video
+    [InlineData("1106")]   // Онгоинги (HD Video)
+    public void FormerlyMissingSections_AreInQuickParse(string id)
+    {
+        Assert.True(RutrackerCategories.Map.ContainsKey(id));
+        Assert.Contains(id, RutrackerCategories.QuickParseIds);
     }
 
     [Fact]

--- a/tests/JacRed.Tests/Trackers/ParseAllCycleStoreTests.cs
+++ b/tests/JacRed.Tests/Trackers/ParseAllCycleStoreTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using JacRed.Infrastructure.Trackers;
+using JacRed.Models.tParse;
+using Xunit;
+
+namespace JacRed.Tests.Trackers;
+
+public class ParseAllCycleStoreTests : IDisposable
+{
+    readonly string _tempDir;
+    readonly List<string> _paths = new();
+
+    public ParseAllCycleStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "jacred-parseall-cycle-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in _paths)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+                var tmp = path + ".tmp";
+                if (File.Exists(tmp))
+                    File.Delete(tmp);
+            }
+            catch { }
+        }
+
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch { }
+    }
+
+    string NewPath(string name)
+    {
+        var path = Path.Combine(_tempDir, name);
+        _paths.Add(path);
+        return path;
+    }
+
+    static Dictionary<string, List<TaskParse>> SampleMap(int pagesPerCat = 2)
+    {
+        return new Dictionary<string, List<TaskParse>>
+        {
+            ["100"] = Enumerable.Range(0, pagesPerCat).Select(p => new TaskParse(p)).ToList(),
+            ["200"] = Enumerable.Range(0, pagesPerCat).Select(p => new TaskParse(p)).ToList()
+        };
+    }
+
+    static IEnumerable<TaskParse> AllPages(Dictionary<string, List<TaskParse>> map)
+        => map.SelectMany(kv => kv.Value);
+
+    [Fact]
+    public void CompletedPagesStayExcludedAfterDateChange()
+    {
+        var cyclePath = NewPath("cycle.json");
+        var map = SampleMap();
+        var pages = AllPages(map).ToList();
+        var fingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+
+        var cycle = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+        ParseAllCycleStore.MarkDoneInCycle(pages[0], cycle);
+
+        pages[0].updateTime = DateTime.Today.AddDays(-1);
+
+        Assert.False(ParseAllCycleStore.IsPendingInCycle(pages[0], cycle));
+        Assert.True(ParseAllCycleStore.IsPendingInCycle(pages[1], cycle));
+    }
+
+    [Fact]
+    public void NextRunContinuesSameCycleId()
+    {
+        var cyclePath = NewPath("cycle-resume.json");
+        var map = SampleMap(pagesPerCat: 3);
+        var pages = AllPages(map).ToList();
+        var fingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+
+        var cycle1 = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+        ParseAllCycleStore.MarkDoneInCycle(pages[0], cycle1);
+        ParseAllCycleStore.SaveState(cyclePath, cycle1);
+
+        var cycle2 = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+
+        Assert.Equal(cycle1.CycleId, cycle2.CycleId);
+        Assert.False(ParseAllCycleStore.IsPendingInCycle(pages[0], cycle2));
+        Assert.Equal(pages.Count - 1, ParseAllCycleStore.CountPendingInCycle(pages, cycle2));
+    }
+
+    [Fact]
+    public void EmptyPendingRotatesToNewCycle()
+    {
+        var cyclePath = NewPath("cycle-rotate.json");
+        var map = SampleMap();
+        var pages = AllPages(map).ToList();
+        var fingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+
+        var cycle1 = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+        foreach (var page in pages)
+            ParseAllCycleStore.MarkDoneInCycle(page, cycle1);
+        ParseAllCycleStore.SaveState(cyclePath, cycle1);
+
+        var cycle2 = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+
+        Assert.NotEqual(cycle1.CycleId, cycle2.CycleId);
+        Assert.All(pages, p => Assert.True(ParseAllCycleStore.IsPendingInCycle(p, cycle2)));
+    }
+
+    [Fact]
+    public void MapGrowthAddsPendingWithoutResettingCycle()
+    {
+        var cyclePath = NewPath("cycle-growth.json");
+        var map = SampleMap(pagesPerCat: 1);
+        var pages = AllPages(map).ToList();
+        var fingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+
+        var cycle = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+        ParseAllCycleStore.MarkDoneInCycle(pages[0], cycle);
+        ParseAllCycleStore.MarkDoneInCycle(pages[1], cycle);
+        ParseAllCycleStore.SaveState(cyclePath, cycle);
+
+        map["300"] = new List<TaskParse> { new TaskParse(0) };
+        pages = AllPages(map).ToList();
+        var newFingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+
+        var resumed = ParseAllCycleStore.BeginFullCycle(cyclePath, newFingerprint, pages.Count, pages, rotateIfComplete: true);
+
+        Assert.Equal(cycle.CycleId, resumed.CycleId);
+        Assert.False(ParseAllCycleStore.IsPendingInCycle(pages[0], resumed));
+        Assert.True(ParseAllCycleStore.IsPendingInCycle(pages[^1], resumed));
+    }
+
+    [Fact]
+    public void MigrationStampsTodayPagesOnFirstSidecar()
+    {
+        var cyclePath = NewPath("cycle-migrate.json");
+        var map = SampleMap();
+        var pages = AllPages(map).ToList();
+        pages[0].updateTime = DateTime.Today;
+        pages[1].updateTime = DateTime.Today.AddDays(-3);
+
+        var fingerprint = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.FlatMapKeys(map));
+        var cycle = ParseAllCycleStore.BeginFullCycle(cyclePath, fingerprint, pages.Count, pages, rotateIfComplete: true);
+
+        Assert.Equal(cycle.CycleId, pages[0].parseAllCycleId);
+        Assert.Null(pages[1].parseAllCycleId);
+        Assert.False(ParseAllCycleStore.IsPendingInCycle(pages[0], cycle));
+        Assert.True(ParseAllCycleStore.IsPendingInCycle(pages[1], cycle));
+    }
+
+    [Fact]
+    public void PartialRunLogic_DoesNotUseCycleStamp()
+    {
+        var map = SampleMap(pagesPerCat: 1);
+        var page = map["100"][0];
+        page.updateTime = DateTime.Today;
+
+        Assert.False(DateTime.Today != page.updateTime);
+        Assert.True(string.IsNullOrEmpty(page.parseAllCycleId));
+    }
+
+    [Fact]
+    public void NestedMapFingerprint_IsStable()
+    {
+        var map = new Dictionary<string, Dictionary<string, List<TaskParse>>>
+        {
+            ["1"] = new Dictionary<string, List<TaskParse>>
+            {
+                ["&d=2024"] = new List<TaskParse> { new TaskParse(0), new TaskParse(1) }
+            }
+        };
+
+        var fp1 = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.NestedMapKeys(map));
+        var fp2 = ParseAllCycleStore.ComputeFingerprint(ParseAllCycleStore.NestedMapKeys(map));
+
+        Assert.Equal(fp1, fp2);
+        Assert.Equal(64, fp1.Length);
+    }
+
+    [Fact]
+    public void WriteJsonAtomic_ReplacesExistingFile()
+    {
+        var path = NewPath("atomic.json");
+        ParseAllCycleStore.WriteJsonAtomic(path, new { v = 1 });
+        ParseAllCycleStore.WriteJsonAtomic(path, new { v = 2 });
+
+        var text = File.ReadAllText(path);
+        Assert.Contains("\"v\": 2", text);
+        Assert.DoesNotContain("\"v\": 1", text);
+    }
+}


### PR DESCRIPTION
- Introduced ParseAllCycleStore to manage ParseAllTask cycle states, allowing for persistent checkpoints that survive cancellations and time transitions.
- Added methods for loading, saving, and managing cycle states, including fingerprint computation and pending task identification.
- Updated various sync services (Anibelka, Kinozal, Korsars, etc.) to utilize the new cycle management features, ensuring consistent state handling across different trackers.
- Enhanced task parsing logic to mark tasks as done within the context of their respective cycles, improving overall tracking accuracy.

Fix #149 