### PR TITLE
feat(bitru): refactor backfill and parsing logic

### DIFF
--- a/Infrastructure/Trackers/Bitru/BitruApiSyncService.cs
+++ b/Infrastructure/Trackers/Bitru/BitruApiSyncService.cs
@@ -68,17 +68,12 @@ namespace JacRed.Infrastructure.Trackers.Bitru
                     int lim = BitruApiPagination.ClampLimit(limit);
                     ParserLog.Write(TrackerName, $"Parse start, limit={lim}, maxPages=1, api={ApiUrl}");
 
-                    var fetch = await FetchTorrentsFromApi(
-                        limit: lim,
-                        olderThanUnix: null,
-                        maxPages: 1,
-                        persistBackfillCursor: false,
-                        cancellationToken);
-
-                    if (fetch.Torrents.Count > 0)
+                    var page = await FetchOnePage(lim, olderThanUnix: null, previousIds: null, cancellationToken);
+                    if (!page.Stop && page.Torrents.Count > 0)
                     {
-                        await SaveTorrentsAndMagnets(fetch.Torrents, cancellationToken);
-                        log = $"saved {fetch.Torrents.Count}";
+                        await SaveTorrentsAndMagnets(page.Torrents, cancellationToken);
+                        WriteLastNewTor(page.Torrents);
+                        log = $"saved {page.Torrents.Count}";
                     }
                     else
                         log = "no items";
@@ -98,6 +93,7 @@ namespace JacRed.Infrastructure.Trackers.Bitru
         /// <summary>
         /// Walk older archive pages. Live API: after_date means older-than (docs label is inverted).
         /// Progress is stored in Data/temp/bitru_backfill_cursor.txt as unix seconds.
+        /// Cursor advances only after a page is saved.
         /// </summary>
         public async Task<string> BackfillAsync(int pages = 20, int limit = 100, CancellationToken cancellationToken = default)
         {
@@ -107,37 +103,13 @@ namespace JacRed.Infrastructure.Trackers.Bitru
 
             return await TrackerSyncHelpers.RunParseAsync(TrackerName, _parseLock, checkDisabled: false, async () =>
             {
-                string log = "";
+                var sw = Stopwatch.StartNew();
+                ParserLog.Write(TrackerName,
+                    $"Backfill start, pages={maxPages}, limit={lim}, cursor={(startCursor.HasValue ? startCursor.Value.ToString(CultureInfo.InvariantCulture) : "none")}, api={ApiUrl}");
 
-                try
-                {
-                    var sw = Stopwatch.StartNew();
-                    ParserLog.Write(TrackerName,
-                        $"Backfill start, pages={maxPages}, limit={lim}, cursor={(startCursor.HasValue ? startCursor.Value.ToString(CultureInfo.InvariantCulture) : "none")}, api={ApiUrl}");
-
-                    var fetch = await FetchTorrentsFromApi(
-                        limit: lim,
-                        olderThanUnix: startCursor,
-                        maxPages: maxPages,
-                        persistBackfillCursor: true,
-                        cancellationToken);
-
-                    if (fetch.Torrents.Count > 0)
-                    {
-                        await SaveTorrentsAndMagnets(fetch.Torrents, cancellationToken);
-                        log = $"saved {fetch.Torrents.Count}, pages={fetch.PagesFetched}, cursor={fetch.LastCursor?.ToString(CultureInfo.InvariantCulture) ?? "none"}";
-                    }
-                    else
-                        log = $"no items, pages={fetch.PagesFetched}, cursor={fetch.LastCursor?.ToString(CultureInfo.InvariantCulture) ?? startCursor?.ToString(CultureInfo.InvariantCulture) ?? "none"}";
-
+                var (log, completed) = await CrawlOlderPagesAsync("Backfill", maxPages, lim, startCursor, cancellationToken);
+                if (completed)
                     ParserLog.Write(TrackerName, $"Backfill completed in {sw.Elapsed.TotalSeconds:F1}s, {log}");
-                }
-                catch (Exception ex)
-                {
-                    ParserLog.Write(TrackerName, $"Error: {ex.Message}");
-                    log = $"error: {ex.Message}";
-                }
-
                 return string.IsNullOrWhiteSpace(log) ? "ok" : log;
             }, cancellationToken);
         }
@@ -160,39 +132,57 @@ namespace JacRed.Infrastructure.Trackers.Bitru
 
             return await TrackerSyncHelpers.RunParseAsync(TrackerName, _parseLock, checkDisabled: false, async () =>
             {
-                string log = "";
+                var sw = Stopwatch.StartNew();
+                ParserLog.Write(TrackerName,
+                    $"ParseFromDate lastnewtor={lastnewtor} (olderThan unix={unixFrom}), pages={maxPages}, limit={lim}");
 
-                try
-                {
-                    var sw = Stopwatch.StartNew();
-                    ParserLog.Write(TrackerName,
-                        $"ParseFromDate lastnewtor={lastnewtor} (olderThan unix={unixFrom}), pages={maxPages}, limit={lim}");
-
-                    var fetch = await FetchTorrentsFromApi(
-                        limit: lim,
-                        olderThanUnix: unixFrom,
-                        maxPages: maxPages,
-                        persistBackfillCursor: true,
-                        cancellationToken);
-
-                    if (fetch.Torrents.Count > 0)
-                    {
-                        await SaveTorrentsAndMagnets(fetch.Torrents, cancellationToken);
-                        log = $"saved {fetch.Torrents.Count}, pages={fetch.PagesFetched}, cursor={fetch.LastCursor?.ToString(CultureInfo.InvariantCulture) ?? "none"}";
-                    }
-                    else
-                        log = $"no items, pages={fetch.PagesFetched}";
-
+                var (log, completed) = await CrawlOlderPagesAsync("ParseFromDate", maxPages, lim, unixFrom, cancellationToken);
+                if (completed)
                     ParserLog.Write(TrackerName, $"ParseFromDate completed in {sw.Elapsed.TotalSeconds:F1}s, {log}");
-                }
-                catch (Exception ex)
-                {
-                    ParserLog.Write(TrackerName, $"Error: {ex.Message}");
-                    log = $"error: {ex.Message}";
-                }
-
                 return string.IsNullOrWhiteSpace(log) ? "ok" : log;
             }, cancellationToken);
+        }
+
+        async Task<(string log, bool completed)> CrawlOlderPagesAsync(
+            string jobLabel,
+            int maxPages,
+            int limit,
+            long? startCursor,
+            CancellationToken cancellationToken)
+        {
+            var progress = new BitruBackfillProgress { LastCommittedCursor = startCursor };
+            HashSet<long> previousIds = null;
+
+            try
+            {
+                await BitruBackfillCommitLoop.RunAsync(
+                    maxPages,
+                    startCursor,
+                    fetchPage: async (cursor, ct) =>
+                    {
+                        var page = await FetchOnePage(limit, cursor, previousIds, ct);
+                        if (!page.Stop)
+                            previousIds = page.Ids;
+                        return page;
+                    },
+                    savePage: SaveTorrentsAndMagnets,
+                    commitCursor: WriteBackfillCursor,
+                    progress,
+                    cancellationToken);
+
+                return (progress.FormatLog(), true);
+            }
+            catch (OperationCanceledException)
+            {
+                string log = progress.FormatCanceledLog();
+                ParserLog.Write(TrackerName, $"{jobLabel} canceled, {log}");
+                return (log, false);
+            }
+            catch (Exception ex)
+            {
+                ParserLog.Write(TrackerName, $"{jobLabel} error: {ex.Message}");
+                return ($"error: {ex.Message}", false);
+            }
         }
 
         async Task<BitruApiResponse> ApiRequestAsync(object jsonParams, CancellationToken cancellationToken)
@@ -207,92 +197,60 @@ namespace JacRed.Infrastructure.Trackers.Bitru
             return JsonConvert.DeserializeObject<BitruApiResponse>(response);
         }
 
-        async Task<FetchResult> FetchTorrentsFromApi(
+        async Task<BitruBackfillPage> FetchOnePage(
             int limit,
             long? olderThanUnix,
-            int maxPages,
-            bool persistBackfillCursor,
+            HashSet<long> previousIds,
             CancellationToken cancellationToken)
         {
-            var all = new List<TorrentDetails>();
-            int pagesFetched = 0;
-            long? lastCursor = olderThanUnix;
-            long? requestCursor = olderThanUnix;
-            HashSet<long> previousIds = null;
+            await Task.Delay(ApiDelayMs, cancellationToken);
 
-            maxPages = BitruApiPagination.ClampPages(maxPages);
-            var currentParams = BitruApiPagination.BuildRequestParams(limit, requestCursor);
-
-            for (int page = 0; page < maxPages; page++)
+            var currentParams = BitruApiPagination.BuildRequestParams(limit, olderThanUnix);
+            var resp = await ApiRequestAsync(currentParams, cancellationToken);
+            if (resp == null || resp.HasError || resp.Result?.Items == null)
             {
-                await Task.Delay(ApiDelayMs, cancellationToken);
-
-                var resp = await ApiRequestAsync(currentParams, cancellationToken);
-                if (resp == null || resp.HasError || resp.Result?.Items == null)
-                {
-                    if (resp != null && resp.HasError && !string.IsNullOrEmpty(resp.ErrorMessage))
-                        ParserLog.Write(TrackerName, $"API error: {resp.ErrorMessage}");
-                    break;
-                }
-
-                if (resp.Result.Items.Count == 0)
-                    break;
-
-                var pageTorrents = BitruApiParser.ParseTorrentsFromResponse(resp, HostUrl);
-                var pageIds = BitruApiPagination.CollectTorrentIds(pageTorrents.Select(t => t.url));
-
-                if (BitruApiPagination.IsDuplicatePage(previousIds, pageIds))
-                {
-                    ParserLog.Write(TrackerName, $"Stop: page {page + 1} fully overlaps previous page");
-                    break;
-                }
-
-                all.AddRange(pageTorrents);
-                pagesFetched++;
-                previousIds = pageIds;
-
-                if (!BitruApiPagination.TryGetNextOlderPageCursor(resp.Result, requestCursor, out long nextCursor))
-                    break;
-
-                lastCursor = nextCursor;
-                if (persistBackfillCursor)
-                    WriteBackfillCursor(nextCursor);
-
-                if (page + 1 >= maxPages)
-                    break;
-
-                requestCursor = nextCursor;
-                currentParams = BitruApiPagination.BuildRequestParams(limit, nextCursor);
+                if (resp != null && resp.HasError && !string.IsNullOrEmpty(resp.ErrorMessage))
+                    ParserLog.Write(TrackerName, $"API error: {resp.ErrorMessage}");
+                return BitruBackfillPage.Halt();
             }
 
-            return new FetchResult(all, lastCursor, pagesFetched);
+            if (resp.Result.Items.Count == 0)
+                return BitruBackfillPage.Halt();
+
+            var pageTorrents = BitruApiParser.ParseTorrentsFromResponse(resp, HostUrl);
+            var pageIds = BitruApiPagination.CollectTorrentIds(pageTorrents.Select(t => t.url));
+
+            if (BitruApiPagination.IsDuplicatePage(previousIds, pageIds))
+            {
+                ParserLog.Write(TrackerName, "Stop: page fully overlaps previous page");
+                return BitruBackfillPage.Halt();
+            }
+
+            long? nextCursor = null;
+            if (BitruApiPagination.TryGetNextOlderPageCursor(resp.Result, olderThanUnix, out long parsedCursor))
+                nextCursor = parsedCursor;
+
+            return BitruBackfillPage.Ok(pageTorrents, nextCursor, pageIds);
         }
 
         long? ReadBackfillCursor()
         {
             try
             {
-                if (!IO.File.Exists(BackfillCursorPath))
-                    return null;
-                string text = IO.File.ReadAllText(BackfillCursorPath).Trim();
-                if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long unix) && unix > 0)
-                    return unix;
+                return BitruBackfillCommitLoop.ReadCursor(BackfillCursorPath);
             }
             catch (Exception ex)
             {
                 ParserLog.Write(TrackerName, $"Read backfill cursor failed: {ex.Message}");
+                return null;
             }
-            return null;
         }
 
         void WriteBackfillCursor(long unix)
         {
             try
             {
-                string dir = IO.Path.GetDirectoryName(BackfillCursorPath);
-                if (!string.IsNullOrEmpty(dir))
-                    IO.Directory.CreateDirectory(dir);
-                IO.File.WriteAllText(BackfillCursorPath, unix.ToString(CultureInfo.InvariantCulture));
+                BitruBackfillCommitLoop.WriteCursorAtomic(BackfillCursorPath, unix);
             }
             catch (Exception ex)
             {
@@ -300,7 +258,7 @@ namespace JacRed.Infrastructure.Trackers.Bitru
             }
         }
 
-        async Task SaveTorrentsAndMagnets(List<TorrentDetails> torrents, CancellationToken cancellationToken)
+        async Task SaveTorrentsAndMagnets(IReadOnlyList<TorrentDetails> torrents, CancellationToken cancellationToken)
         {
             await FileDB.AddOrUpdate(torrents, async (t, db) =>
             {
@@ -329,7 +287,10 @@ namespace JacRed.Infrastructure.Trackers.Bitru
 
                 return false;
             });
+        }
 
+        static void WriteLastNewTor(IReadOnlyList<TorrentDetails> torrents)
+        {
             try
             {
                 var lastTor = torrents.OrderByDescending(x => x.createTime).FirstOrDefault();
@@ -337,20 +298,6 @@ namespace JacRed.Infrastructure.Trackers.Bitru
                     IO.File.WriteAllText(LastNewTorPath, lastTor.createTime.ToString("dd.MM.yyyy", CultureInfo.InvariantCulture));
             }
             catch { }
-        }
-
-        readonly struct FetchResult
-        {
-            public FetchResult(List<TorrentDetails> torrents, long? lastCursor, int pagesFetched)
-            {
-                Torrents = torrents ?? new List<TorrentDetails>();
-                LastCursor = lastCursor;
-                PagesFetched = pagesFetched;
-            }
-
-            public List<TorrentDetails> Torrents { get; }
-            public long? LastCursor { get; }
-            public int PagesFetched { get; }
         }
     }
 }

--- a/Infrastructure/Trackers/Bitru/BitruBackfillCommitLoop.cs
+++ b/Infrastructure/Trackers/Bitru/BitruBackfillCommitLoop.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using JacRed.Models.Details;
+using IO = System.IO;
+
+namespace JacRed.Infrastructure.Trackers.Bitru
+{
+    internal readonly struct BitruBackfillPage
+    {
+        public BitruBackfillPage(IReadOnlyList<TorrentDetails> torrents, long? nextCursor, bool stop, HashSet<long> ids = null)
+        {
+            Torrents = torrents ?? Array.Empty<TorrentDetails>();
+            NextCursor = nextCursor;
+            Stop = stop;
+            Ids = ids;
+        }
+
+        public IReadOnlyList<TorrentDetails> Torrents { get; }
+        public long? NextCursor { get; }
+        public bool Stop { get; }
+        public HashSet<long> Ids { get; }
+
+        public static BitruBackfillPage Halt() => new(Array.Empty<TorrentDetails>(), null, stop: true);
+
+        public static BitruBackfillPage Ok(IReadOnlyList<TorrentDetails> torrents, long? nextCursor, HashSet<long> ids)
+            => new(torrents, nextCursor, stop: false, ids);
+    }
+
+    internal sealed class BitruBackfillProgress
+    {
+        public int FetchedPages { get; set; }
+        public int CommittedPages { get; set; }
+        public int SavedCount { get; set; }
+        public long? LastCommittedCursor { get; set; }
+
+        public string FormatLog()
+        {
+            string cursor = FormatCursor(LastCommittedCursor);
+            if (SavedCount == 0 && CommittedPages == 0)
+                return $"no items, fetchedPages={FetchedPages}, committedPages={CommittedPages}, cursor={cursor}";
+            return $"saved {SavedCount}, fetchedPages={FetchedPages}, committedPages={CommittedPages}, cursor={cursor}";
+        }
+
+        public string FormatCanceledLog()
+        {
+            string cursor = FormatCursor(LastCommittedCursor);
+            return $"canceled, saved={SavedCount}, fetchedPages={FetchedPages}, committedPages={CommittedPages}, cursor={cursor}";
+        }
+
+        static string FormatCursor(long? cursor)
+            => cursor?.ToString(CultureInfo.InvariantCulture) ?? "none";
+    }
+
+    /// <summary>
+    /// Page-by-page backfill: fetch → save → commit cursor.
+    /// Cursor advances only after the page is fully saved.
+    /// </summary>
+    internal static class BitruBackfillCommitLoop
+    {
+        public static async Task<BitruBackfillProgress> RunAsync(
+            int maxPages,
+            long? startCursor,
+            Func<long?, CancellationToken, Task<BitruBackfillPage>> fetchPage,
+            Func<IReadOnlyList<TorrentDetails>, CancellationToken, Task> savePage,
+            Action<long> commitCursor,
+            BitruBackfillProgress progress,
+            CancellationToken cancellationToken)
+        {
+            if (!progress.LastCommittedCursor.HasValue && startCursor.HasValue)
+                progress.LastCommittedCursor = startCursor;
+
+            maxPages = BitruApiPagination.ClampPages(maxPages);
+            long? requestCursor = startCursor;
+
+            for (int page = 0; page < maxPages; page++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var fetched = await fetchPage(requestCursor, cancellationToken);
+                if (fetched.Stop)
+                    break;
+
+                progress.FetchedPages++;
+
+                await savePage(fetched.Torrents, cancellationToken);
+
+                progress.SavedCount += fetched.Torrents.Count;
+                progress.CommittedPages++;
+
+                if (!fetched.NextCursor.HasValue)
+                    break;
+
+                commitCursor(fetched.NextCursor.Value);
+                progress.LastCommittedCursor = fetched.NextCursor;
+                requestCursor = fetched.NextCursor;
+            }
+
+            return progress;
+        }
+
+        public static void WriteCursorAtomic(string path, long unix)
+        {
+            var fullPath = IO.Path.GetFullPath(path);
+            var dir = IO.Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir) && !IO.Directory.Exists(dir))
+                IO.Directory.CreateDirectory(dir);
+
+            string text = unix.ToString(CultureInfo.InvariantCulture);
+            string tempPath = fullPath + ".tmp";
+            IO.File.WriteAllText(tempPath, text);
+            if (IO.File.Exists(fullPath))
+                IO.File.Replace(tempPath, fullPath, null);
+            else
+                IO.File.Move(tempPath, fullPath);
+        }
+
+        public static long? ReadCursor(string path)
+        {
+            if (!IO.File.Exists(path))
+                return null;
+            string text = IO.File.ReadAllText(path).Trim();
+            if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long unix) && unix > 0)
+                return unix;
+            return null;
+        }
+    }
+}

--- a/tests/JacRed.Tests/Bitru/BitruBackfillCommitLoopTests.cs
+++ b/tests/JacRed.Tests/Bitru/BitruBackfillCommitLoopTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using JacRed.Infrastructure.Trackers.Bitru;
+using JacRed.Models.Details;
+using Xunit;
+
+namespace JacRed.Tests.Bitru;
+
+public class BitruBackfillCommitLoopTests : IDisposable
+{
+    readonly string _tempDir;
+
+    public BitruBackfillCommitLoopTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "jacred-bitru-backfill-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch { }
+    }
+
+    [Fact]
+    public async Task RunAsync_TwoPagesSaved_CommitsLastCursor()
+    {
+        long? committed = null;
+        var pages = new Queue<BitruBackfillPage>(new[]
+        {
+            BitruBackfillPage.Ok(DummyTorrents(2), 200, null),
+            BitruBackfillPage.Ok(DummyTorrents(3), 100, null)
+        });
+
+        var progress = new BitruBackfillProgress();
+        await BitruBackfillCommitLoop.RunAsync(
+            maxPages: 5,
+            startCursor: 300,
+            fetchPage: (_, _) => Task.FromResult(pages.Count > 0 ? pages.Dequeue() : BitruBackfillPage.Halt()),
+            savePage: (_, _) => Task.CompletedTask,
+            commitCursor: unix => committed = unix,
+            progress,
+            CancellationToken.None);
+
+        Assert.Equal(100, committed);
+        Assert.Equal(2, progress.FetchedPages);
+        Assert.Equal(2, progress.CommittedPages);
+        Assert.Equal(5, progress.SavedCount);
+        Assert.Equal(100, progress.LastCommittedCursor);
+        Assert.Equal("saved 5, fetchedPages=2, committedPages=2, cursor=100", progress.FormatLog());
+    }
+
+    [Fact]
+    public async Task RunAsync_CancelDuringSecondPageSave_KeepsFirstCursor()
+    {
+        using var cts = new CancellationTokenSource();
+        long? committed = null;
+        int saveCalls = 0;
+        var pages = new Queue<BitruBackfillPage>(new[]
+        {
+            BitruBackfillPage.Ok(DummyTorrents(2), 200, null),
+            BitruBackfillPage.Ok(DummyTorrents(3), 100, null)
+        });
+
+        var progress = new BitruBackfillProgress { LastCommittedCursor = 300 };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            BitruBackfillCommitLoop.RunAsync(
+                maxPages: 5,
+                startCursor: 300,
+                fetchPage: (_, _) => Task.FromResult(pages.Count > 0 ? pages.Dequeue() : BitruBackfillPage.Halt()),
+                savePage: (_, ct) =>
+                {
+                    saveCalls++;
+                    if (saveCalls == 2)
+                    {
+                        cts.Cancel();
+                        ct.ThrowIfCancellationRequested();
+                    }
+                    return Task.CompletedTask;
+                },
+                commitCursor: unix => committed = unix,
+                progress,
+                cts.Token));
+
+        Assert.Equal(200, committed);
+        Assert.Equal(2, progress.FetchedPages);
+        Assert.Equal(1, progress.CommittedPages);
+        Assert.Equal(2, progress.SavedCount);
+        Assert.Equal(200, progress.LastCommittedCursor);
+        Assert.Equal("canceled, saved=2, fetchedPages=2, committedPages=1, cursor=200", progress.FormatCanceledLog());
+    }
+
+    [Fact]
+    public async Task RunAsync_CancelDuringFirstPageSave_DoesNotWriteCursor()
+    {
+        using var cts = new CancellationTokenSource();
+        long? committed = null;
+        var progress = new BitruBackfillProgress { LastCommittedCursor = 300 };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            BitruBackfillCommitLoop.RunAsync(
+                maxPages: 5,
+                startCursor: 300,
+                fetchPage: (_, _) => Task.FromResult(BitruBackfillPage.Ok(DummyTorrents(2), 200, null)),
+                savePage: (_, ct) =>
+                {
+                    cts.Cancel();
+                    ct.ThrowIfCancellationRequested();
+                    return Task.CompletedTask;
+                },
+                commitCursor: unix => committed = unix,
+                progress,
+                cts.Token));
+
+        Assert.Null(committed);
+        Assert.Equal(1, progress.FetchedPages);
+        Assert.Equal(0, progress.CommittedPages);
+        Assert.Equal(0, progress.SavedCount);
+        Assert.Equal(300, progress.LastCommittedCursor);
+        Assert.Equal("canceled, saved=0, fetchedPages=1, committedPages=0, cursor=300", progress.FormatCanceledLog());
+    }
+
+    [Fact]
+    public async Task RunAsync_HaltOnFirstPage_DoesNotSaveOrCommit()
+    {
+        long? committed = null;
+        bool saved = false;
+        var progress = new BitruBackfillProgress { LastCommittedCursor = 300 };
+
+        await BitruBackfillCommitLoop.RunAsync(
+            maxPages: 5,
+            startCursor: 300,
+            fetchPage: (_, _) => Task.FromResult(BitruBackfillPage.Halt()),
+            savePage: (_, _) =>
+            {
+                saved = true;
+                return Task.CompletedTask;
+            },
+            commitCursor: unix => committed = unix,
+            progress,
+            CancellationToken.None);
+
+        Assert.False(saved);
+        Assert.Null(committed);
+        Assert.Equal(0, progress.FetchedPages);
+        Assert.Equal(0, progress.CommittedPages);
+        Assert.Equal("no items, fetchedPages=0, committedPages=0, cursor=300", progress.FormatLog());
+    }
+
+    [Fact]
+    public void WriteCursorAtomic_ReplacesExistingFile()
+    {
+        var path = Path.Combine(_tempDir, "bitru_backfill_cursor.txt");
+        BitruBackfillCommitLoop.WriteCursorAtomic(path, 1770045331);
+        BitruBackfillCommitLoop.WriteCursorAtomic(path, 1769339212);
+
+        Assert.Equal(1769339212, BitruBackfillCommitLoop.ReadCursor(path));
+        Assert.Equal("1769339212", File.ReadAllText(path));
+        Assert.False(File.Exists(path + ".tmp"));
+    }
+
+    static List<TorrentDetails> DummyTorrents(int count)
+    {
+        var list = new List<TorrentDetails>(count);
+        for (int i = 0; i < count; i++)
+            list.Add(new TorrentDetails { title = $"t{i}" });
+        return list;
+    }
+}


### PR DESCRIPTION
- Replaced FetchTorrentsFromApi with a new CrawlOlderPagesAsync method to streamline backfill and parsing processes.
- Introduced BitruBackfillCommitLoop for page-by-page backfill management, ensuring cursor commits only after successful saves.
- Added comprehensive logging for backfill operations, including handling of cancellation and error scenarios.
- Created unit tests for BitruBackfillCommitLoop to validate functionality and ensure robustness.

Fix #152 