### PR TITLE
feat(search): add season/episode stripping functionality

### DIFF
--- a/Configuration/Schema/ConfigSchema.cs
+++ b/Configuration/Schema/ConfigSchema.cs
@@ -110,6 +110,8 @@ namespace JacRed.Configuration.Schema
                         Field("search.maxV1Pairs", "int", "Max v1 pairs", "При mergeV1=auto или true (fuzzy)", min: 1),
                         Field("search.v1Sort", "string", "V1 sort", "sid, pir, size…"),
                         Field("search.stripTrailingYear", "bool", "Strip trailing year", "Fuzzy: запрос без года"),
+                        Field("search.stripSeasonEpisode", "bool", "Strip season/episode", "Fuzzy: запрос без SxxExx"),
+                        Field("search.skipSeasonEpisodeFilter", "bool", "Skip season/ep filter", "Не фильтровать season/ep на сервере"),
                         Field("search.skipCatFilter", "bool", "Skip cat filter", "Не фильтровать cat/Category[] на сервере")
                     }),
                     Group("alloha", "Alloha", "KP/IMDB/TMDB ID → title (API v2)", new[]

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -100,6 +100,8 @@ search:
   maxV1Pairs: 4 # Лимит v1-пар при mergeV1=auto в fuzzy mode
   v1Sort: sid # sid (seeders), pir, size; также IMDB/KP exact v1
   stripTrailingYear: true # Fuzzy: доп. запрос без года в конце
+  stripSeasonEpisode: true # Fuzzy: доп. запрос без S01/S01E01 (AIOStreams)
+  skipSeasonEpisodeFilter: false # true — не фильтровать season/ep (AIOStreams фильтрует сам)
   skipCatFilter: true # Не фильтровать cat/Category[] на сервере (Lampa фильтрует сама)
 
 # Alloha TV API v2 — resolve KP/IMDB/TMDB (tt… / kp… / tmdb… / themoviedb.org URL) to titles for FileDB search

--- a/Data/init.yaml
+++ b/Data/init.yaml
@@ -86,6 +86,8 @@ search:
   maxV1Pairs: 4
   v1Sort: sid
   stripTrailingYear: true
+  stripSeasonEpisode: true
+  skipSeasonEpisodeFilter: false
   skipCatFilter: true
 torznab:
   enable: true

--- a/Infrastructure/Indexers/IndexerRequestParams.cs
+++ b/Infrastructure/Indexers/IndexerRequestParams.cs
@@ -282,5 +282,38 @@ namespace JacRed.Infrastructure.Indexers
             var m = Regex.Match(query.Trim(), @"^(.+?)\s+(19|20)\d{2}$");
             return m.Success ? m.Groups[1].Value.Trim() : null;
         }
+
+        static readonly Regex SeasonEpisodeTokenRe = new Regex(
+            @"\b(S\d{1,2}E\d{1,2}|S\d{1,2}E?\d{0,2}|E\d{1,2}|\d{1,2}x\d{1,2})\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        static readonly Regex RussianSeasonSuffixRe = new Regex(
+            @"\s*\d{1,2}(-\d{1,2})?\s*сезон\s*.*$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        static readonly Regex SeasonWordSuffixRe = new Regex(
+            @"\b(Сезон|Season)\s*\d{1,2}(?!\d).*$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Strip inline TV season/episode tokens from text search queries (AIOStreams/Sonarr-style <c>q=</c> params).
+        /// Returns null when nothing changed.
+        /// </summary>
+        public static string StripSeasonEpisode(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query)) return null;
+            if (IsImdbOrKpQuery(query)) return null;
+
+            string original = query.Trim();
+            string t = SeasonEpisodeTokenRe.Replace(original, "");
+            t = RussianSeasonSuffixRe.Replace(t, "");
+            t = SeasonWordSuffixRe.Replace(t, "");
+            t = Regex.Replace(t, @"\s{2,}", " ").Trim();
+
+            if (string.IsNullOrEmpty(t) || string.Equals(t, original, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return t;
+        }
     }
 }

--- a/Infrastructure/Indexers/IndexerSearchEngine.cs
+++ b/Infrastructure/Indexers/IndexerSearchEngine.cs
@@ -94,11 +94,26 @@ namespace JacRed.Infrastructure.Indexers
 
             if (!string.IsNullOrWhiteSpace(query) && !skipCombined)
             {
+                string strippedSeason = settings.stripSeasonEpisode
+                    ? IndexerRequestParams.StripSeasonEpisode(query)
+                    : null;
+
                 if (settings.stripTrailingYear)
                 {
-                    var stripped = IndexerRequestParams.StripTrailingYear(query);
-                    if (!string.IsNullOrWhiteSpace(stripped)) variants.Add(stripped);
+                    var strippedYear = IndexerRequestParams.StripTrailingYear(query);
+                    if (!string.IsNullOrWhiteSpace(strippedYear)) variants.Add(strippedYear);
                 }
+
+                if (!string.IsNullOrWhiteSpace(strippedSeason))
+                    variants.Add(strippedSeason);
+
+                if (settings.stripTrailingYear && !string.IsNullOrWhiteSpace(strippedSeason))
+                {
+                    var strippedYearFromSeason = IndexerRequestParams.StripTrailingYear(strippedSeason);
+                    if (!string.IsNullOrWhiteSpace(strippedYearFromSeason))
+                        variants.Add(strippedYearFromSeason);
+                }
+
                 if (!variants.Contains(query)) variants.Add(query);
             }
 

--- a/Infrastructure/Indexers/IndexerSearchHelper.cs
+++ b/Infrastructure/Indexers/IndexerSearchHelper.cs
@@ -128,7 +128,7 @@ namespace JacRed.Infrastructure.Indexers
             if (req.Year > 0 && !req.CardMode)
                 results = IndexerResultFilters.FilterByYear(results, req.Year);
 
-            if (req.Season.HasValue)
+            if (req.Season.HasValue && !settings.skipSeasonEpisodeFilter)
                 results = SeasonEpisodeFilter.Filter(results, req.Season.Value, req.Episode);
 
             results = IndexerResultFilters.FilterByTrackers(results, req.Trackers);

--- a/Models/AppConf/SearchSettings.cs
+++ b/Models/AppConf/SearchSettings.cs
@@ -17,6 +17,12 @@ namespace JacRed.Models.AppConf
         /// <summary>Strip trailing year from fuzzy query and search both variants.</summary>
         public bool stripTrailingYear { get; set; } = true;
 
+        /// <summary>Strip inline SxxExx / season tokens from fuzzy query and search both variants.</summary>
+        public bool stripSeasonEpisode { get; set; } = true;
+
+        /// <summary>Skip season/episode post-filter (client filters by episode, e.g. AIOStreams).</summary>
+        public bool skipSeasonEpisodeFilter { get; set; } = false;
+
         /// <summary>Skip category post-filter on server (client filters by cat/Category[]).</summary>
         public bool skipCatFilter { get; set; } = true;
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ tags:
 
 ## OpenAPI / Swagger
 
-Спецификация: OpenAPI **3.0.3**, `info.version` **1.2.4** (источник: [`web/public/openapi.yaml`](https://github.com/jacred-fdb/jacred/blob/main/web/public/openapi.yaml)). В описании — список `TrackerSlug`, схема `BackgroundJob`, Torznab HEAD и общие query-параметры.
+Спецификация: OpenAPI **3.0.3**, `info.version` **1.2.5** (источник: [`web/public/openapi.yaml`](https://github.com/jacred-fdb/jacred/blob/main/web/public/openapi.yaml)). В описании — список `TrackerSlug`, схема `BackgroundJob`, Torznab HEAD и общие query-параметры.
 
 | URL | Назначение |
 | --- | --- |
@@ -43,7 +43,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 Сводная таблица «клиент → URL → формат» — в [Torznab XML](configuration.md#torznab-xml-torznab).
 
 - **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa** и др.).
-  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP/TMDB exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback.
+  - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP/TMDB exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback. Fuzzy `q`/`Query` с `S01`/`S01E01` расширяется до имени шоу при `search.stripSeasonEpisode` (по умолчанию `true`).
   - Параметры Lampa: `Query`, `title`, `title_original`, `year`, `is_serial`, `genres`, `Category[]`, `Tracker[]`, `season`, `ep`, `limit`, `offset`, `apikey`.
   - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true`.
 - **`GET /api/v2.0/indexers`** — список индексаторов (Jackett/Prowlarr).
@@ -52,7 +52,7 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 - **`GET /api/v1/indexer/{id}/newznab`** — Torznab XML через Prowlarr-совместимый путь (`t=caps|search|…`).
 - **`GET /api/v1/search`** — Prowlarr Search Feed ([wiki](https://wiki.servarr.com/en/prowlarr/search#search-feed)): JSON-массив релизов.
   - Параметры: `query`, `type` (`search`|`tvsearch`|`movie`|`music`|`book`), `indexerIds` (`1`, `-2` torrents; `-1` usenet → пусто), `categories`, `limit`, `offset`, `apikey`.
-  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{TmdbId:1315772}`, `{Season:1}`, `{Episode:2}` и т.п. ID-запросы (`tt…`/`kp…`/`tmdb…`/themoviedb.org URL/`{ImdbId:…}`/`{TmdbId:…}`) → Alloha v2.
+  - Brace-токены в `query` (как в UI Prowlarr): `{ImdbId:tt…}`, `{TmdbId:1315772}`, `{Season:1}`, `{Episode:2}` и т.п. ID-запросы (`tt…`/`kp…`/`tmdb…`/themoviedb.org URL/`{ImdbId:…}`/`{TmdbId:…}`) → Alloha v2. Inline `S01`/`S01E01` в `query` снимается при `search.stripSeasonEpisode`.
   - Lampa (`parser_torrent_type=prowlarr`): `query` + `type=tvsearch|search` + `categories` — запрос поднимается до card-поиска как у Jackett (`title`/`title_original`/`year`, `is_serial` 1=фильм / 2=сериал).
   - Один агрегированный indexer `id=1`; ответ в схеме ReleaseResource (`guid`, `title`, `size`, `seeders`, `magnetUrl`, `categories`, …).
   - JacRed-расширения как у Jackett: `ffprobe`, `languages`, `info` при `tracks: true` (иначе поля опускаются / null).
@@ -63,7 +63,8 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
   - Параметры: `q`, `imdbid`, `season`, `ep`, `year`, `cat`, `title`, `title_original`, `is_serial`, `limit`, `offset`, `apikey`.
   - IMDB/KP/TMDB ID (`tt…`, `kp…`, `tmdb…`, themoviedb.org `/movie|tv/{id}-…`) → Alloha v2 title resolve (name / original_name / alternative_name, type), затем v1 FileDB с `exact=true` (год ±1 при `alloha.filterByYear`).
   - Card mode (Lampa): `title` + `title_original` + `year` + `is_serial` + `genres`.
-  - Объединение v1+v2, bilingual `Русский / English`, post-filter по сезону/эпизоду/году/категории.
+  - Объединение v1+v2, bilingual `Русский / English`, stripping `S01`/`S01E01` из `q` (`search.stripSeasonEpisode`), post-filter по сезону/эпизоду/году/категории (`search.skipSeasonEpisodeFilter` отключает season/ep).
+  - `tvdbid`/`rid` без `q`/`imdbid` → пустой ответ (TVDB не резолвится).
 - **`GET /api/v1.0/torrents`** — поиск торрентов (собственный JSON API JacRed, не Torznab и не Jackett).
   - Параметры: `search` / связанные фильтры, `tracker` (один slug или список через запятую — значения `TrackerSlug`), `sort`, `type`, …
   - IMDB/KP/TMDB ID (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL) → Alloha v2 title resolve, затем exact FileDB (+ год ±1 / `type` из Alloha, если клиент не задал).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,8 @@ globalproxy:
         "maxV1Pairs": 4,
         "v1Sort": "sid",
         "stripTrailingYear": true,
+        "stripSeasonEpisode": true,
+        "skipSeasonEpisodeFilter": false,
         "skipCatFilter": true
       },
       "alloha": {
@@ -254,6 +256,8 @@ globalproxy:
 | `maxV1Pairs` | Лимит v1-запросов при `mergeV1=auto` (fuzzy) | `4` |
 | `v1Sort` | Сортировка v1 (`sid` = seeders; также IMDB/KP) | `sid` |
 | `stripTrailingYear` | Доп. вариант fuzzy-запроса без года | `true` |
+| `stripSeasonEpisode` | Доп. вариант fuzzy-запроса без S01/S01E01 | `true` |
+| `skipSeasonEpisodeFilter` | Не фильтровать по `season`/`ep` на сервере (AIOStreams) | `false` |
 | `skipCatFilter` | Не фильтровать по `cat` / `Category[]` на сервере | `true` |
 
 **`mergeV1: auto`** — v1 fuzzy **только в fuzzy mode** (Torznab text search, Lampa global search). Card mode (Lampa: `title` + `title_original`) — только v2 exact, без v1 fuzzy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,8 @@ globalproxy:
 
 **`mergeV1: auto`** — v1 fuzzy **только в fuzzy mode** (Torznab text search, Lampa global search). Card mode (Lampa: `title` + `title_original`) — только v2 exact, без v1 fuzzy.
 
+**AIOStreams / Sonarr-style `q=Show S01E01`:** при `stripSeasonEpisode: true` fuzzy ищет и полное `q`, и имя шоу без сезона/эпизода (`silo S01` → `silo`; `укрытие 2023 S01E01` → `укрытие 2023` → `укрытие` вместе с `stripTrailingYear`). `skipSeasonEpisodeFilter: true` отдаёт все релизы шоу — клиент фильтрует эпизоды сам.
+
 | `mergeV1` | Card (Lampa карточка) | Fuzzy (Query / Torznab) |
 | --- | --- | --- |
 | `false` | v2 only | v2 only |
@@ -307,6 +309,7 @@ Jackett JSON (`/api/v2.0/indexers/.../results`) **всегда** использ�
 | --- | --- | --- |
 | **Lampa** | `/api/v2.0/indexers/all/results` | Jackett JSON (`Results[]`). Тип парсера в Lampa: **Jackett**, не Prowlarr/Torznab |
 | **Sonarr / Radarr** | `/torznab/api` | Torznab XML (Generic Torznab indexer) |
+| **AIOStreams** | `/torznab/api` | Torznab XML; `q=Show S01` stripping; `skipSeasonEpisodeFilter: true` если клиент фильтрует эпизоды |
 | **Prowlarr** (ручная настройка Generic Torznab) | `/torznab/api` | Torznab XML |
 | **qui / autobrr** (discover, backend=**jackett**) | `/api/v2.0/indexers/all/results/torznab/api` | Torznab XML + `t=indexers` discover |
 | **qui / autobrr** (discover, backend=**prowlarr**) | `/api/v1/indexer` + `/api/v1/indexer/1/newznab` (+ `/api/v1/search`) | Prowlarr REST + Torznab XML / Search JSON |

--- a/tests/JacRed.Tests/Indexers/AllohaSearchParamsTests.cs
+++ b/tests/JacRed.Tests/Indexers/AllohaSearchParamsTests.cs
@@ -111,4 +111,37 @@ public class AllohaSearchParamsTests
         Assert.Equal(3, filtered.Count);
         Assert.DoesNotContain(filtered, r => r.Title == "y2001");
     }
+
+    [Theory]
+    [InlineData("silo S01", "silo")]
+    [InlineData("укрытие S01", "укрытие")]
+    [InlineData("silo us S01", "silo us")]
+    [InlineData("укрытие 2023 S01E01", "укрытие 2023")]
+    [InlineData("silo 2023 S01", "silo 2023")]
+    [InlineData("укрытие S01E01", "укрытие")]
+    [InlineData("укрытие 2023 S01", "укрытие 2023")]
+    [InlineData("silo S01E01", "silo")]
+    [InlineData("silo 2023 S01E01", "silo 2023")]
+    [InlineData("silo us S01E01", "silo us")]
+    public void StripSeasonEpisode_SiloQueries(string raw, string expected)
+    {
+        Assert.Equal(expected, IndexerRequestParams.StripSeasonEpisode(raw));
+    }
+
+    [Theory]
+    [InlineData("Fight Club 1999")]
+    [InlineData("tt14688458")]
+    [InlineData("Breaking Bad")]
+    public void StripSeasonEpisode_Unchanged_ReturnsNull(string raw)
+    {
+        Assert.Null(IndexerRequestParams.StripSeasonEpisode(raw));
+    }
+
+    [Fact]
+    public void StripSeasonEpisode_ChainedWithTrailingYear()
+    {
+        var strippedSeason = IndexerRequestParams.StripSeasonEpisode("укрытие 2023 S01");
+        Assert.Equal("укрытие 2023", strippedSeason);
+        Assert.Equal("укрытие", IndexerRequestParams.StripTrailingYear(strippedSeason));
+    }
 }

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: JacRed API
-  version: 1.2.4
+  version: 1.2.5
   description: |
     Torrent aggregator API: Jackett-compatible search, native torrent search, Torznab XML,
     statistics, sync protocol, and configuration management.
@@ -175,6 +175,10 @@ paths:
         (`GET /v2/movies/search`) to titles (plus optional alternative name, year, type), then searched
         in FileDB with exact match. When the client omits `year`, Alloha year ±1 is applied if
         `alloha.filterByYear` is enabled.
+
+        **TV text queries:** when `search.stripSeasonEpisode` is true (default), inline `S01` / `S01E01`
+        tokens are stripped and both variants are searched (AIOStreams-style `q=silo S01`).
+        Trailing year is also stripped when `search.stripTrailingYear` is true.
       operationId: jackettSearch
       parameters:
         - name: status
@@ -385,6 +389,9 @@ paths:
 
         **IMDb / Kinopoisk / TMDB IDs:** `q` as `tt…`/`kp…`/`tmdb…`, a themoviedb.org URL, or `imdbid` →
         Alloha TV API v2 title resolve → FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
+        **TVDB-only** (`tvdbid` / `rid` with no `q`/`imdbid`) returns empty — JacRed does not resolve TVDB ids.
+        **TV text queries:** `search.stripSeasonEpisode` (default true) searches show name without `S01`/`S01E01`;
+        `season`/`ep` still post-filter unless `search.skipSeasonEpisodeFilter` is true.
       operationId: torznabRoot
       parameters:
         - $ref: "#/components/parameters/ApiKeyQuery"
@@ -696,6 +703,7 @@ paths:
         Brace tokens in `query` (e.g. `{ImdbId:tt123}`, `{Season:1}`) are parsed like Prowlarr UI search.
         IMDb/KP/TMDB id queries (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL, or brace `{ImdbId:…}` / `{TmdbId:…}`)
         are resolved via Alloha TV API v2 before FileDB exact search.
+        Inline `S01`/`S01E01` in free-text `query` is stripped when `search.stripSeasonEpisode` is true (default).
         JacRed exposes a single aggregate torrent indexer (`id=1`); `indexerIds=-1` (usenet) returns `[]`.
         Each release also includes JacRed extensions (`ffprobe`, `languages`, `info`) when `tracks: true`, same as Jackett results.
         Lampa Prowlarr mode (`query` + `type` + `categories`) is promoted to Jackett-style card search
@@ -711,7 +719,9 @@ paths:
           in: query
           schema:
             type: string
-          description: URL-encoded search string (supports Prowlarr brace tokens)
+          description: |
+            URL-encoded search string (supports Prowlarr brace tokens).
+            Inline `S01`/`S01E01` is stripped when `search.stripSeasonEpisode` is true.
         - $ref: "#/components/parameters/SearchQ"
         - name: type
           in: query
@@ -1309,7 +1319,12 @@ components:
       in: query
       schema:
         type: string
-      description: Free-text search query
+      description: |
+        Free-text search query. When `search.stripSeasonEpisode` is true (default), inline TV tokens
+        (`S01`, `S01E01`, `1x01`, `Season 1`) are stripped and both variants are searched
+        (e.g. `silo S01` also searches `silo`). Trailing year is also stripped when
+        `search.stripTrailingYear` is true (`укрытие 2023 S01` → `укрытие 2023` → `укрытие`).
+        IMDb/KP/TMDB ids (`tt…`/`kp…`/`tmdb…`) are not stripped.
     TorznabCat:
       name: cat
       in: query
@@ -1331,7 +1346,9 @@ components:
       in: query
       schema:
         type: string
-      description: TheTVDB id (tv-search)
+      description: |
+        TheTVDB id (tv-search). Advertised in caps; JacRed does not resolve TVDB ids.
+        A `tvdbid`-only request (no `q`/`imdbid`) returns empty results — send `q` or `imdbid` instead.
     TorznabRid:
       name: rid
       in: query
@@ -1343,13 +1360,16 @@ components:
       in: query
       schema:
         type: integer
-      description: Season number (tv-search filter)
+      description: |
+        Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+        (clients such as AIOStreams filter episodes themselves).
     TorznabEp:
       name: ep
       in: query
       schema:
         type: integer
-      description: Episode number (tv-search filter)
+      description: |
+        Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true.
     TorznabEpisode:
       name: episode
       in: query
@@ -1394,13 +1414,14 @@ components:
       in: query
       schema:
         type: string
-      description: Free-text search alias for `query` / Torznab `q`
+      description: |
+        Free-text search alias for `query` / Torznab `q`. Same season/year stripping as Torznab `q`.
     SearchQueryAlt:
       name: Query
       in: query
       schema:
         type: string
-      description: Alternate capitalization of free-text search query
+      description: Alternate capitalization of free-text search query (same stripping as `q`)
     ImdbIdAltUnderscore:
       name: imdb_id
       in: query

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -114,6 +114,10 @@ export interface paths {
          *     (`GET /v2/movies/search`) to titles (plus optional alternative name, year, type), then searched
          *     in FileDB with exact match. When the client omits `year`, Alloha year ±1 is applied if
          *     `alloha.filterByYear` is enabled.
+         *
+         *     **TV text queries:** when `search.stripSeasonEpisode` is true (default), inline `S01` / `S01E01`
+         *     tokens are stripped and both variants are searched (AIOStreams-style `q=silo S01`).
+         *     Trailing year is also stripped when `search.stripTrailingYear` is true.
          */
         get: operations["jackettSearch"];
         put?: never;
@@ -206,6 +210,9 @@ export interface paths {
          *
          *     **IMDb / Kinopoisk / TMDB IDs:** `q` as `tt…`/`kp…`/`tmdb…`, a themoviedb.org URL, or `imdbid` →
          *     Alloha TV API v2 title resolve → FileDB exact search (year ±1 when client `year` absent and `alloha.filterByYear`).
+         *     **TVDB-only** (`tvdbid` / `rid` with no `q`/`imdbid`) returns empty — JacRed does not resolve TVDB ids.
+         *     **TV text queries:** `search.stripSeasonEpisode` (default true) searches show name without `S01`/`S01E01`;
+         *     `season`/`ep` still post-filter unless `search.skipSeasonEpisodeFilter` is true.
          */
         get: operations["torznabRoot"];
         put?: never;
@@ -352,6 +359,7 @@ export interface paths {
          *     Brace tokens in `query` (e.g. `{ImdbId:tt123}`, `{Season:1}`) are parsed like Prowlarr UI search.
          *     IMDb/KP/TMDB id queries (`tt…`, `kp…`, `tmdb…`, themoviedb.org URL, or brace `{ImdbId:…}` / `{TmdbId:…}`)
          *     are resolved via Alloha TV API v2 before FileDB exact search.
+         *     Inline `S01`/`S01E01` in free-text `query` is stripped when `search.stripSeasonEpisode` is true (default).
          *     JacRed exposes a single aggregate torrent indexer (`id=1`); `indexerIds=-1` (usenet) returns `[]`.
          *     Each release also includes JacRed extensions (`ffprobe`, `languages`, `info`) when `tracks: true`, same as Jackett results.
          *     Lampa Prowlarr mode (`query` + `type` + `categories`) is promoted to Jackett-style card search
@@ -1170,7 +1178,13 @@ export interface components {
         ApiKeyQuery: string;
         /** @description Torznab function (`caps`, `indexers`, or search type) */
         TorznabT: "caps" | "indexers" | "search" | "tvsearch" | "movie" | "tv" | "moviesearch";
-        /** @description Free-text search query */
+        /**
+         * @description Free-text search query. When `search.stripSeasonEpisode` is true (default), inline TV tokens
+         *     (`S01`, `S01E01`, `1x01`, `Season 1`) are stripped and both variants are searched
+         *     (e.g. `silo S01` also searches `silo`). Trailing year is also stripped when
+         *     `search.stripTrailingYear` is true (`укрытие 2023 S01` → `укрытие 2023` → `укрытие`).
+         *     IMDb/KP/TMDB ids (`tt…`/`kp…`/`tmdb…`) are not stripped.
+         */
         TorznabQ: string;
         /** @description Comma-separated Torznab category ids */
         TorznabCat: string;
@@ -1181,13 +1195,19 @@ export interface components {
          *     `/movie|tv/{id}-…` URL (same Alloha resolve path).
          */
         TorznabImdbId: string;
-        /** @description TheTVDB id (tv-search) */
+        /**
+         * @description TheTVDB id (tv-search). Advertised in caps; JacRed does not resolve TVDB ids.
+         *     A `tvdbid`-only request (no `q`/`imdbid`) returns empty results — send `q` or `imdbid` instead.
+         */
         TorznabTvdbId: string;
         /** @description Alias for `tvdbid` */
         TorznabRid: string;
-        /** @description Season number (tv-search filter) */
+        /**
+         * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+         *     (clients such as AIOStreams filter episodes themselves).
+         */
         TorznabSeason: number;
-        /** @description Episode number (tv-search filter) */
+        /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
         TorznabEp: number;
         /** @description Alias for `ep` */
         TorznabEpisode: number;
@@ -1205,9 +1225,9 @@ export interface components {
          * @example true
          */
         TorznabConfigured: string;
-        /** @description Free-text search alias for `query` / Torznab `q` */
+        /** @description Free-text search alias for `query` / Torznab `q`. Same season/year stripping as Torznab `q`. */
         SearchQ: string;
-        /** @description Alternate capitalization of free-text search query */
+        /** @description Alternate capitalization of free-text search query (same stripping as `q`) */
         SearchQueryAlt: string;
         /** @description Alias for `imdbid` */
         ImdbIdAltUnderscore: string;
@@ -1371,9 +1391,9 @@ export interface operations {
                 /** @description API key (alternative — X-Api-Key header or Bearer) */
                 apikey?: components["parameters"]["ApiKeyQuery"];
                 query?: string;
-                /** @description Free-text search alias for `query` / Torznab `q` */
+                /** @description Free-text search alias for `query` / Torznab `q`. Same season/year stripping as Torznab `q`. */
                 q?: components["parameters"]["SearchQ"];
-                /** @description Alternate capitalization of free-text search query */
+                /** @description Alternate capitalization of free-text search query (same stripping as `q`) */
                 Query?: components["parameters"]["SearchQueryAlt"];
                 /** @description Localized title (JacRed / Lampa card search) */
                 title?: components["parameters"]["TorznabTitle"];
@@ -1423,9 +1443,12 @@ export interface operations {
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
                 /** @description Alias for `imdbid` */
                 imdbId?: components["parameters"]["ImdbIdAltCamel"];
-                /** @description Season number (tv-search filter) */
+                /**
+                 * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+                 *     (clients such as AIOStreams filter episodes themselves).
+                 */
                 season?: components["parameters"]["TorznabSeason"];
-                /** @description Episode number (tv-search filter) */
+                /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
                 ep?: components["parameters"]["TorznabEp"];
                 /** @description Alias for `ep` */
                 episode?: components["parameters"]["TorznabEpisode"];
@@ -1577,9 +1600,15 @@ export interface operations {
                 apikey?: components["parameters"]["ApiKeyQuery"];
                 /** @description Torznab function (`caps`, `indexers`, or search type) */
                 t?: components["parameters"]["TorznabT"];
-                /** @description Free-text search query */
+                /**
+                 * @description Free-text search query. When `search.stripSeasonEpisode` is true (default), inline TV tokens
+                 *     (`S01`, `S01E01`, `1x01`, `Season 1`) are stripped and both variants are searched
+                 *     (e.g. `silo S01` also searches `silo`). Trailing year is also stripped when
+                 *     `search.stripTrailingYear` is true (`укрытие 2023 S01` → `укрытие 2023` → `укрытие`).
+                 *     IMDb/KP/TMDB ids (`tt…`/`kp…`/`tmdb…`) are not stripped.
+                 */
                 q?: components["parameters"]["TorznabQ"];
-                /** @description Alternate capitalization of free-text search query */
+                /** @description Alternate capitalization of free-text search query (same stripping as `q`) */
                 Query?: components["parameters"]["SearchQueryAlt"];
                 /** @description Comma-separated Torznab category ids */
                 cat?: components["parameters"]["TorznabCat"];
@@ -1603,13 +1632,19 @@ export interface operations {
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
                 /** @description Alias for `imdbid` */
                 imdbId?: components["parameters"]["ImdbIdAltCamel"];
-                /** @description TheTVDB id (tv-search) */
+                /**
+                 * @description TheTVDB id (tv-search). Advertised in caps; JacRed does not resolve TVDB ids.
+                 *     A `tvdbid`-only request (no `q`/`imdbid`) returns empty results — send `q` or `imdbid` instead.
+                 */
                 tvdbid?: components["parameters"]["TorznabTvdbId"];
                 /** @description Alias for `tvdbid` */
                 rid?: components["parameters"]["TorznabRid"];
-                /** @description Season number (tv-search filter) */
+                /**
+                 * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+                 *     (clients such as AIOStreams filter episodes themselves).
+                 */
                 season?: components["parameters"]["TorznabSeason"];
-                /** @description Episode number (tv-search filter) */
+                /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
                 ep?: components["parameters"]["TorznabEp"];
                 /** @description Alias for `ep` */
                 episode?: components["parameters"]["TorznabEpisode"];
@@ -1718,9 +1753,15 @@ export interface operations {
                 apikey?: components["parameters"]["ApiKeyQuery"];
                 /** @description Torznab function (`caps`, `indexers`, or search type) */
                 t?: components["parameters"]["TorznabT"];
-                /** @description Free-text search query */
+                /**
+                 * @description Free-text search query. When `search.stripSeasonEpisode` is true (default), inline TV tokens
+                 *     (`S01`, `S01E01`, `1x01`, `Season 1`) are stripped and both variants are searched
+                 *     (e.g. `silo S01` also searches `silo`). Trailing year is also stripped when
+                 *     `search.stripTrailingYear` is true (`укрытие 2023 S01` → `укрытие 2023` → `укрытие`).
+                 *     IMDb/KP/TMDB ids (`tt…`/`kp…`/`tmdb…`) are not stripped.
+                 */
                 q?: components["parameters"]["TorznabQ"];
-                /** @description Alternate capitalization of free-text search query */
+                /** @description Alternate capitalization of free-text search query (same stripping as `q`) */
                 Query?: components["parameters"]["SearchQueryAlt"];
                 /** @description Comma-separated Torznab category ids */
                 cat?: components["parameters"]["TorznabCat"];
@@ -1744,13 +1785,19 @@ export interface operations {
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
                 /** @description Alias for `imdbid` */
                 imdbId?: components["parameters"]["ImdbIdAltCamel"];
-                /** @description TheTVDB id (tv-search) */
+                /**
+                 * @description TheTVDB id (tv-search). Advertised in caps; JacRed does not resolve TVDB ids.
+                 *     A `tvdbid`-only request (no `q`/`imdbid`) returns empty results — send `q` or `imdbid` instead.
+                 */
                 tvdbid?: components["parameters"]["TorznabTvdbId"];
                 /** @description Alias for `tvdbid` */
                 rid?: components["parameters"]["TorznabRid"];
-                /** @description Season number (tv-search filter) */
+                /**
+                 * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+                 *     (clients such as AIOStreams filter episodes themselves).
+                 */
                 season?: components["parameters"]["TorznabSeason"];
-                /** @description Episode number (tv-search filter) */
+                /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
                 ep?: components["parameters"]["TorznabEp"];
                 /** @description Alias for `ep` */
                 episode?: components["parameters"]["TorznabEpisode"];
@@ -1954,9 +2001,15 @@ export interface operations {
                 apikey?: components["parameters"]["ApiKeyQuery"];
                 /** @description Torznab function (`caps`, `indexers`, or search type) */
                 t?: components["parameters"]["TorznabT"];
-                /** @description Free-text search query */
+                /**
+                 * @description Free-text search query. When `search.stripSeasonEpisode` is true (default), inline TV tokens
+                 *     (`S01`, `S01E01`, `1x01`, `Season 1`) are stripped and both variants are searched
+                 *     (e.g. `silo S01` also searches `silo`). Trailing year is also stripped when
+                 *     `search.stripTrailingYear` is true (`укрытие 2023 S01` → `укрытие 2023` → `укрытие`).
+                 *     IMDb/KP/TMDB ids (`tt…`/`kp…`/`tmdb…`) are not stripped.
+                 */
                 q?: components["parameters"]["TorznabQ"];
-                /** @description Alternate capitalization of free-text search query */
+                /** @description Alternate capitalization of free-text search query (same stripping as `q`) */
                 Query?: components["parameters"]["SearchQueryAlt"];
                 /** @description Comma-separated Torznab category ids */
                 cat?: components["parameters"]["TorznabCat"];
@@ -1980,13 +2033,19 @@ export interface operations {
                 imdb_id?: components["parameters"]["ImdbIdAltUnderscore"];
                 /** @description Alias for `imdbid` */
                 imdbId?: components["parameters"]["ImdbIdAltCamel"];
-                /** @description TheTVDB id (tv-search) */
+                /**
+                 * @description TheTVDB id (tv-search). Advertised in caps; JacRed does not resolve TVDB ids.
+                 *     A `tvdbid`-only request (no `q`/`imdbid`) returns empty results — send `q` or `imdbid` instead.
+                 */
                 tvdbid?: components["parameters"]["TorznabTvdbId"];
                 /** @description Alias for `tvdbid` */
                 rid?: components["parameters"]["TorznabRid"];
-                /** @description Season number (tv-search filter) */
+                /**
+                 * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+                 *     (clients such as AIOStreams filter episodes themselves).
+                 */
                 season?: components["parameters"]["TorznabSeason"];
-                /** @description Episode number (tv-search filter) */
+                /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
                 ep?: components["parameters"]["TorznabEp"];
                 /** @description Alias for `ep` */
                 episode?: components["parameters"]["TorznabEpisode"];
@@ -2098,9 +2157,12 @@ export interface operations {
             query?: {
                 /** @description API key (alternative — X-Api-Key header or Bearer) */
                 apikey?: components["parameters"]["ApiKeyQuery"];
-                /** @description URL-encoded search string (supports Prowlarr brace tokens) */
+                /**
+                 * @description URL-encoded search string (supports Prowlarr brace tokens).
+                 *     Inline `S01`/`S01E01` is stripped when `search.stripSeasonEpisode` is true.
+                 */
                 query?: string;
-                /** @description Free-text search alias for `query` / Torznab `q` */
+                /** @description Free-text search alias for `query` / Torznab `q`. Same season/year stripping as Torznab `q`. */
                 q?: components["parameters"]["SearchQ"];
                 /** @description Search kind. `movie`/`moviesearch` map to `is_serial=1`; `tv`/`tvsearch` map to `is_serial=2`. */
                 type?: "search" | "tvsearch" | "movie" | "moviesearch" | "tv" | "music" | "book";
@@ -2131,9 +2193,12 @@ export interface operations {
                 year?: components["parameters"]["Year"];
                 /** @description -1 unknown, 1 movie, 2 serial, 3 tvshow, 4 doc, 5 anime */
                 is_serial?: components["parameters"]["IsSerial"];
-                /** @description Season number (tv-search filter) */
+                /**
+                 * @description Season number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true
+                 *     (clients such as AIOStreams filter episodes themselves).
+                 */
                 season?: components["parameters"]["TorznabSeason"];
-                /** @description Episode number (tv-search filter) */
+                /** @description Episode number (tv-search post-filter). Skipped when `search.skipSeasonEpisodeFilter` is true. */
                 ep?: components["parameters"]["TorznabEp"];
                 /** @description Alias for `ep` */
                 episode?: components["parameters"]["TorznabEpisode"];


### PR DESCRIPTION
- Introduced new settings to strip season and episode tokens from search queries, enhancing fuzzy search capabilities.
- Implemented the `StripSeasonEpisode` method to remove inline SxxExx tokens and related suffixes from queries.
- Updated configuration schema and example data to include `stripSeasonEpisode` and `skipSeasonEpisodeFilter` options.
- Enhanced search engine logic to utilize the new stripping functionality based on user settings.
- Added unit tests to ensure correct behavior of the new stripping feature.

Fix #153 