### PR TITLE
fix(anistar): update Anistar host and parsing logic

### DIFF
--- a/.cursor/agents/jacred-tracker-parser.md
+++ b/.cursor/agents/jacred-tracker-parser.md
@@ -37,7 +37,7 @@ cluster over inventing new shapes.
 - Do not edit the user’s `.cursor/plans/*.plan.md` unless asked.
 - Successor sites get a **new slug** (do not retarget predecessors).
 - Icon from **that** site’s favicon; FDB URLs must be unique per release; prefer site JSON APIs when present.
-- Critical auth/magnet: Anibelka anon-only; Rutracker Flare ≠ Anistar cookie; Ultradox Referer; RuDub/Mazepa `MagnetNoTrackers`.
+- Critical auth/magnet: Anibelka anon-only; Rutracker Flare ≠ Anistar (v30 anon); Ultradox Referer; RuDub/Mazepa `MagnetNoTrackers`.
 
 ## Output
 

--- a/.cursor/skills/jacred-tracker-parser/SKILL.md
+++ b/.cursor/skills/jacred-tracker-parser/SKILL.md
@@ -78,7 +78,7 @@ Details per slug: [reference.md](reference.md).
 ## Magnet / auth rules (critical)
 
 - **Anibelka:** anonymous only — never cookie/login (passkeys).
-- **Rutracker:** FlareSolverr Warmup; Anistar does **not** use that path (live origin `v30.astar.bz`, anon).
+- **Rutracker:** FlareSolverr Warmup; Anistar does **not** use that path (`host`/`alias` mirror split).
 - **Ultradox:** google/yandex-like Referer or 503; magnets on detail pages.
 - **RuDub / Mazepa:** `MagnetNoTrackers` when auth announce has passkey.
 - **Successor sites:** new slug (e.g. `rudub`); never retarget predecessor (`baibako`).

--- a/.cursor/skills/jacred-tracker-parser/SKILL.md
+++ b/.cursor/skills/jacred-tracker-parser/SKILL.md
@@ -78,7 +78,7 @@ Details per slug: [reference.md](reference.md).
 ## Magnet / auth rules (critical)
 
 - **Anibelka:** anonymous only — never cookie/login (passkeys).
-- **Rutracker:** FlareSolverr Warmup; Anistar does **not** use that path (static CF cookie).
+- **Rutracker:** FlareSolverr Warmup; Anistar does **not** use that path (live origin `v30.astar.bz`, anon).
 - **Ultradox:** google/yandex-like Referer or 503; magnets on detail pages.
 - **RuDub / Mazepa:** `MagnetNoTrackers` when auth announce has passkey.
 - **Successor sites:** new slug (e.g. `rudub`); never retarget predecessor (`baibako`).

--- a/.cursor/skills/jacred-tracker-parser/reference.md
+++ b/.cursor/skills/jacred-tracker-parser/reference.md
@@ -17,7 +17,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 | Auth | Slugs | Gotcha |
 |------|-------|--------|
 | CF + FlareSolverr | rutracker | Warmup ~5m before parse; not for Anistar |
-| Static CF/session cookie | anistar | Manual/`cf_clearance` export |
+| Public anon HTML | anistar (`v30.astar.bz`) | Brand `anistar.org` is CF 403; cookie optional on v30 |
 | Login and/or cookie | kinozal, baibako, rudub, animelayer, anifilm, korsars (`bb_data`), selezen, toloka, mazepa, lostfilm | Prefer config cookie when set |
 | Anon only | anibelka | Never login — passkeys in torrents |
 | Anon + Referer trick | ultradox | google/yandex Referer; own origin → 503 |
@@ -31,7 +31,8 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 |--------|-------|
 | `MagnetNoTrackers` | rudub, mazepa |
 | t→M anon (full Magnet OK) | anibelka |
-| t→M after login | baibako, animelayer, anistar, anifilm, toloka, lostfilm, megapeer, viruseproject, bitru, knaben fallback |
+| t→M after login | baibako, animelayer, anifilm, toloka, lostfilm, megapeer, viruseproject, bitru, knaben fallback |
+| t→M anon | anistar (`gettorrent.php` on v30) |
 | Magnet HTML/API | rutor, nnmclub, torrentby, rutracker, korsars, selezen, anidub, aniliberty, leproduction, ultradox (detail), kinozal (hash→magnet), subsplease (`xl=`) |
 
 ## Per-slug one-liners
@@ -51,7 +52,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 - **rudub** — login/cookie · `limit_page` · NoTrk · 1080/2160, cp1251, mirrors
 - **animelayer** — login/cookie · page-range · t→M · re-login on empty
 - **anidub** — anon · page-range 1-based · magnet prefer
-- **anistar** — static CF cookie · `limit_page` cats · t→M · no JacRed Flare
+- **anistar** — anon on `v30.astar.bz` · `limit_page` cats · t→M · no JacRed Flare; `anistar.org` is CF parking
 - **anibelka** — anon only · trio · t→M
 - **aniliberty** — anon · JSON torrents API · magnet
 - **anifilm** — login/CSRF or cookie · cats + `fullparse` · t→M · prefer 1080

--- a/.cursor/skills/jacred-tracker-parser/reference.md
+++ b/.cursor/skills/jacred-tracker-parser/reference.md
@@ -17,7 +17,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 | Auth | Slugs | Gotcha |
 |------|-------|--------|
 | CF + FlareSolverr | rutracker | Warmup ~5m before parse; not for Anistar |
-| Public anon HTML | anistar (`v30.astar.bz`) | Brand `anistar.org` is CF 403; cookie optional on v30 |
+| Public anon HTML | anistar (`host` + `alias`) | FDB on `host`; fetch via `alias` mirror |
 | Login and/or cookie | kinozal, baibako, rudub, animelayer, anifilm, korsars (`bb_data`), selezen, toloka, mazepa, lostfilm | Prefer config cookie when set |
 | Anon only | anibelka | Never login — passkeys in torrents |
 | Anon + Referer trick | ultradox | google/yandex Referer; own origin → 503 |
@@ -52,7 +52,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 - **rudub** — login/cookie · `limit_page` · NoTrk · 1080/2160, cp1251, mirrors
 - **animelayer** — login/cookie · page-range · t→M · re-login on empty
 - **anidub** — anon · page-range 1-based · magnet prefer
-- **anistar** — anon on `v30.astar.bz` · `limit_page` cats · t→M · no JacRed Flare; `anistar.org` is CF parking
+- **anistar** — `host`/`alias` · `limit_page` cats · t→M · FDB on brand host, fetch on mirror
 - **anibelka** — anon only · trio · t→M
 - **aniliberty** — anon · JSON torrents API · magnet
 - **anifilm** — login/CSRF or cookie · cats + `fullparse` · t→M · prefer 1080

--- a/Configuration/AppOptions.cs
+++ b/Configuration/AppOptions.cs
@@ -144,7 +144,7 @@ namespace JacRed.Configuration
 
         public TrackerSettings Anidub = new TrackerSettings("https://tr.anidub.com");
 
-        public TrackerSettings Anistar = new TrackerSettings("https://v30.astar.bz");
+        public TrackerSettings Anistar = new TrackerSettings("https://anistar.org");
 
         public TrackerSettings Anibelka = new TrackerSettings("https://anibelka.com");
 

--- a/Configuration/AppOptions.cs
+++ b/Configuration/AppOptions.cs
@@ -144,7 +144,7 @@ namespace JacRed.Configuration
 
         public TrackerSettings Anidub = new TrackerSettings("https://tr.anidub.com");
 
-        public TrackerSettings Anistar = new TrackerSettings("https://anistar.org");
+        public TrackerSettings Anistar = new TrackerSettings("https://v30.astar.bz");
 
         public TrackerSettings Anibelka = new TrackerSettings("https://anibelka.com");
 

--- a/Controllers/Cron/AnistarController.cs
+++ b/Controllers/Cron/AnistarController.cs
@@ -23,6 +23,7 @@ namespace JacRed.Controllers.Cron
         /// "work" if parsing is already in progress,
         /// "canceled" if the operation was canceled,
         /// "config missing" if host is empty,
+        /// "empty" if every list page returned no posts,
         /// "ok" if parsing completed successfully.
         /// </returns>
         [HttpGet]

--- a/Data/crontab
+++ b/Data/crontab
@@ -151,7 +151,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # anidub-parse -> /cron/anidub/parse (max_time=900s)
 4,19,34,49 * * * *  /opt/jacred/Data/run-job.sh anidub-parse http://127.0.0.1:9117/cron/anidub/parse 900
 
-# --- anistar (CF cookie required) ---
+# --- anistar (v30.astar.bz, cookie optional) ---
 # anistar-parse -> /cron/anistar/parse?limit_page=3 (max_time=900s)
 40 6 * * *  /opt/jacred/Data/run-job.sh anistar-parse "http://127.0.0.1:9117/cron/anistar/parse?limit_page=3" 900
 

--- a/Data/crontab
+++ b/Data/crontab
@@ -151,7 +151,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # anidub-parse -> /cron/anidub/parse (max_time=900s)
 4,19,34,49 * * * *  /opt/jacred/Data/run-job.sh anidub-parse http://127.0.0.1:9117/cron/anidub/parse 900
 
-# --- anistar (v30.astar.bz, cookie optional) ---
+# --- anistar (alias = live mirror, host = FDB urls) ---
 # anistar-parse -> /cron/anistar/parse?limit_page=3 (max_time=900s)
 40 6 * * *  /opt/jacred/Data/run-job.sh anistar-parse "http://127.0.0.1:9117/cron/anistar/parse?limit_page=3" 900
 

--- a/Data/example.conf
+++ b/Data/example.conf
@@ -199,7 +199,8 @@
     "log": true
   },
   "Anistar": {
-    "host": "https://v30.astar.bz",
+    "host": "https://anistar.org",
+    "alias": "https://v30.astar.bz",
     "useproxy": false,
     "reqMinute": 8,
     "parseDelay": 7000,

--- a/Data/example.conf
+++ b/Data/example.conf
@@ -199,12 +199,12 @@
     "log": true
   },
   "Anistar": {
-    "host": "https://anistar.org",
+    "host": "https://v30.astar.bz",
     "useproxy": false,
     "reqMinute": 8,
     "parseDelay": 7000,
     "log": true,
-    "cookie": "cf_clearance=example_clearance; PHPSESSID=example_phpsessid"
+    "cookie": ""
   },
   "Anibelka": {
     "host": "https://anibelka.com",

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -239,13 +239,14 @@ Anidub:
   log: true
 
 Anistar:
-  host: https://anistar.org
+  host: https://v30.astar.bz
   useproxy: false
   reqMinute: 8
   parseDelay: 7000
   log: true
-  # CF/session cookie required for live parse (FlareSolverr or browser export).
-  cookie: "cf_clearance=example_clearance; PHPSESSID=example_phpsessid"
+  # Cookie optional on v30.astar.bz (anon). Old brand domain anistar.org is CF-only;
+  # next mirror via alias, e.g. alias: https://v31.astar.bz
+  cookie: ""
 
 # Anonymous only — do not set cookie/login (passkeys must not enter magnets).
 Anibelka:

--- a/Data/example.yaml
+++ b/Data/example.yaml
@@ -239,13 +239,13 @@ Anidub:
   log: true
 
 Anistar:
-  host: https://v30.astar.bz
+  host: https://anistar.org
+  alias: https://v30.astar.bz
   useproxy: false
   reqMinute: 8
   parseDelay: 7000
   log: true
-  # Cookie optional on v30.astar.bz (anon). Old brand domain anistar.org is CF-only;
-  # next mirror via alias, e.g. alias: https://v31.astar.bz
+  # alias = live mirror for fetch; host = canonical FDB urls. Cookie optional on v30.
   cookie: ""
 
 # Anonymous only — do not set cookie/login (passkeys must not enter magnets).

--- a/Data/init.conf
+++ b/Data/init.conf
@@ -106,7 +106,7 @@
     }
   },
   "Anistar": {
-    "host": "https://anistar.org",
+    "host": "https://v30.astar.bz",
     "useproxy": false,
     "reqMinute": 8,
     "parseDelay": 7000,

--- a/Data/init.conf
+++ b/Data/init.conf
@@ -106,7 +106,8 @@
     }
   },
   "Anistar": {
-    "host": "https://v30.astar.bz",
+    "host": "https://anistar.org",
+    "alias": "https://v30.astar.bz",
     "useproxy": false,
     "reqMinute": 8,
     "parseDelay": 7000,

--- a/Data/init.yaml
+++ b/Data/init.yaml
@@ -99,7 +99,8 @@ logging:
     parsers: None
 
 Anistar:
-  host: https://v30.astar.bz
+  host: https://anistar.org
+  alias: https://v30.astar.bz
   useproxy: false
   reqMinute: 8
   parseDelay: 7000

--- a/Data/init.yaml
+++ b/Data/init.yaml
@@ -99,7 +99,7 @@ logging:
     parsers: None
 
 Anistar:
-  host: https://anistar.org
+  host: https://v30.astar.bz
   useproxy: false
   reqMinute: 8
   parseDelay: 7000

--- a/Infrastructure/Trackers/Anistar/AnistarCategories.cs
+++ b/Infrastructure/Trackers/Anistar/AnistarCategories.cs
@@ -8,7 +8,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
     }
 
     /// <summary>
-    /// Single source of truth for anistar.org section paths and JacRed types.
+    /// Single source of truth for Anistar (v30.astar.bz) section paths and JacRed types.
     /// </summary>
     static class AnistarCategories
     {

--- a/Infrastructure/Trackers/Anistar/AnistarParser.cs
+++ b/Infrastructure/Trackers/Anistar/AnistarParser.cs
@@ -39,28 +39,33 @@ namespace JacRed.Infrastructure.Trackers.Anistar
             return maxPage;
         }
 
-        public static List<string> ExtractPostUrls(string listHtml, string host)
+        public static List<string> ExtractPostUrls(string listHtml, string canonHost)
         {
             var outList = new List<string>();
             if (string.IsNullOrWhiteSpace(listHtml))
                 return outList;
 
-            host = (host ?? "").TrimEnd('/');
+            canonHost = (canonHost ?? "").TrimEnd('/');
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (Match m in PostUrlAbsRe.Matches(listHtml))
+            void AddPath(string path)
             {
-                string url = m.Value;
-                if (seen.Add(url))
-                    outList.Add(url);
-            }
-
-            foreach (Match m in PostUrlRelRe.Matches(listHtml))
-            {
-                string abs = host + m.Value;
+                if (string.IsNullOrWhiteSpace(path))
+                    return;
+                string abs = canonHost + path;
                 if (seen.Add(abs))
                     outList.Add(abs);
             }
+
+            foreach (Match m in PostUrlAbsRe.Matches(listHtml))
+            {
+                var pathMatch = PostUrlRelRe.Match(m.Value);
+                if (pathMatch.Success)
+                    AddPath(pathMatch.Value);
+            }
+
+            foreach (Match m in PostUrlRelRe.Matches(listHtml))
+                AddPath(m.Value);
 
             return outList;
         }

--- a/Infrastructure/Trackers/Anistar/AnistarParser.cs
+++ b/Infrastructure/Trackers/Anistar/AnistarParser.cs
@@ -20,8 +20,9 @@ namespace JacRed.Infrastructure.Trackers.Anistar
         static readonly Regex DateRe = new Regex(@"\b(\d{2})-(\d{2})-(\d{4})\b", RegexOptions.Compiled);
         static readonly Regex SidRe = new Regex(@"<div class=""li_distribute"">\s*([0-9]+)\s*</div>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         static readonly Regex PirRe = new Regex(@"<div class=""li_swing"">\s*([0-9]+)\s*</div>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        static readonly Regex RangeRe = new Regex(@"\b(\d{1,4})\s*-\s*(\d{1,4})\b", RegexOptions.Compiled);
-        static readonly Regex SingleNumRe = new Regex(@"\b(\d{1,4})\b", RegexOptions.Compiled);
+        static readonly Regex SeriesRangeRe = new Regex(@"сери[яи]\s+(\d{1,4})\s*-\s*(\d{1,4})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        static readonly Regex SeriesSingleRe = new Regex(@"серия\s+(\d{1,4})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        static readonly Regex FilmRe = new Regex(@"^\s*фильм\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         static readonly Regex CleanSpaceRe = new Regex(@"\s+", RegexOptions.Compiled);
 
         public static int DetectLastPage(string listHtml)
@@ -86,6 +87,30 @@ namespace JacRed.Infrastructure.Trackers.Anistar
             return (name, original);
         }
 
+        /// <summary>
+        /// Episode/film label from <c>info_d1</c>. Does not treat the size number
+        /// in <c>Фильм (3.05 Gb)</c> as an episode.
+        /// </summary>
+        public static (string epLabel, string epNum) ParseEpisodeLabel(string info)
+        {
+            if (string.IsNullOrWhiteSpace(info))
+                return ("Серия 1", "1");
+
+            info = info.Trim();
+            var rangeMatch = SeriesRangeRe.Match(info);
+            if (rangeMatch.Success)
+                return ($"Серии {rangeMatch.Groups[1].Value}-{rangeMatch.Groups[2].Value}", rangeMatch.Groups[1].Value);
+
+            var singleMatch = SeriesSingleRe.Match(info);
+            if (singleMatch.Success)
+                return ("Серия " + singleMatch.Groups[1].Value, singleMatch.Groups[1].Value);
+
+            if (FilmRe.IsMatch(info))
+                return ("Фильм", "film");
+
+            return ("Серия 1", "1");
+        }
+
         public static List<AnistarDetails> ParseDetailTorrents(string postHtml, string postUrl, string[] types)
         {
             var torrents = new List<AnistarDetails>();
@@ -114,24 +139,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 string epNum = "1";
                 var infoMatch = InfoD1Re.Match(around);
                 if (infoMatch.Success)
-                {
-                    string info = HttpUtility.HtmlDecode(infoMatch.Groups[1].Value).Trim();
-                    var rangeMatch = RangeRe.Match(info);
-                    if (rangeMatch.Success)
-                    {
-                        epLabel = $"Серии {rangeMatch.Groups[1].Value}-{rangeMatch.Groups[2].Value}";
-                        epNum = rangeMatch.Groups[1].Value;
-                    }
-                    else
-                    {
-                        var singleMatch = SingleNumRe.Match(info);
-                        if (singleMatch.Success)
-                        {
-                            epNum = singleMatch.Groups[1].Value;
-                            epLabel = "Серия " + epNum;
-                        }
-                    }
-                }
+                    (epLabel, epNum) = ParseEpisodeLabel(HttpUtility.HtmlDecode(infoMatch.Groups[1].Value));
 
                 DateTime createTime = DateTime.UtcNow;
                 int relased = createTime.Year;

--- a/Infrastructure/Trackers/Anistar/AnistarSyncService.cs
+++ b/Infrastructure/Trackers/Anistar/AnistarSyncService.cs
@@ -19,6 +19,11 @@ namespace JacRed.Infrastructure.Trackers.Anistar
 
         static readonly TrackerParseLock _parseLock = new TrackerParseLock();
 
+        static string RequestHost() => (AppInit.conf.Anistar?.rqHost() ?? "").TrimEnd('/');
+
+        static string CookieOrNull()
+            => string.IsNullOrWhiteSpace(AppInit.conf.Anistar?.cookie) ? null : AppInit.conf.Anistar.cookie;
+
         public async Task<string> ParseAsync(int limitPage = 0)
         {
             return await TrackerSyncHelpers.RunParseAsync(TrackerName, _parseLock, checkDisabled: false, async () =>
@@ -26,20 +31,25 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 try
                 {
                     var sw = Stopwatch.StartNew();
-                    string host = (AppInit.conf.Anistar.host ?? "").TrimEnd('/');
+                    string host = RequestHost();
                     if (string.IsNullOrWhiteSpace(host))
                     {
                         ParserLog.Write(TrackerName, "Config missing", new Dictionary<string, object> { { "reason", "empty host" } });
                         return "config missing";
                     }
 
+                    string cookie = CookieOrNull();
+                    bool cookieSet = cookie != null;
+
                     ParserLog.Write(TrackerName, "Starting parse", new Dictionary<string, object>
                     {
                         { "limitPage", limitPage },
-                        { "host", host }
+                        { "host", host },
+                        { "cookieSet", cookieSet }
                     });
 
                     int totalFetched = 0, totalAdded = 0, totalUpdated = 0, totalSkipped = 0, totalFailed = 0;
+                    int emptyPages = 0;
 
                     foreach (var kv in AnistarCategories.Map)
                     {
@@ -48,7 +58,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                         int lastPage = limitPage;
                         if (lastPage <= 0)
                         {
-                            string firstHtml = await HttpClient.Get($"{host}/{catPath}/", encoding: PageEncoding, cookie: AppInit.conf.Anistar.cookie, useproxy: AppInit.conf.Anistar.useproxy);
+                            string firstHtml = await HttpClient.Get($"{host}/{catPath}/", encoding: PageEncoding, cookie: cookie, useproxy: AppInit.conf.Anistar.useproxy);
                             lastPage = AnistarParser.DetectLastPage(firstHtml);
                         }
 
@@ -58,24 +68,25 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                                 ? $"{host}/{catPath}/"
                                 : $"{host}/{catPath}/page/{page}/";
 
-                            if (page > 1 || catPath != "anime")
-                                ParserLog.Write(TrackerName, "Parsing list page", new Dictionary<string, object>
-                                {
-                                    { "category", catPath },
-                                    { "page", page },
-                                    { "url", listUrl }
-                                });
+                            ParserLog.Write(TrackerName, "Parsing list page", new Dictionary<string, object>
+                            {
+                                { "category", catPath },
+                                { "page", page },
+                                { "url", listUrl }
+                            });
 
-                            string listHtml = await HttpClient.Get(listUrl, encoding: PageEncoding, cookie: AppInit.conf.Anistar.cookie, referer: host + "/", useproxy: AppInit.conf.Anistar.useproxy);
-                            if (string.IsNullOrEmpty(listHtml))
+                            string listHtml = await HttpClient.Get(listUrl, encoding: PageEncoding, cookie: cookie, referer: host + "/", useproxy: AppInit.conf.Anistar.useproxy);
+                            if (!TryUseListHtml(listHtml, listUrl, catPath, page, cookieSet, out var postUrls))
+                            {
+                                emptyPages++;
                                 continue;
+                            }
 
-                            var postUrls = AnistarParser.ExtractPostUrls(listHtml, host);
                             totalFetched += postUrls.Count;
 
                             foreach (string postUrl in postUrls)
                             {
-                                var (added, updated, skipped, failed) = await ParseDetailAndSave(postUrl, listUrl, host, types);
+                                var (added, updated, skipped, failed) = await ParseDetailAndSave(postUrl, listUrl, host, types, cookie, cookieSet);
                                 totalAdded += added;
                                 totalUpdated += updated;
                                 totalSkipped += skipped;
@@ -87,15 +98,21 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                         }
                     }
 
-                    ParserLog.Write(TrackerName, $"Parse completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)",
+                    bool noResults = totalFetched == 0;
+                    ParserLog.Write(TrackerName, noResults
+                            ? $"Parse completed with no results (took {sw.Elapsed.TotalSeconds:F1}s)"
+                            : $"Parse completed successfully (took {sw.Elapsed.TotalSeconds:F1}s)",
                         new Dictionary<string, object>
                         {
                             { "fetched", totalFetched },
                             { "added", totalAdded },
                             { "updated", totalUpdated },
                             { "skipped", totalSkipped },
-                            { "failed", totalFailed }
+                            { "failed", totalFailed },
+                            { "emptyPages", emptyPages }
                         });
+
+                    return noResults ? "empty" : "ok";
                 }
                 catch (OperationCanceledException oce)
                 {
@@ -122,15 +139,80 @@ namespace JacRed.Infrastructure.Trackers.Anistar
             });
         }
 
-        async Task<(int added, int updated, int skipped, int failed)> ParseDetailAndSave(string postUrl, string referer, string host, string[] types)
+        static bool TryUseListHtml(string listHtml, string listUrl, string catPath, int page, bool cookieSet, out List<string> postUrls)
         {
-            string postHtml = await HttpClient.Get(postUrl, encoding: PageEncoding, cookie: AppInit.conf.Anistar.cookie, referer: referer, useproxy: AppInit.conf.Anistar.useproxy);
-            if (string.IsNullOrEmpty(postHtml))
-                return (0, 0, 0, 0);
+            postUrls = null;
+            if (string.IsNullOrEmpty(listHtml))
+            {
+                ParserLog.Write(TrackerName, "Page fetch failed", new Dictionary<string, object>
+                {
+                    { "category", catPath },
+                    { "page", page },
+                    { "url", listUrl },
+                    { "htmlLength", 0 },
+                    { "cookieSet", cookieSet },
+                    { "reason", "null response" }
+                });
+                return false;
+            }
+
+            if (CloudflareClearance.IsChallengeBody(listHtml))
+            {
+                ParserLog.Write(TrackerName, "Page fetch failed", new Dictionary<string, object>
+                {
+                    { "category", catPath },
+                    { "page", page },
+                    { "url", listUrl },
+                    { "htmlLength", listHtml.Length },
+                    { "cookieSet", cookieSet },
+                    { "reason", "cloudflare challenge" }
+                });
+                return false;
+            }
+
+            postUrls = AnistarParser.ExtractPostUrls(listHtml, RequestHost());
+            if (postUrls.Count == 0)
+            {
+                ParserLog.Write(TrackerName, "No posts extracted", new Dictionary<string, object>
+                {
+                    { "category", catPath },
+                    { "page", page },
+                    { "url", listUrl },
+                    { "htmlLength", listHtml.Length },
+                    { "cookieSet", cookieSet },
+                    { "hasDleContent", listHtml.IndexOf("dle-content", StringComparison.OrdinalIgnoreCase) >= 0 }
+                });
+                return false;
+            }
+
+            return true;
+        }
+
+        async Task<(int added, int updated, int skipped, int failed)> ParseDetailAndSave(string postUrl, string referer, string host, string[] types, string cookie, bool cookieSet)
+        {
+            string postHtml = await HttpClient.Get(postUrl, encoding: PageEncoding, cookie: cookie, referer: referer, useproxy: AppInit.conf.Anistar.useproxy);
+            if (string.IsNullOrEmpty(postHtml) || CloudflareClearance.IsChallengeBody(postHtml))
+            {
+                ParserLog.Write(TrackerName, "Detail fetch failed", new Dictionary<string, object>
+                {
+                    { "url", postUrl },
+                    { "htmlLength", postHtml?.Length ?? 0 },
+                    { "cookieSet", cookieSet },
+                    { "reason", string.IsNullOrEmpty(postHtml) ? "null response" : "cloudflare challenge" }
+                });
+                return (0, 0, 0, 1);
+            }
 
             var torrents = AnistarParser.ParseDetailTorrents(postHtml, postUrl, types);
             if (torrents.Count == 0)
+            {
+                ParserLog.Write(TrackerName, "No torrents extracted", new Dictionary<string, object>
+                {
+                    { "url", postUrl },
+                    { "htmlLength", postHtml.Length }
+                });
                 return (0, 0, 0, 0);
+            }
 
             int addedCount = 0, updatedCount = 0, skippedCount = 0, failedCount = 0;
 
@@ -152,7 +234,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 if (!string.IsNullOrWhiteSpace(t.downloadId))
                 {
                     string downUrl = $"{host}/engine/gettorrent.php?id={t.downloadId}";
-                    byte[] torrentFile = await HttpClient.Download(downUrl, cookie: AppInit.conf.Anistar.cookie, referer: host, useproxy: AppInit.conf.Anistar.useproxy);
+                    byte[] torrentFile = await HttpClient.Download(downUrl, cookie: cookie, referer: host, useproxy: AppInit.conf.Anistar.useproxy);
                     if (torrentFile != null && torrentFile.Length > 0)
                     {
                         string magnet = BencodeTo.Magnet(torrentFile);

--- a/Infrastructure/Trackers/Anistar/AnistarSyncService.cs
+++ b/Infrastructure/Trackers/Anistar/AnistarSyncService.cs
@@ -11,6 +11,9 @@ using JacRed.Models.Details;
 
 namespace JacRed.Infrastructure.Trackers.Anistar
 {
+    /// <summary>
+    /// Requests use <c>alias</c> (rqHost); FDB urls stay on <c>host</c>.
+    /// </summary>
     public class AnistarSyncService
     {
         const string TrackerName = "anistar";
@@ -19,7 +22,14 @@ namespace JacRed.Infrastructure.Trackers.Anistar
 
         static readonly TrackerParseLock _parseLock = new TrackerParseLock();
 
+        /// <summary>Canonical host stored in FDB urls.</summary>
+        static string CanonicalHost() => (AppInit.conf.Anistar?.host ?? "").TrimEnd('/');
+
+        /// <summary>Request host — alias when set.</summary>
         static string RequestHost() => (AppInit.conf.Anistar?.rqHost() ?? "").TrimEnd('/');
+
+        static string FetchUrl(string canonUrl)
+            => AppInit.conf.Anistar?.rqHost(canonUrl) ?? canonUrl;
 
         static string CookieOrNull()
             => string.IsNullOrWhiteSpace(AppInit.conf.Anistar?.cookie) ? null : AppInit.conf.Anistar.cookie;
@@ -31,10 +41,14 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 try
                 {
                     var sw = Stopwatch.StartNew();
-                    string host = RequestHost();
-                    if (string.IsNullOrWhiteSpace(host))
+                    string rqHost = RequestHost();
+                    string canonHost = CanonicalHost();
+                    if (string.IsNullOrWhiteSpace(rqHost) || string.IsNullOrWhiteSpace(canonHost))
                     {
-                        ParserLog.Write(TrackerName, "Config missing", new Dictionary<string, object> { { "reason", "empty host" } });
+                        ParserLog.Write(TrackerName, "Config missing", new Dictionary<string, object>
+                        {
+                            { "reason", string.IsNullOrWhiteSpace(canonHost) ? "empty host" : "empty request host" }
+                        });
                         return "config missing";
                     }
 
@@ -44,7 +58,8 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                     ParserLog.Write(TrackerName, "Starting parse", new Dictionary<string, object>
                     {
                         { "limitPage", limitPage },
-                        { "host", host },
+                        { "host", canonHost },
+                        { "rqHost", rqHost },
                         { "cookieSet", cookieSet }
                     });
 
@@ -58,15 +73,15 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                         int lastPage = limitPage;
                         if (lastPage <= 0)
                         {
-                            string firstHtml = await HttpClient.Get($"{host}/{catPath}/", encoding: PageEncoding, cookie: cookie, useproxy: AppInit.conf.Anistar.useproxy);
+                            string firstHtml = await HttpClient.Get($"{rqHost}/{catPath}/", encoding: PageEncoding, cookie: cookie, useproxy: AppInit.conf.Anistar.useproxy);
                             lastPage = AnistarParser.DetectLastPage(firstHtml);
                         }
 
                         for (int page = 1; page <= lastPage; page++)
                         {
                             string listUrl = page <= 1
-                                ? $"{host}/{catPath}/"
-                                : $"{host}/{catPath}/page/{page}/";
+                                ? $"{rqHost}/{catPath}/"
+                                : $"{rqHost}/{catPath}/page/{page}/";
 
                             ParserLog.Write(TrackerName, "Parsing list page", new Dictionary<string, object>
                             {
@@ -75,8 +90,8 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                                 { "url", listUrl }
                             });
 
-                            string listHtml = await HttpClient.Get(listUrl, encoding: PageEncoding, cookie: cookie, referer: host + "/", useproxy: AppInit.conf.Anistar.useproxy);
-                            if (!TryUseListHtml(listHtml, listUrl, catPath, page, cookieSet, out var postUrls))
+                            string listHtml = await HttpClient.Get(listUrl, encoding: PageEncoding, cookie: cookie, referer: rqHost + "/", useproxy: AppInit.conf.Anistar.useproxy);
+                            if (!TryUseListHtml(listHtml, listUrl, catPath, page, canonHost, cookieSet, out var postUrls))
                             {
                                 emptyPages++;
                                 continue;
@@ -84,9 +99,9 @@ namespace JacRed.Infrastructure.Trackers.Anistar
 
                             totalFetched += postUrls.Count;
 
-                            foreach (string postUrl in postUrls)
+                            foreach (string canonPostUrl in postUrls)
                             {
-                                var (added, updated, skipped, failed) = await ParseDetailAndSave(postUrl, listUrl, host, types, cookie, cookieSet);
+                                var (added, updated, skipped, failed) = await ParseDetailAndSave(canonPostUrl, listUrl, rqHost, types, cookie, cookieSet);
                                 totalAdded += added;
                                 totalUpdated += updated;
                                 totalSkipped += skipped;
@@ -139,7 +154,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
             });
         }
 
-        static bool TryUseListHtml(string listHtml, string listUrl, string catPath, int page, bool cookieSet, out List<string> postUrls)
+        static bool TryUseListHtml(string listHtml, string listUrl, string catPath, int page, string canonHost, bool cookieSet, out List<string> postUrls)
         {
             postUrls = null;
             if (string.IsNullOrEmpty(listHtml))
@@ -170,7 +185,7 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 return false;
             }
 
-            postUrls = AnistarParser.ExtractPostUrls(listHtml, RequestHost());
+            postUrls = AnistarParser.ExtractPostUrls(listHtml, canonHost);
             if (postUrls.Count == 0)
             {
                 ParserLog.Write(TrackerName, "No posts extracted", new Dictionary<string, object>
@@ -188,14 +203,16 @@ namespace JacRed.Infrastructure.Trackers.Anistar
             return true;
         }
 
-        async Task<(int added, int updated, int skipped, int failed)> ParseDetailAndSave(string postUrl, string referer, string host, string[] types, string cookie, bool cookieSet)
+        async Task<(int added, int updated, int skipped, int failed)> ParseDetailAndSave(string canonPostUrl, string referer, string rqHost, string[] types, string cookie, bool cookieSet)
         {
-            string postHtml = await HttpClient.Get(postUrl, encoding: PageEncoding, cookie: cookie, referer: referer, useproxy: AppInit.conf.Anistar.useproxy);
+            string fetchPostUrl = FetchUrl(canonPostUrl);
+            string postHtml = await HttpClient.Get(fetchPostUrl, encoding: PageEncoding, cookie: cookie, referer: referer, useproxy: AppInit.conf.Anistar.useproxy);
             if (string.IsNullOrEmpty(postHtml) || CloudflareClearance.IsChallengeBody(postHtml))
             {
                 ParserLog.Write(TrackerName, "Detail fetch failed", new Dictionary<string, object>
                 {
-                    { "url", postUrl },
+                    { "url", fetchPostUrl },
+                    { "canonUrl", canonPostUrl },
                     { "htmlLength", postHtml?.Length ?? 0 },
                     { "cookieSet", cookieSet },
                     { "reason", string.IsNullOrEmpty(postHtml) ? "null response" : "cloudflare challenge" }
@@ -203,12 +220,13 @@ namespace JacRed.Infrastructure.Trackers.Anistar
                 return (0, 0, 0, 1);
             }
 
-            var torrents = AnistarParser.ParseDetailTorrents(postHtml, postUrl, types);
+            var torrents = AnistarParser.ParseDetailTorrents(postHtml, canonPostUrl, types);
             if (torrents.Count == 0)
             {
                 ParserLog.Write(TrackerName, "No torrents extracted", new Dictionary<string, object>
                 {
-                    { "url", postUrl },
+                    { "url", fetchPostUrl },
+                    { "canonUrl", canonPostUrl },
                     { "htmlLength", postHtml.Length }
                 });
                 return (0, 0, 0, 0);
@@ -233,8 +251,8 @@ namespace JacRed.Infrastructure.Trackers.Anistar
 
                 if (!string.IsNullOrWhiteSpace(t.downloadId))
                 {
-                    string downUrl = $"{host}/engine/gettorrent.php?id={t.downloadId}";
-                    byte[] torrentFile = await HttpClient.Download(downUrl, cookie: cookie, referer: host, useproxy: AppInit.conf.Anistar.useproxy);
+                    string downUrl = $"{rqHost}/engine/gettorrent.php?id={t.downloadId}";
+                    byte[] torrentFile = await HttpClient.Download(downUrl, cookie: cookie, referer: rqHost, useproxy: AppInit.conf.Anistar.useproxy);
                     if (torrentFile != null && torrentFile.Length > 0)
                     {
                         string magnet = BencodeTo.Magnet(torrentFile);

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,7 +175,7 @@ curl -s 'http://127.0.0.1:9117/dev/ExportTracksStatus'
 
 | Трекер | Типичные действия | Расписание в примере crontab |
 | --- | --- | --- |
-| **anistar** | `parse?limit_page=3` (нужна cookie) | daily `40 6` |
+| **anistar** | `parse?limit_page=3` (host `v30.astar.bz`) | daily `40 6` |
 | **leproduction** | `parse?limit_page=3` | daily `45 6` |
 | **viruseproject** | `parse?limit_page=3` | daily `50 6` |
 | **anifilm** | `parse` (login/cookie; max_time 1800s) | daily `55 6` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,7 +175,7 @@ curl -s 'http://127.0.0.1:9117/dev/ExportTracksStatus'
 
 | Трекер | Типичные действия | Расписание в примере crontab |
 | --- | --- | --- |
-| **anistar** | `parse?limit_page=3` (host `v30.astar.bz`) | daily `40 6` |
+| **anistar** | `parse?limit_page=3` (`alias` = live mirror) | daily `40 6` |
 | **leproduction** | `parse?limit_page=3` | daily `45 6` |
 | **viruseproject** | `parse?limit_page=3` | daily `50 6` |
 | **anifilm** | `parse` (login/cookie; max_time 1800s) | daily `55 6` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ journalctl -u jacred -g 'fdb:' -p warning
 | --- | --- |
 | **Korsars** | `login.u` / `login.p` **или** статическая cookie с `bb_data` (если задана cookie — логин не обязателен) |
 | **Anifilm** | `login` **или** session cookie (например `XSRF-TOKEN` + session) |
-| **Anistar** | Текущий origin — `https://v30.astar.bz` (анонимно, cookie не нужна). Старый бренд `anistar.org` отдаёт Cloudflare 403 без редиректа. Следующее зеркало — `alias`. **Не** использует блок `flaresolverr` / `/cron/cloudflare/Warmup` как Rutracker |
+| **Anistar** | `host` — canonical FDB urls (`anistar.org`); `alias` — live mirror for fetch (`v30.astar.bz`, update when site rotates). Cookie optional on alias. **Не** использует FlareSolverr Warmup |
 | **Anibelka** | Только анонимно — **не** задавайте `cookie` / `login` (в раздачах есть passkey) |
 | **SubsPlease** | Только анонимно — JSON API; 1080p magnets only; Batches via `ParseShows` |
 | **RuDub** | `login` **или** cookie (`PHPSESSID` / `uid` / `pass`); парсит только HD 1080 / HD 2160; зеркала `rN.rudub.world` через `host`/`alias` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ journalctl -u jacred -g 'fdb:' -p warning
 | --- | --- |
 | **Korsars** | `login.u` / `login.p` **или** статическая cookie с `bb_data` (если задана cookie — логин не обязателен) |
 | **Anifilm** | `login` **или** session cookie (например `XSRF-TOKEN` + session) |
-| **Anistar** | Статическая cookie (`cf_clearance` + session) обязательна для live-парса; получить экспортом из браузера или через FlareSolverr вручную. **Не** использует блок `flaresolverr` / `/cron/cloudflare/Warmup` как Rutracker |
+| **Anistar** | Текущий origin — `https://v30.astar.bz` (анонимно, cookie не нужна). Старый бренд `anistar.org` отдаёт Cloudflare 403 без редиректа. Следующее зеркало — `alias`. **Не** использует блок `flaresolverr` / `/cron/cloudflare/Warmup` как Rutracker |
 | **Anibelka** | Только анонимно — **не** задавайте `cookie` / `login` (в раздачах есть passkey) |
 | **SubsPlease** | Только анонимно — JSON API; 1080p magnets only; Batches via `ParseShows` |
 | **RuDub** | `login` **или** cookie (`PHPSESSID` / `uid` / `pass`); парсит только HD 1080 / HD 2160; зеркала `rN.rudub.world` через `host`/`alias` |

--- a/docs/trackers-and-parsing.md
+++ b/docs/trackers-and-parsing.md
@@ -32,7 +32,7 @@ tags:
    - Добавьте slug’и в **`synctrackers`**, если хотите видеть их в `GET /api/v1.0/trackers` и sync-фильтре.
    - Настройте прокси, если требуется доступ к .onion доменам.
    - **Rutracker / Cloudflare:** блок **`flaresolverr`** + на VPS egress через **WARP SOCKS** (`PROXY_URL` у контейнера FlareSolverr, volume для `/var/lib/cloudflare-warp`). Cookie `cf_clearance` живёт в persistent-сессии FlareSolverr — держите `sessionIdleMinutes` и keep-alive Warmup. `network_mode: host` сам IP не меняет. Альтернатива без FlareSolverr — Worker **`Rutracker.alias`**. Подробности: [`Infrastructure/Trackers/Rutracker/README.md`](https://github.com/jacred-fdb/jacred/blob/main/Infrastructure/Trackers/Rutracker/README.md).
-   - **Anistar:** задайте cookie в конфиге; встроенный FlareSolverr-warmup Rutracker на Anistar не действует.
+   - **Anistar:** `host: https://v30.astar.bz` (анонимно). Не указывайте `anistar.org` — там Cloudflare 403. Встроенный FlareSolverr-warmup Rutracker на Anistar не действует.
 
 2. Выберите режим работы:
    - **Парсинг через cron:** По умолчанию база скачивается при установке, парсинг выполняется по расписанию из [`Data/crontab`](https://github.com/jacred-fdb/jacred/blob/main/Data/crontab) (включая `cloudflare-warmup` за ~5 мин до `rutracker-parse`, daily page-парсеры и hourly Rutor-style для anibelka/korsars/ultradox/rudub/subsplease). Активируйте: `crontab /opt/jacred/Data/crontab`

--- a/docs/trackers-and-parsing.md
+++ b/docs/trackers-and-parsing.md
@@ -32,7 +32,7 @@ tags:
    - Добавьте slug’и в **`synctrackers`**, если хотите видеть их в `GET /api/v1.0/trackers` и sync-фильтре.
    - Настройте прокси, если требуется доступ к .onion доменам.
    - **Rutracker / Cloudflare:** блок **`flaresolverr`** + на VPS egress через **WARP SOCKS** (`PROXY_URL` у контейнера FlareSolverr, volume для `/var/lib/cloudflare-warp`). Cookie `cf_clearance` живёт в persistent-сессии FlareSolverr — держите `sessionIdleMinutes` и keep-alive Warmup. `network_mode: host` сам IP не меняет. Альтернатива без FlareSolverr — Worker **`Rutracker.alias`**. Подробности: [`Infrastructure/Trackers/Rutracker/README.md`](https://github.com/jacred-fdb/jacred/blob/main/Infrastructure/Trackers/Rutracker/README.md).
-   - **Anistar:** `host: https://v30.astar.bz` (анонимно). Не указывайте `anistar.org` — там Cloudflare 403. Встроенный FlareSolverr-warmup Rutracker на Anistar не действует.
+   - **Anistar:** `host: https://anistar.org` (FDB urls), `alias: https://v30.astar.bz` (fetch). При смене зеркала меняйте только `alias`. FlareSolverr-warmup Rutracker не используется.
 
 2. Выберите режим работы:
    - **Парсинг через cron:** По умолчанию база скачивается при установке, парсинг выполняется по расписанию из [`Data/crontab`](https://github.com/jacred-fdb/jacred/blob/main/Data/crontab) (включая `cloudflare-warmup` за ~5 мин до `rutracker-parse`, daily page-парсеры и hourly Rutor-style для anibelka/korsars/ultradox/rudub/subsplease). Активируйте: `crontab /opt/jacred/Data/crontab`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,7 +25,7 @@ tags:
     - Убедитесь, что трекер доступен и учётные данные верны
     - **Конфиг не подхватывается:** рабочий файл — `./init.yaml` (CWD рядом с бинарником); правка только `Data/init.yaml` без копии/symlink в корень не применяется
     - **Korsars:** в логе `login.u empty` / `login failed` — задайте `Korsars.login` или `cookie` с `bb_data` в корневом `init.yaml`
-    - **Anistar:** пустой parse при 403/CF — нужна cookie; встроенный Rutracker Warmup не помогает
+    - **Anistar:** пустой parse за 0s / `empty` — проверьте `Anistar.host` (должен быть `https://v30.astar.bz`, не `anistar.org`). Бренд-домен за Cloudflare 403; встроенный Rutracker Warmup не помогает. В логе ищите `Page fetch failed` / `reason: null response` или `cloudflare challenge`
     - **Anibelka:** не логиньтесь — анонимный download
     - **Rutracker / Cloudflare:** проверьте, что FlareSolverr доступен (`curl http://127.0.0.1:8191/` или `http://flaresolverr:8191/` в compose), в конфиге `flaresolverr.enable: true` и верный `url`, и что срабатывает warmup: `curl http://127.0.0.1:9117/cron/cloudflare/Warmup` (первый ответ может занять до ~180 с). Если на VPS challenge детектится, но не решается — задайте residential/ISP `PROXY_*` у контейнера FlareSolverr (см. playbook в [Rutracker README](https://github.com/jacred-fdb/jacred/blob/main/Infrastructure/Trackers/Rutracker/README.md)). Smoke: [`./scripts/cron_rutracker_smoke.sh`](https://github.com/jacred-fdb/jacred/blob/main/scripts/cron_rutracker_smoke.sh)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,7 +25,7 @@ tags:
     - Убедитесь, что трекер доступен и учётные данные верны
     - **Конфиг не подхватывается:** рабочий файл — `./init.yaml` (CWD рядом с бинарником); правка только `Data/init.yaml` без копии/symlink в корень не применяется
     - **Korsars:** в логе `login.u empty` / `login failed` — задайте `Korsars.login` или `cookie` с `bb_data` в корневом `init.yaml`
-    - **Anistar:** пустой parse за 0s / `empty` — проверьте `Anistar.host` (должен быть `https://v30.astar.bz`, не `anistar.org`). Бренд-домен за Cloudflare 403; встроенный Rutracker Warmup не помогает. В логе ищите `Page fetch failed` / `reason: null response` или `cloudflare challenge`
+    - **Anistar:** пустой parse / `empty` — проверьте `Anistar.alias` (должен быть рабочее зеркало, напр. `https://v30.astar.bz`). `host` только для FDB-ссылок, через него не ходим. В логе: `Page fetch failed` / `rqHost`
     - **Anibelka:** не логиньтесь — анонимный download
     - **Rutracker / Cloudflare:** проверьте, что FlareSolverr доступен (`curl http://127.0.0.1:8191/` или `http://flaresolverr:8191/` в compose), в конфиге `flaresolverr.enable: true` и верный `url`, и что срабатывает warmup: `curl http://127.0.0.1:9117/cron/cloudflare/Warmup` (первый ответ может занять до ~180 с). Если на VPS challenge детектится, но не решается — задайте residential/ISP `PROXY_*` у контейнера FlareSolverr (см. playbook в [Rutracker README](https://github.com/jacred-fdb/jacred/blob/main/Infrastructure/Trackers/Rutracker/README.md)). Smoke: [`./scripts/cron_rutracker_smoke.sh`](https://github.com/jacred-fdb/jacred/blob/main/scripts/cron_rutracker_smoke.sh)
 

--- a/scripts/dry_run_anistar_parser.py
+++ b/scripts/dry_run_anistar_parser.py
@@ -78,9 +78,9 @@ def extract_post_urls(html: str, host: str) -> List[str]:
     return out
 
 
-def score_listing(html: str, host: str) -> Tuple[int, List[str]]:
+def score_listing(html: str, host: str, sample_limit: int = 8) -> Tuple[int, List[str]]:
     urls = extract_post_urls(html, host)
-    return len(urls), urls[:3]
+    return len(urls), urls[:sample_limit]
 
 
 def score_detail(html: str) -> Tuple[int, int, List[str]]:
@@ -107,7 +107,7 @@ def write_synthetic_fixtures(fixture_dir: Path) -> None:
     fixture_dir.mkdir(parents=True, exist_ok=True)
     listing = """<!DOCTYPE html>
 <html><head><title>Anistar anime</title></head><body>
-<a href="https://anistar.org/12-test-show.html">Test Show</a>
+<a href="https://v30.astar.bz/12-test-show.html">Test Show</a>
 <a href="/34-another-anime.html">Another</a>
 <div class="navigation"><a href="/anime/page/2/">2</a><a href="/anime/page/5/">5</a></div>
 </body></html>
@@ -137,7 +137,7 @@ def write_synthetic_fixtures(fixture_dir: Path) -> None:
 
 def main(argv: Optional[List[str]] = None) -> int:
     p = argparse.ArgumentParser(description="Dry-run Anistar HTML vs JacRed parser regexes")
-    p.add_argument("--host", default=os.environ.get("ANISTAR_HOST", "https://anistar.org"))
+    p.add_argument("--host", default=os.environ.get("ANISTAR_HOST", "https://v30.astar.bz"))
     p.add_argument("--cookie", default=os.environ.get("ANISTAR_COOKIE", ""))
     p.add_argument("--refresh-fixtures", action="store_true")
     p.add_argument("--fixture-dir", default=str(DEFAULT_FIXTURE_DIR))
@@ -161,34 +161,43 @@ def main(argv: Optional[List[str]] = None) -> int:
         valid_list = posts > 0
         status = "OK" if valid_list else "FAIL"
         print(f"[{status}] listing {args.category} posts={posts}")
-        for s in samples:
+        for s in samples[:3]:
             print(f"         sample: {s}")
-        report["listing"] = {"posts": posts, "valid": valid_list, "samples": samples}
+        report["listing"] = {"posts": posts, "valid": valid_list, "samples": samples[:3]}
 
         detail_html = ""
-        detail_url = samples[0] if samples else ""
+        detail_url = ""
         blocks = ok = 0
         detail_samples: List[str] = []
+        valid_detail = False
+        for candidate in samples:
+            candidate_html = fetch(candidate, args.cookie)
+            candidate_blocks, candidate_ok, candidate_samples = score_detail(candidate_html)
+            if candidate_blocks <= 0:
+                print(f"[SKIP] detail {candidate} blocks=0 (promo/no torrents)")
+                continue
+            detail_url = candidate
+            detail_html = candidate_html
+            blocks, ok, detail_samples = candidate_blocks, candidate_ok, candidate_samples
+            valid_detail = True
+            break
+
+        rate = round(ok / blocks * 100, 1) if blocks else 0.0
+        status = "OK" if valid_detail else "FAIL"
+        print(f"[{status}] detail blocks={blocks} ok={ok} rate={rate}%")
         if detail_url:
-            detail_html = fetch(detail_url, args.cookie)
-            blocks, ok, detail_samples = score_detail(detail_html)
-            rate = round(ok / blocks * 100, 1) if blocks else 0.0
-            valid_detail = blocks > 0
-            status = "OK" if valid_detail else "FAIL"
-            print(f"[{status}] detail blocks={blocks} ok={ok} rate={rate}%")
-            for s in detail_samples:
-                print(f"         sample: {s}")
-            report["detail"] = {
-                "url": detail_url,
-                "blocks": blocks,
-                "ok": ok,
-                "rate": rate,
-                "valid": valid_detail,
-                "samples": detail_samples,
-            }
-            live_ok = valid_list and valid_detail
-        else:
-            live_ok = False
+            print(f"         url: {detail_url}")
+        for s in detail_samples:
+            print(f"         sample: {s}")
+        report["detail"] = {
+            "url": detail_url,
+            "blocks": blocks,
+            "ok": ok,
+            "rate": rate,
+            "valid": valid_detail,
+            "samples": detail_samples,
+        }
+        live_ok = valid_list and valid_detail
 
         report["live"] = live_ok
 

--- a/tests/JacRed.Tests/Anistar/AnistarParserFixtureTests.cs
+++ b/tests/JacRed.Tests/Anistar/AnistarParserFixtureTests.cs
@@ -13,7 +13,7 @@ namespace JacRed.Tests.Anistar;
 public class AnistarParserFixtureTests
 {
     readonly ITestOutputHelper _output;
-    const string Host = "https://v30.astar.bz";
+    const string CanonHost = "https://anistar.org";
 
     public AnistarParserFixtureTests(ITestOutputHelper output)
     {
@@ -25,7 +25,7 @@ public class AnistarParserFixtureTests
     public void ExtractPostUrls_ListingFixture_YieldsAbsolutePostLinks()
     {
         string html = FixtureLoader.Read("Anistar/listing_anime.html");
-        var urls = AnistarParser.ExtractPostUrls(html, Host);
+        var urls = AnistarParser.ExtractPostUrls(html, CanonHost);
 
         _output.WriteLine($"posts={urls.Count}");
         foreach (var u in urls.Take(3))
@@ -34,10 +34,24 @@ public class AnistarParserFixtureTests
         Assert.True(urls.Count >= 1, $"expected >=1 post urls, got {urls.Count}");
         Assert.All(urls, u =>
         {
-            Assert.StartsWith("http", u, StringComparison.OrdinalIgnoreCase);
+            Assert.StartsWith(CanonHost, u, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(".html", u, StringComparison.OrdinalIgnoreCase);
             Assert.Matches(@"/\d{2,}-", u);
         });
+    }
+
+    [Fact]
+    public void ExtractPostUrls_AbsoluteMirrorLinks_NormalizeToCanonHost()
+    {
+        const string html = """
+            <a href="https://v30.astar.bz/11012-gundam.html">Gundam</a>
+            <a href="/11011-nano.html">Nano</a>
+            """;
+        var urls = AnistarParser.ExtractPostUrls(html, CanonHost);
+
+        Assert.Equal(2, urls.Count);
+        Assert.Contains("https://anistar.org/11012-gundam.html", urls);
+        Assert.Contains("https://anistar.org/11011-nano.html", urls);
     }
 
     [Fact]
@@ -53,7 +67,7 @@ public class AnistarParserFixtureTests
     public void ParseDetailTorrents_DetailFixture_YieldsTypedTorrents()
     {
         string html = FixtureLoader.Read("Anistar/detail_sample.html");
-        string postUrl = "https://v30.astar.bz/12-test-show.html";
+        string postUrl = "https://anistar.org/12-test-show.html";
         var torrents = AnistarParser.ParseDetailTorrents(html, postUrl, new[] { "anime" });
 
         _output.WriteLine($"torrents={torrents.Count}");
@@ -128,7 +142,7 @@ public class AnistarParserFixtureTests
             </div>
             </body></html>
             """;
-        string postUrl = "https://v30.astar.bz/11012-gundam.html";
+        string postUrl = "https://anistar.org/11012-gundam.html";
         var torrents = AnistarParser.ParseDetailTorrents(html, postUrl, new[] { "anime" });
 
         Assert.Single(torrents);
@@ -141,7 +155,7 @@ public class AnistarParserFixtureTests
     [Fact]
     public void ParseDetailTorrents_EmptyHtml_ReturnsEmpty()
     {
-        Assert.Empty(AnistarParser.ParseDetailTorrents("", "https://v30.astar.bz/12-x.html", new[] { "anime" }));
-        Assert.Empty(AnistarParser.ParseDetailTorrents("<html></html>", "https://v30.astar.bz/12-x.html", new[] { "anime" }));
+        Assert.Empty(AnistarParser.ParseDetailTorrents("", "https://anistar.org/12-x.html", new[] { "anime" }));
+        Assert.Empty(AnistarParser.ParseDetailTorrents("<html></html>", "https://anistar.org/12-x.html", new[] { "anime" }));
     }
 }

--- a/tests/JacRed.Tests/Anistar/AnistarParserFixtureTests.cs
+++ b/tests/JacRed.Tests/Anistar/AnistarParserFixtureTests.cs
@@ -13,7 +13,7 @@ namespace JacRed.Tests.Anistar;
 public class AnistarParserFixtureTests
 {
     readonly ITestOutputHelper _output;
-    const string Host = "https://anistar.org";
+    const string Host = "https://v30.astar.bz";
 
     public AnistarParserFixtureTests(ITestOutputHelper output)
     {
@@ -53,7 +53,7 @@ public class AnistarParserFixtureTests
     public void ParseDetailTorrents_DetailFixture_YieldsTypedTorrents()
     {
         string html = FixtureLoader.Read("Anistar/detail_sample.html");
-        string postUrl = "https://anistar.org/12-test-show.html";
+        string postUrl = "https://v30.astar.bz/12-test-show.html";
         var torrents = AnistarParser.ParseDetailTorrents(html, postUrl, new[] { "anime" });
 
         _output.WriteLine($"torrents={torrents.Count}");
@@ -77,7 +77,7 @@ public class AnistarParserFixtureTests
             Assert.True(t.relased >= 1900);
         });
 
-        // Synthetic fixture (live anistar.org returns 403 without cookie) has two blocks.
+        // Synthetic two-block fixture (or captured live HTML).
         if (torrents.Count == 2 && torrents[0].downloadId == "1001")
         {
             Assert.Equal("Тестовое аниме", torrents[0].name);
@@ -99,9 +99,49 @@ public class AnistarParserFixtureTests
     }
 
     [Fact]
+    public void ParseEpisodeLabel_FilmSize_IsNotEpisodeNumber()
+    {
+        var (filmLabel, filmNum) = AnistarParser.ParseEpisodeLabel("Фильм (3.05 Gb)");
+        Assert.Equal("Фильм", filmLabel);
+        Assert.Equal("film", filmNum);
+
+        var (epLabel, epNum) = AnistarParser.ParseEpisodeLabel("Серия 7 (466.54 Mb)");
+        Assert.Equal("Серия 7", epLabel);
+        Assert.Equal("7", epNum);
+
+        var (rangeLabel, rangeNum) = AnistarParser.ParseEpisodeLabel("Серии 1-12");
+        Assert.Equal("Серии 1-12", rangeLabel);
+        Assert.Equal("1", rangeNum);
+    }
+
+    [Fact]
+    public void ParseDetailTorrents_FilmInfoD1_DoesNotUseSizeAsEpisode()
+    {
+        const string html = """
+            <html><body>
+            <h1>Гандам / Gundam</h1>
+            <div id="torrent_46365_info" class="torrent">
+              <div class="info_d1">Фильм (3.05 Gb)</div>
+              <div>18-08-2026</div>
+              <div class="li_distribute">0</div>
+              <div class="li_swing">23</div>
+            </div>
+            </body></html>
+            """;
+        string postUrl = "https://v30.astar.bz/11012-gundam.html";
+        var torrents = AnistarParser.ParseDetailTorrents(html, postUrl, new[] { "anime" });
+
+        Assert.Single(torrents);
+        Assert.Equal("46365", torrents[0].downloadId);
+        Assert.Contains("Фильм", torrents[0].title, StringComparison.Ordinal);
+        Assert.DoesNotContain("Серия 3", torrents[0].title, StringComparison.Ordinal);
+        Assert.EndsWith("?e=film&id=46365", torrents[0].url, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ParseDetailTorrents_EmptyHtml_ReturnsEmpty()
     {
-        Assert.Empty(AnistarParser.ParseDetailTorrents("", "https://anistar.org/12-x.html", new[] { "anime" }));
-        Assert.Empty(AnistarParser.ParseDetailTorrents("<html></html>", "https://anistar.org/12-x.html", new[] { "anime" }));
+        Assert.Empty(AnistarParser.ParseDetailTorrents("", "https://v30.astar.bz/12-x.html", new[] { "anime" }));
+        Assert.Empty(AnistarParser.ParseDetailTorrents("<html></html>", "https://v30.astar.bz/12-x.html", new[] { "anime" }));
     }
 }

--- a/tests/JacRed.Tests/Fixtures/Anistar/detail_sample.html
+++ b/tests/JacRed.Tests/Fixtures/Anistar/detail_sample.html
@@ -1,16 +1,1150 @@
 <!DOCTYPE html>
-<html><head><title>detail</title></head><body>
-<h1>Тестовое аниме / Test Anime</h1>
-<div id="torrent_1001_info" class="torrent">
-  <div class="info_d1">Серия 3</div>
-  <div>12-07-2024</div>
-  <div class="li_distribute">10</div>
-  <div class="li_swing">2</div>
+<html lang="ru" dir="ltr">
+
+<head>
+<meta name="reyden-x" content="53229bea-4fa6-40aa-96dc-c3b87fe20450" />
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, user-scalable=no" />
+<meta name="yandex-verification" content="50449ae2d254adbf" />
+<meta name="robots" content="all" />
+
+<meta name="revisit-after" content="1 days" /> 
+<meta property="og:image" content="/uploads/posters/11012/original.jpg"/>
+<link rel="shortcut icon" href="/favicon.png?r=1" type="image/png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png"/>
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
+<link rel="manifest" href="/manifest.json"/>  
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/font/BebasBold.css"/><link href='https://fonts.googleapis.com/css?family=Roboto+Condensed&amp;subset=latin,cyrillic-ext,cyrillic' rel='stylesheet'  property='stylesheet' type='text/css'>
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/frends.css"/>
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/style.css?rand=18"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/engine.css"/>
+<link href='/templates/new36/theme/jquery-ui.css' rel='stylesheet' type='text/css' />
+<base href="https://v30.astar.bz/11012-mobilnyy-voin-gandam-gquuuuuux-nachalo-kidou-senshi-gundam-gquuuuuux-beginning.html" />
+<link rel="canonical" href="https://v30.astar.bz/11012-mobilnyy-voin-gandam-gquuuuuux-nachalo-kidou-senshi-gundam-gquuuuuux-beginning.html" /> 
+<title>Мобильный воин Гандам: GQuuuuuuX — Начало ,  Kidou Senshi Gundam: GQuuuuuuX - Beginning смотреть онлайн или скачать бесплатно</title>
+<meta http-equiv="Content-Type" content="text/html; charset=Windows-1251" />
+<meta name="Description" content="Амате Юзуриха - ученица старшей школы, мирно живущая в космической колонии, парящей в открытом космосе. Когда она встречает военного беженца по имени Ньяан, Амате оказывается втянутой в неле" />
+<meta name="Keywords" content="Мобильный воин Гандам: GQuuuuuuX — Начало ,  Kidou Senshi Gundam: GQuuuuuuX - Beginning смотреть онлайн или скачать бесплатно" />
+<meta property="og:site_name" content="Anistar - все аниме в одном сайте в режиме онлайн"/>
+<meta property="og:type" content="Movie"/>
+<meta property="og:title" content="Мобильный воин Гандам: GQuuuuuuX — Начало ,  Kidou Senshi Gundam: GQuuuuuuX - Beginning смотреть онлайн или скачать бесплатно"/>
+<meta property="og:url" content="https://v30.astar.bz/11012-mobilnyy-voin-gandam-gquuuuuux-nachalo-kidou-senshi-gundam-gquuuuuux-beginning.html"/>
+<link rel="search" type="application/opensearchdescription+xml" href="https://v30.astar.bz/engine/opensearch.php" title="База №1 по просмотру аниме онлайн бесплатно"/>
+<link rel="alternate" type="application/rss+xml" title="База №1 по просмотру аниме онлайн бесплатно" href="https://v30.astar.bz/rss.xml"/>
+
+<script src="/templates/new36/js/jquery.min.js"></script><script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js"></script><script type="text/javascript" src="/engine/classes/js/jqueryui.js"></script>
+<script type="text/javascript" src="/engine/classes/js/dle_js.js?243566927"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js"></script>
+<link media="screen" href="/engine/editor/css/default.css" type="text/css" rel="stylesheet" />
+<script src='https://www.google.com/recaptcha/api.js'></script>
+
+
+
+<!-- Yandex.RTB -->
+<script>window.yaContextCb=window.yaContextCb||[]</script>
+<script>
+
+		window.addEventListener('load', function() {
+			let YandexRTB_Script=document.createElement('script');
+			YandexRTB_Script.src='https://yandex.ru/ads/system/context.js';
+			document.getElementsByTagName('head')[0].appendChild(YandexRTB_Script);
+		});
+	
+</script>
+
+
+<script type="text/javascript">
+function skinChange(a) {
+	if(a=='new36'){
+		document.querySelector('html').classList.remove('dark-theme');
+	} else{
+		document.querySelector('html').classList.add('dark-theme');
+	}
+	try{
+		if(a=='new36'){
+			localStorage.removeItem('dark-theme');
+		} else{
+			localStorage.setItem("dark-theme",1); 
+		}
+	}catch(e){}
+};
+try{
+	if(localStorage.getItem('dark-theme')!=null) {	
+		skinChange('dark-theme');
+	} else {
+		skinChange('new36');
+	}
+}catch(e){}
+</script>
+
+<!-- Yandex.Metrika counter --> <script type="text/javascript" > (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)}; m[i].l=1*new Date(); for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }} k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)}) (window, document, "script", "https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js", "ym"); ym(15019516, "init", { clickmap:true, trackLinks:true, accurateTrackBounce:true, trackHash:true }); </script> <noscript><div><img src="https://mc.yandex.ru/watch/15019516" style="position:absolute; left:-9999px;" alt="" /></div></noscript> <!-- /Yandex.Metrika counter -->
+
+
+</head>
+
+<script>
+var timeClick=0;
+document.addEventListener("mousedown", function(e) {
+	timeClick=new Date().getTime();
+});
+document.addEventListener("mouseup", function(e) {
+	new Image().src="/themes/timeClick.php?timeClick="+(new Date().getTime() - timeClick);
+});
+sizeWindow=window.outerWidth+"x"+window.outerHeight;
+startMove=0;
+arrayMove=[];
+stopingMove=0;
+if(window.innerWidth<1281){
+	arrayMouseMove=[];
+	document.addEventListener("mousemove", function(e) {
+		arrayMouseMove.push({
+			clientX: e.clientX,
+			clientY: e.clientY,
+			timeStamp: e.timeStamp,
+		});			
+	});
+	setTimeout(function(){		
+		try {
+		  const response = fetch('https://greedseed.world/ping/mouse.php', {
+			method: 'POST',
+			credentials: 'omit',
+			mode: 'no-cors',
+			body: JSON.stringify(arrayMouseMove),
+			headers: {
+			  'Content-Type': 'application/json'
+			}
+		  });
+		} catch (error) {
+		  console.error('Ошибка:', error);
+		}		
+	},120000);
+}
+</script>
+	<header>
+	<div class="width1200">
+		<div class="width50 float-left left1">
+			<div class="logo">
+				<a href="/"><span>Аниме</span></a>
+			</div>
+			
+			<div class="menu">
+				<p><span><button class="menu__handle"><span>Menu</span></button>Смотреть</span></p>
+				<div class="drowmenu">
+					<div class="left-menu">
+						<ul>
+							<li><a href="/">Главная</a></li>
+							<li><a href="/new/">Новинки</a></li>
+							<li><a href="/next/">Скоро</a></li>
+							<li><a href="/raspisanie-vyhoda-seriy-ongoingov.html"><span>Расписание</span></a></li>
+							<li><a href="/news/">Новости</a></li>
+							<li><a href="/?do=chat"><span>Чат</span></a></li>
+							<li><a href="/?action_skin_change=1&skin_name=smartphone">Мобильная версия</a></li> 
+							</ul>
+					</div>
+					<div class="left-menu2">
+						<ul>
+							<li><a href="/anime/">Аниме</a></li>
+							<li><a href="/m/">Манга</a></li>
+							<li><a href="/dorams/">Дорамы</a></li>
+							<li><a href="/kupit-vip.html"><span>VIP</span></a></li>
+							<li><a href="/rules.html">Правила сайта</a></li>
+							<li><a target="_blank" href="https://t.me/anistar_it"><span>Тех. поддержка</span></a></li>
+							<li><a href="/adv.html"><span>Рекламодателю</span></a></li>
+						</ul>
+					</div>
+					
+					
+					
+					<div class="clear clr"></div>
+				</div>
+			</div>
+
+			<ul class="change-color">
+				<li class="is-active" onclick="skinChange('new36');"><span class="fa fa-sun-o"></span></li>
+				<li onclick="skinChange('new36-black');"><span class="fa fa-moon-o"></span></li> 
+			</ul>	
+
+			<script type="text/javascript">
+			jQuery(document).ready(function(){
+				jQuery("header .menu > p").on("click",function(){
+					if ( jQuery("header .menu").hasClass("active") ) {
+						jQuery("header .menu").removeClass("active");
+					} else jQuery("header .menu").addClass("active");
+				});
+				jQuery(".panel").on("click",function(){
+					jQuery(".panel").removeClass("active");
+					if ( jQuery(this).hasClass("active") ) {
+						jQuery(this).removeClass("active");
+					} else jQuery(this).addClass("active");
+				});
+			});
+			</script>
+		</div>
+		<div class="width50 float-right left2">
+		   <div class="panel-right">
+			<div class="panel vk-top">
+				<a href="https://vk.com/anistar_new" rel="nofollow"><span class="icon-top"></span></a>
+				<div class="hidden-panel"></div>
+			</div>
+			
+			<div class=" active panel profile-top">
+				<div class="hidden-panel"><div class="login_nav2">
+			<form method="post" action="">
+						<div>
+						<input type="text" placeholder="Ваш логин" name="login_name" id="login_name" />
+						<input type="password" placeholder="Ваш пароль" name="login_password" id="login_password" />
+						<input name="login" type="hidden" id="login" value="submit" />
+						</div>
+						<div>
+							<input id='ssubmit1' type="submit" value="Войти" />
+						</div>
+						
+						<div>
+							<a href="https://v30.astar.bz/index.php?do=register">Регистрация</a>
+							<a href="https://v30.astar.bz/index.php?do=lostpassword">Забыли пароль?</a>
+						</div>
+			</form>
 </div>
-<div id="torrent_1002_info" class="torrent">
-  <div class="info_d1">Серии 1-12</div>
-  <div>01-01-2023</div>
-  <div class="li_distribute">5</div>
-  <div class="li_swing">1</div>
+
+   
+
+
+
+
 </div>
-</body></html>
+				<span class="icon-top"></span>
+			</div>
+			</div>
+		</div>
+		<div class="clear clr"></div>
+	</div>
+	</header>
+		<div class="clear clr"></div>
+		<div class="clear clr"></div>
+
+
+
+
+<div id="loading-layer" style="display:none">Загрузка. Пожалуйста, подождите...</div>
+<script type="text/javascript">
+<!--
+var dle_root       = '/';
+var dle_admin      = '';
+var dle_login_hash = '';
+var dle_group      = 5;
+var dle_skin       = 'new36';
+var dle_wysiwyg    = '0';
+var quick_wysiwyg  = '1';
+var dle_act_lang   = ["Да", "Нет", "Ввод", "Отмена", "Сохранить", "Удалить"];
+var menu_short     = 'Быстрое редактирование';
+var menu_full      = 'Полное редактирование';
+var menu_profile   = 'Просмотр профиля';
+var menu_send      = 'Отправить сообщение';
+var menu_uedit     = 'Админцентр';
+var dle_info       = 'Информация';
+var dle_confirm    = 'Подтверждение';
+var dle_prompt     = 'Ввод информации';
+var dle_req_field  = 'Заполните все необходимые поля';
+var dle_del_agree  = 'Вы действительно хотите удалить? Данное действие невозможно будет отменить';
+var dle_spam_agree = 'Вы действительно хотите отметить пользователя как спамера? Это приведет к удалению всех его комментариев';
+var dle_complaint  = 'Укажите текст вашей жалобы для администрации:';
+var dle_big_text   = 'Выделен слишком большой участок текста.';
+var dle_orfo_title = 'Укажите комментарий для администрации к найденной ошибке на странице';
+var dle_p_send     = 'Отправить';
+var dle_p_send_ok  = 'Уведомление успешно отправлено';
+var dle_save_ok    = 'Изменения успешно сохранены. Обновить страницу?';
+var dle_del_news   = 'Удалить статью';
+var allow_dle_delete_news   = false;
+var dle_search_delay   = false;
+var dle_search_value   = '';
+$(function(){
+	FastSearch();
+});
+//-->
+</script>
+
+
+
+	
+	
+	
+		<div style="text-align:center;width:100%;overflow:hidden;"><!-- Yandex.RTB R-A-19663890-2 -->
+<div id="yandex_rtb_R-A-19663890-2"></div>
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-2",
+        "renderTo": "yandex_rtb_R-A-19663890-2"
+    })
+})
+</script></div>
+	
+	
+	
+	
+	
+	<div class="clear clr"></div>
+	<div class="main wrapper width1200">
+		<div class='bg-white-main'   >
+		<div class="content-left">
+			<div class="list-nav">
+				<ul><li class="icon-vip"><a href="/kupit-vip.html"><span>VIP</span></a></li><li  class="icon-clock"><a href="/raspisanie-vyhoda-seriy-ongoingov.html"><span>Расписание</span></a></li><li  class="icon-resp"><a href="https://t.me/anistar_it" target="blank_"><span>Тех. поддержка</span></a></li><li  class="icon-chat"><a href="/?do=chat"><span>Чат</span></a></li><li class="icon-copy"><a href="/copyright.html"><span>Правообладателю</span></a></li></ul>
+			</div> 
+			<script>
+				$('#teh_podderjka').click(function(){
+					DLEconfirm('Прежде чем написать, пожалуйста убедитесь, что ответа на ваш вопрос нету в группе. <br /><br /><li><a target="_blank" href="https://t.me/anistar_it" style="color:#4a0074;">Канал тех. поддержки</a><br /><br />Вы не нашли ответа на ваш вопрос?<br /> <br /> Не работает приложение?  <br /> Ответ: <a href="https://vk.com/anistar_it?w=wall-33569294_3912" style="color:#4a0074;">https://vk.com/anistar_it?w=wall-33569294_3912</a>','Сообщение',function(){
+						window.location.href='/index.php?do=send_admin';
+						
+					});
+				});
+			</script>
+			
+			
+			
+			
+			<div class="text-s">
+
+
+
+
+
+</div>
+			
+<div id='dle-content'>
+
+<div class="donat" style="display:none;">
+					
+<div class="title2"><small>Донат на отключение части рекламы на сайте <br/> Всем пользователям</div>
+<div class="plash_polosa">
+	<div class="donat_sbor">Собрано 31 744  из 60 000 рублей</div>
+	<div class="color_polosa">
+	<div style="width:52.90745%">
+	</div>
+	</div>
+</div>
+<div class="donat_text">
+	<span>Дорогие посетители сайта, мы понимаем, что некоторая реклама очень надоедливая, но отключить ее не можем, т.к. не будет хватать денег на оплату серверов и работы команды. Поэтому запускаем сбор средств: суть в том, что сколько денег наберется за весь январь, столько количество рекламы и будет отключено на весь февраль. Для отключения одной рекламы в плеере, например, нужно набрать 60 000, а для отключения рекламы в верху сайта (автоплей) - 90 000!</span>
+</div>
+<div style="text-align:right">
+	<!--<a href="https://vk.com/overlordsdub?w=app5727453_-130145784"><span class="button_c">Ссылочка на донат</span></a>-->
+	
+	<div id="dialog2" style="display:none;">
+		<form method="POST" name="donat" action="/pay/free/donat.php">
+			<div class="donat_message">
+				<p>Сумма (в рублях):<br />
+				<label for="summ"><br />
+					<input type="text" name="summ" id="summ" value='100' />
+				</label>
+				</p>
+				<input type="submit" class="button_c" value="Перейти к оплате"/>
+				
+			</div>
+		</form>
+	</div>
+	<script>
+$(function(){
+	jQuery("#dialog2").dialog({
+		autoOpen: false,
+		modal: true,
+		title: 'Донат на отключение части рекламы на сайте',
+		height: 290,
+		width: 400,
+		open: function(ev, ui){
+				 $('#myIframe').attr('src','http://www.jQuery.com');
+			  }
+	});
+
+	jQuery('#dialogBtn').click(function(){
+		$('#dialog2').dialog('open');
+	});
+});
+	</script>
+	<style>
+	#myIframe{
+	  height: 170px;
+	  width: 350px;
+	  border:none;
+	}
+	</style>
+	<button id="dialogBtn" class="button_c">Донат через Freekassa</button>
+	
+</div>
+
+				</div>
+
+
+<div class="news"  itemscope itemtype="http://schema.org/Article">
+		<div class="news_header">
+		<div class="title_left"><h1 itemprop="name">Мобильный воин Гандам: GQuuuuuuX — Начало / Kidou Senshi Gundam: GQuuuuuuX - Beginning</h1>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/action/">Экшен</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/fantasy/">Фантастика</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">4</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">6</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:40%;">40</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+			
+			
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/11012/original.jpg" alt="Мобильный воин Гандам: GQuuuuuuX — Начало / Kidou Senshi Gundam: GQuuuuuuX - Beginning" class="main-img" />
+
+			<script>
+			var t = 1787043424;
+
+			if(t>0){
+			var left = parseInt(-62169993017 - t);
+			setInterval(function() {
+			  var foo = new Date;
+			  left = left - 1;
+			  //console.log(t, typeof(l));
+			  if (left > 0){
+			  minutes = left / 60 | 0,
+			  hours = minutes / 60 | 0,
+			  days = hours / 24 | 0,
+			  hours = hours % 24;
+			  if (hours < 10){hours = "0"+hours};
+			seconds = left%60;
+			  if (seconds < 10){seconds = "0"+seconds};
+			minutes %= 60;
+			  if (minutes < 10){minutes = "0"+minutes};
+			  dd = " дней ";
+			  tid = "";
+			  if (days == 1){dd = " день "};
+			  if (days < 5 && days > 1){dd = " дня "};
+			  if (days > 0){tid = days + dd};
+			  document.getElementById('nextserial').style.display="block";
+			  if(days>0){
+			  document.getElementById('nextserial').innerHTML = "До выхода следующей серии осталось:<span>"+ days + " "+ dd + " и " + hours +":"+ minutes +":"+ seconds+"</span>";
+			  } else document.getElementById('nextserial').innerHTML = "До выхода следующей серии осталось:<span>"+ days + ":" + hours +":"+ minutes +":"+ seconds+"</span>"; 
+			  } else {
+				if(-62169993017>0){
+					document.getElementById('nextserial').style.display="block";
+					document.getElementById('nextserial').innerHTML = "Скоро";
+				}
+			  }
+		  }, 1000);
+			} 
+			</script>
+
+			 <div id="nextserial" style="display:none;"></div>
+
+			</div>
+<div class="news_text">
+
+
+ <ul style="margin-left: 0;" class="head">
+<li><b>Год выпуска: </b><a href="/filter/year/2025/">2025</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%CF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>Приключения</a>, <a href='/filter/janrs/%FD%EA%F8%E5%ED/'>экшен</a>, <a href='/filter/janrs/%F4%E0%ED%F2%E0%F1%F2%E8%EA%E0/'>фантастика</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  ><b>Режиссёр: </b><a href='/filter/director/%D6%F3%F0%F3%EC%E0%EA%E8+%CA%E0%E4%E7%F3%FF/'><span itemprop="name">Цурумаки Кадзуя</span></a></li>
+
+
+
+<li><b>Серии: </b>полнометражный фильм, 80 мин.</li>
+
+</ul>
+	
+	
+
+<div class="descripts" itemprop="description">
+Амате Юзуриха - ученица старшей школы, мирно живущая в космической колонии, парящей в открытом космосе. Когда она встречает военного беженца по имени Ньяан, Амате оказывается втянутой в нелегальный вид спорта - дуэли в скафандрах, известный как Битва кланов.<br /><br />Под псевдонимом "Мачу" она изо дня в день бросается в жестокие сражения, пилотируя GQUUUUUX. Затем перед ней появляется неопознанный мобильный скафандр "Гандам", преследуемый космическими силами и полицией, а также его пилот, мальчик по имени Шуджи.
+</div>		
+
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+			 
+<div class="descripts">
+			<p class="reason">Добавлен фильм русской озвучкой</p>
+</div>
+
+
+
+
+
+
+
+<script>
+	jQuery(document).on("click", "#vid_as", function() 	{
+	jQuery(".video_as").hide();
+	jQuery("#vid1").show();
+	
+	jQuery('.actv').removeClass("actv");
+	jQuery(this).addClass("actv");
+	});
+	jQuery(document).on("click", "#vid_as2", function() 	{
+		jQuery(".video_as").hide();
+		jQuery("#vid_5").show();	
+		jQuery('.actv').removeClass("actv");
+		jQuery("#vid_as2").addClass("actv");
+	});
+	jQuery(document).on("click", "#torrent_all", function() 	{
+	jQuery(".video_as").hide();
+	
+	jQuery("#vid_3").show();
+	jQuery('.actv').removeClass("actv");
+	jQuery(this).addClass("actv");
+	});
+	
+	jQuery(document).on("click", "#vid_all", function() {	
+		jQuery(".video_as").hide();
+		jQuery("#vid_2").show();
+		if(jQuery("#vid_2").html()==""){
+		
+		jQuery("#vid_2").html('<iframe src="/test/player2/videoas.php?id=11012&hash=76a0a0ba2833815f1146a459acf39b2f" width="100%" height="480"  scrolling="no" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"></iframe>');
+		}
+		jQuery('.actv').removeClass("actv");
+		jQuery(this).addClass("actv");
+	});
+	
+	
+	</script>
+	<div class="vide_be "><span class="actv" id="vid_all" onClick='yaCounter15019516.reachGoal("as_click");'>Онлайн </span><span id="torrent_all">Скачать</span></div>
+		
+
+	
+
+ 
+    
+	<div class="video_as" id="vid_6" style="display:none;"><iframe src="about:blank;"  allowfullscreen></iframe></div>
+	<div class="video_as" id="vid_2" style="display:block;"><iframe src="/test/player2/videoas_p2p_new.php?id=11012&hash=76a0a0ba2833815f1146a459acf39b2f"  allowfullscreen></iframe>
+	</div>
+	
+	<div class="video_as" id="vid_4"></div>
+	
+	<div class="video_as" id="vid_3">
+		<h3><p><span style="color:#ff0000;">*</span>Что делать, если при просмотре загруженного видео чёрный экран, но звук при этом есть? Обновите видеокодеки вашего проигрывателя до последней версии, скачать их можно <a href="https://codecguide.com/download_kl.htm" target="_blank">здесь</a></p></h3>
+		<div class="list_torrent" style="overflow:auto;height:450px;">
+					<div id="torrent_46365_info" class="torrent">
+	<div class="title">
+		<a  href="/engine/gettorrent.php?id=46365">
+		<div class="info_c">&nbsp;</div>
+		<div class="download">&nbsp;</div>
+		<div class="info_d">
+			<div class="info_d1">Фильм (3.05 Gb)</div>
+		</div>
+		</a>
+		
+	</div>
+	
+
+	<div class="cont">
+
+
+
+		
+
+		<div class="bord_a1">
+			<div class="li_distribute_a1">
+				<b>Раздают: </b> <div class="li_distribute">0</div>
+			</div>
+		</div>
+
+		<div class="bord_a1">
+			<div class="li_swing_a1">
+				<b>Качают: </b><div class="li_swing">31</div>
+			</div>
+			<div class="li_swing_a2">
+				<div id="torrent_46365_leech"></div>
+			</div>
+		</div>
+
+		<div class="bord_a1">
+			<div class="li_download_a1">
+				<b>Скачали: </b><div class="li_download">0</div>
+			</div>
+			<div class="li_download_a2">
+				<div id="torrent_46365_down"></div>
+			</div>
+		</div>
+		<div class="bord_a1">
+		<b>Размер: </b> 3.05 Gb
+		</div>
+		
+		<div class="bord_a1">
+		<b>Дата: </b> 18-08-2026
+		</div>
+		
+	</div>
+</div>
+			
+		</div>
+	</div>
+	
+
+	
+	
+	<br>
+	
+
+	
+	
+	
+		<div style="text-align:center;width:100%;overflow:hidden;"><!-- Yandex.RTB R-A-19663890-1 -->
+<div id="yandex_rtb_R-A-19663890-1"></div>
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-1",
+        "renderTo": "yandex_rtb_R-A-19663890-1"
+    })
+})
+</script></div>
+	
+	
+
+
+<br>
+
+
+
+
+
+
+
+<div class="clear"></div>
+				
+</div>
+
+<script type="text/javascript" src="//vk.com/js/api/share.js?90" charset="windows-1251"></script>
+<div class="share-soc">
+	<div class="soc-share-title">Поделившись этой записью в соцсетях и мессенджерах, вы помогаете нашему проекту развиваться. Чтобы поделиться записью, просто нажмите на иконку нужной соцсети или мессенджера!</div>
+	<div class="panel-social">
+		
+	<script src="https://yastatic.net/share2/share.js"></script><div class="ya-share2" data-curtain data-services="vkontakte,odnoklassniki,telegram,twitter,viber,whatsapp"></div>
+	</div>
+</div>
+ 
+
+	
+	<div style="margin: 0;">
+		Уважаемый посетитель, Вы зашли на сайт как незарегистрированный пользователь.<br />
+		Мы рекомендуем Вам <a href="/index.php?do=register" style="color: #1E90FF">зарегистрироваться</span></a> либо войти на сайт под своим именем.
+	</div>
+	
+<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		 <div class="news_address">
+		        
+				<span class="date-icon">Сегодня, 10:07</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		 
+		
+		</div>
+	</div>
+
+
+
+		<style>
+		.comments_disable_domain p{
+			color: #ff3234;
+			font-family: 'BebasBold', sans-serif;
+		}
+		</style>
+
+<div class="color_t com_links_tab">  <span>Комментарии пользователей</span></div>
+
+
+
+<div class="VK_com com" >
+<!--noindex-->
+
+
+<script type="text/javascript" src="//vk.com/js/api/openapi.js?168"></script>
+
+<script type="text/javascript">
+  VK.init({apiId: 3892629, onlyWidgets: true});
+</script>
+
+
+<div id="vk_comments"></div>
+<script type="text/javascript">
+  var mainDomain = "https://v30.astar.bz"; 
+  
+  var currentPath = window.location.pathname; 
+  
+  var unifiedUrl = mainDomain + currentPath;
+
+  var articleId = "article_11012"; 
+
+  VK.Widgets.Comments("vk_comments", {
+    limit: 10,
+    attach: "*",
+    width: "100%",
+    pageUrl: unifiedUrl 
+  }, articleId); 
+</script>
+<!--/noindex-->
+
+<style>
+.dark-theme #vk_comments, .dark-theme #vk_comments iframe{
+	background: #fff;
+}
+</style>
+ 
+</div>
+
+
+<script>
+function comm(o){
+  jQuery(".com").hide();
+  
+  jQuery(".active_tab_com").removeClass("active_tab_com");
+  jQuery(o).addClass("active_tab_com");
+  jQuery("."+jQuery(o).attr('id')).show();
+}
+</script>
+
+
+</div>
+
+
+			
+			
+			
+		</div>
+		<div class="content-pravo">
+				
+				<div class="news-list" style="margin-bottom:10px;position:relative;z-index:1000001;">
+					<div class="title-3"><span>Актуальный адрес сайта AniStar</span></div>
+				
+					<div class="block-text">
+					<center>
+						<h3><a href="/as_act.php" class="act" target="_blank">V30.ASTAR.BZ</a></h3>
+					</center>
+					</div>
+				</div>		
+
+				<div class="news-list dub_menu" style="margin-bottom:10px;position:relative;z-index:1000001;">
+					<div class="title-3"><span>Озвучка на заказ</span></div>		
+					<div class="block-text">
+					<center>
+						<h3><a href="/order_dub.html">Заказать</a></h3>
+					</center>
+					</div>
+				</div>	
+				
+				
+				
+					
+				<div class="center2" style="margin-bottom:10px;padding-top:5px;"> 
+					<iframe src="/adblock/banner_right.php" style="border:0px;height:300px;overflow:hidden;"></iframe>
+				</div>
+					
+				
+				
+				<div class="news-list search-block" style="position:relative;z-index:1000001;">
+					<div class="title-3"><span>Поиск</span></div>
+				
+					<div class="block-text">
+						<form method="post" action="/">
+								<input name="do" value="search" type="hidden">
+								<input name="subaction" value="search" type="hidden">
+								<input  class="sear_but" id="story" name="story" value="Введите текст для поиска и нажмите 'Enter'" onfocus="this.value = '';" type="text" /> <input type="submit" value="GO">
+							</form>
+					</div>
+				</div>
+					
+				<div class="news-list new_menu" style="position:relative;z-index:100000;">
+				<div class="title-3"><span>Главное на сайте</span></div>
+				
+				<div class="block-text">
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по категориям</div>
+						<ul>
+							<li><a href="/anime/"><span>Все</span></a></li>
+							<li><a href="/new/"><span>Новинки</span></a></li>
+							<li><a href="/rpg/"><span>RPG</span></a></li>
+							<li><a href="/next/"><span>Скоро</span></a></li>
+							<li><a href="/filter/strana/Китай/">Китай</a></li> 
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по жанрам</div>
+						<ul>
+							<li><a href="/thriller/"><span>Боевики</span></a></li>
+							<li><a href="/vampires/"><span>Вампиры</span></a></li>
+							<li><a href="/ani-garem/"><span>Гарем</span></a></li>
+							<li><a href="/detective/"><span>Детектив</span></a></li>
+							<li><a href="/drama/"><span>Драма</span></a></li>
+							<li><a href="/history/"><span>История</span></a></li>
+							<li><a href="/cyberpunk/"><span>Киберпанк</span></a></li>
+							<li><a href="/comedy/"><span>Комедия</span></a></li>
+							<li><a href="/maho-shoujo/"><span>Махо-седзе</span></a></li>
+							<li><a href="/fur/"><span>Меха</span></a></li>
+							<li><a href="/parodies/"><span>Пародии</span></a></li>
+							<li><a href="/senen/"><span>Сёнен</span></a></li>
+							<li><a href="/sports/"><span>Спорт</span></a></li>
+							<li><a href="/mysticism/"><span>Мистика</span></a></li>
+
+							<li><a href="/music/"><span>Музыкальное</span></a></li>
+							<li><a href="/everyday-life/"><span>Повседневность</span></a></li>
+							<li><a href="/adventures/"><span>Приключения</span></a></li>
+							<li><a href="/romance/"><span>Романтика</span></a></li>
+							<li><a href="/shoujo/"><span>Cедзе</span></a></li>
+							<li><a href="/senen-ay/"><span>Сёнен-ай</span></a></li>
+							<li><a href="/horror/"><span>Триллер</span></a></li>
+							<li><a href="/horor/"><span>Ужасы</span></a></li>
+							<li><a href="/fantasy/"><span>Фантастика</span></a></li>
+							<li><a href="/fentezi/"><span>Фэнтeзи</span></a></li>
+							<li><a href="/school/"><span>Школа</span></a></li>
+							<li><a href="/echchi-erotic/"><span>Эччи</span></a></li>
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по годам</div>
+						<ul>
+							<li><a href="/index.php?do=xfsearch&xf=2026&type=year&r=anime"><span>2026</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2025&type=year&r=anime"><span>2025</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2024&type=year&r=anime"><span>2024</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2023&type=year&r=anime"><span>2023</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2022&type=year&r=anime"><span>2022</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2021&type=year&r=anime"><span>2021</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2020&type=year&r=anime"><span>2020</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2019&type=year&r=anime"><span>2019</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2018&type=year&r=anime"><span>2018</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2017&type=year&r=anime"><span>2017</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2016&type=year&r=anime"><span>2016</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2015&type=year&r=anime"><span>2015</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2014&type=year&r=anime"><span>2014</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2013&type=year&r=anime"><span>2013</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2012&type=year&r=anime"><span>2012</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2011&type=year&r=anime"><span>2011</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2010&type=year&r=anime"><span>2010</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2009&type=year&r=anime"><span>2009</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2008&type=year&r=anime"><span>2008</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2007&type=year&r=anime"><span>2007</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2006&type=year&r=anime"><span>2006</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2005&type=year&r=anime"><span>2005</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2004&type=year&r=anime"><span>2004</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2003&type=year&r=anime"><span>2003</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2002&type=year&r=anime"><span>2002</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2001&type=year&r=anime"><span>2001</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2000&type=year&r=anime"><span>2000</span></a></li>
+						</ul>
+					</div>
+					
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Манга по категориям</div>
+						<ul>
+							<li><a href="/m/"><span>Все</span></a></li>
+							<li><a href="/m/vanshot/">Ваншот</a></li> 
+							<li><a href="/m/ongoing/">Онгоинг-манга</a></li> 
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Манга по жанрам</div>
+						<ul>
+							<li><a href="/m/mthriller/">Боевик</a></li> 
+							<li><a href="/m/mdrama/">Драма</a></li> 
+							<li><a href="/m/mdetective/">Детектив</a></li> 
+							<li><a href="/m/mvampires/">Вампиры</a></li> 
+							<li><a href="/m/mhistory/">Кстория</a></li> 
+							<li><a href="/m/mcomedy/">Комедия</a></li> 
+							<li><a href="/m/mmaho-shoujo/">Махо-сёдзё</a></li> 
+							<li><a href="/m/mfur/">Меха</a></li> 
+							<li><a href="/m/mmysticism/">Мистика</a></li> 
+							<li><a href="/m/msciencefiction/">Научная фантастика</a></li> 
+							<li><a href="/m/mdaily/">Повседневность</a></li> 
+							<li><a href="/m/madventures/">Приключения</a></li> 
+							<li><a href="/m/mromance/">Романтика</a></li> 
+							<li><a href="/m/msupernatural/">Сверхъестественное</a></li> 
+							<li><a href="/m/mshoujo/">Сёдзё</a></li> 
+							<li><a href="/m/msport/">Спорт</a></li> 
+							<li><a href="/m/tragedy/">Трагедия</a></li> 
+							<li><a href="/m/mthriller1/">Триллер</a></li> 
+							<li><a href="/m/mhorror/">Ужасы</a></li> 
+							<li><a href="/m/mfantasy/">Фантастика</a></li> 
+							<li><a href="/m/mfantasy1/">Фэнтези</a></li> 
+							<li><a href="/m/mschool/">Школа</a></li> 
+							<li><a href="/m/sen/">Сёнэн</a></li> 
+							<li><a href="/m/senau/"> Cёнэн-ай</a></li> 
+							<li><a href="/m/psihology/">Психология</a></li> 
+							<li><a href="/m/metty_dor/">Эччи</a></li> 
+						</ul>
+					</div>
+					
+					
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Дорамы по категориям</div>
+						<ul>
+							<li><a href="/dorams/"><span>Все</span></a></li>
+							<li><a href="/next_dor/"><span>Скоро</span></a></li>
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Дорамы по жанрам</div>
+						<ul>
+							<li><a href="/dorams/thriller_dor/"><span>Боевики</span></a></li>
+							<li><a href="/dorams/vampires_dor/"><span>Вампиры</span></a></li>
+							<li><a href="/dorams/detective_dor/"><span>Детектив</span></a></li>
+							<li><a href="/dorams/drama_dor/"><span>Драма</span></a></li>
+							<li><a href="/dorams/history_dor/"><span>История</span></a></li> 
+							<li><a href="/dorams/cyberpunk_dor/"><span>Киберпанк</span></a></li>
+							<li><a href="/dorams/comedy_dor/"><span>Комедия</span></a></li>
+							<li><a href="/dorams/maho-shoujo_dor/"><span>Махо-седзе</span></a></li>
+							<li><a href="/dorams/fur_dor/"><span>Меха</span></a></li>
+							<li><a href="/dorams/parodies_dor/"><span>Пародии</span></a></li>
+							<li><a href="/dorams/senen_dor/"><span>Сёнен</span></a></li>
+							<li><a href="/dorams/sports_dor/"><span>Спорт</span></a></li>
+							<li><a href="/dorams/mysticism_dor/"><span>Мистика</span></a></li>
+
+							<li><a href="/dorams/music_dor/"><span>Музыкальное</span></a></li>
+							<li><a href="/dorams/everyday-life_dor/"><span>Повседневность</span></a></li>
+							<li><a href="/dorams/adventures_dor/"><span>Приключения</span></a></li>
+							<li><a href="/dorams/romance_dor/"><span>Романтика</span></a></li>
+							<li><a href="/dorams/shoujo_dor/"><span>Cедзе</span></a></li>
+							<li><a href="/dorams/senen-ay_dor/"><span>Сёнен-ай</span></a></li>
+							<li><a href="/dorams/horror_dor/"><span>Триллер</span></a></li>
+							<li><a href="/dorams/horor_dor/"><span>Ужасы</span></a></li>
+							<li><a href="/dorams/fantasy_dor/"><span>Фантастика</span></a></li>
+							<li><a href="/dorams/fentezi_dor/"><span>Фэнтeзи</span></a></li>
+							<li><a href="/dorams/school_dor/"><span>Школа</span></a></li>
+							<li><a href="/dorams/echchi-erotic_dor/"><span>Эччи</span></a></li>
+						</ul>
+					</div>
+					
+					<div class="cat_anime menu_link">
+						<div class="tit_sp"><a href="/raspisanie-vyhoda-seriy-ongoingov.html">Расписание</a></div>
+						<div class="tit_sp"><a href="/news/">Новости</a></div>
+						<div class="tit_sp"><a href="/kupit-vip.html">Купить VIP</a></div>
+						<div class="tit_sp"><a href="/?do=chat">Чат</a></div>
+					</div>
+					
+				</div>
+			</div>
+			<script>
+				jQuery(".hid_ul .tit_sp").on("click",function(){
+					  tree = jQuery(this).parents();
+					  if (jQuery(tree[0]).hasClass("act_hid") ) jQuery('.act_hid').removeClass('act_hid');
+					  else {
+						  jQuery('.act_hid').removeClass('act_hid');
+							jQuery(tree[0]).addClass("act_hid");				  
+					  }
+
+				});
+			</script>
+			
+			
+			
+			<style>
+			.center2{text-align:center;}
+			</style>
+			
+					
+			
+			
+			
+			<div class="news-list-vk" style="margin-bottom:10px;position:relative;z-index:1000001;">
+				<div class="title-3"><span>Мы ВКонтакте</span></div>
+				
+				<div class="block-text-vk">
+					<center>
+					<script type="text/javascript" src="//vk.com/js/api/openapi.js?168"></script>
+
+					<!-- VK Widget -->
+					<div id="vk_groups" style="max-height:315px;"></div>
+					<script type="text/javascript">
+					VK.Widgets.Group("vk_groups", {mode: 3, width: "315",color3:"#4a0074"}, 198159176);
+					</script>	
+					</center>
+				</div>
+				</div>	
+			
+			
+			
+				
+			<div class="center2" style="width:100%;overflow:hidden;"><!-- Yandex.RTB R-A-19663890-4 -->
+<div id="yandex_rtb_R-A-19663890-4"></div>
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-4",
+        "renderTo": "yandex_rtb_R-A-19663890-4"
+    })
+})
+</script></div>
+			
+			
+			
+			
+					
+		</div>
+		
+		
+		<div class="clr clear"></div>
+		<div class="text-s s2">
+			
+
+
+
+
+
+
+
+
+
+
+
+		</div>
+		</div>
+	</div>
+		
+	<div class="footer">
+	
+	 <div class="prefooter">
+		<div class="width1200">
+		<ul class="menu_dark">
+			<li><a href="/">Главная</a></li>
+			<li><a href="/anime/">Аниме</a></li>
+			<li><a href="/new/">Новинки</a></li>
+			<li><a href="/m/">Манга</a></li>
+			<li><a href="/raspisanie-vyhoda-seriy-ongoingov.html">Расписание</a></li>
+			<li><a href="/dorams/">Дорамы</a></li>
+			<li><a href="/news/">Новости</a></li>
+			<li><a href="/kupit-vip.html">VIP</a></li>
+			<li><a href="/rules.html">Правила сайта</a></li>
+			<li><a target="_blank" href="https://t.me/anistar_it"><span>Тех. поддержка</span></a></li>
+			<li><a href="/?do=chat">Чат</a></li>
+			<li><a href="/copyright.html">Для правообладателей</a></li>
+			<li><a href="?action_skin_change=1&skin_name=smartphone">Мобильная версия сайта</a></li>
+			<li><a href="/adv.html">Для рекламодателей</a></li> 
+		</ul>
+		</div>
+	 </div>
+	<div class="full-footer">
+		<div class="width1200">
+			<div class="f-left"></div>
+			<div class="f-center">Сopyright © 2012-<script type="text/javascript">dt = new Date();document.write(dt.getFullYear());</script> All rights reserved AniStar
+			</div>
+			<div class="f-right">
+			<span class='freekassaNew'><a href="https://freekassa.net" target="_blank" rel="noopener noreferrer">
+			  <img src="https://cdn.freekassa.net/banners/big-dark-1.png" title="Прием платежей на сайте для физических лиц и т.д.">
+			</a></span>
+			<style>
+			.freekassaNew{
+				display:block;
+				position:absolute;
+				overflow:hidden;
+				width:1px;
+				height:1px;
+			}
+			</style>
+			
+			<!-- Yandex.Metrika informer <a href="https://metrika.yandex.ru/stat/?id=15019516&amp;from=informer" target="_blank" rel="nofollow"><img src="https://metrika-informer.com/informer/15019516/3_1_FFFFFFFF_EFEFEFFF_0_pageviews" style="width:88px; height:31px; border:0;" alt="Яндекс.Метрика" title="Яндекс.Метрика: данные за сегодня (просмотры, визиты и уникальные посетители)" class="ym-advanced-informer" data-cid="15019516" data-lang="ru" /></a> <!-- /Yandex.Metrika informer --> <!-- Yandex.Metrika counter -->
+
+			<!--LiveInternet counter--><script type="text/javascript">
+			document.write('<a href="//www.liveinternet.ru/click" '+
+			'target="_blank"><img src="//counter.yadro.ru/hit?t17.1;r'+
+			escape(document.referrer)+((typeof(screen)=='undefined')?'':
+			';s'+screen.width+'*'+screen.height+'*'+(screen.colorDepth?
+			screen.colorDepth:screen.pixelDepth))+';u'+escape(document.URL)+
+			';h'+escape(document.title.substring(0,150))+';'+Math.random()+
+			'" alt="" title="LiveInternet: показано число просмотров за 24'+
+			' часа, посетителей за 24 часа и за сегодня" '+
+			'border="0" width="88" height="31"><\/a>')
+			</script><!--/LiveInternet-->
+			
+			</div>
+			<div class="clr clear"></div>
+		</div>
+	</div>
+	 
+		<div class="width1200"><div class="img-footer"></div></div>
+	</div>
+		
+
+	</div>
+	
+	
+<div id="scroller" class="b-top" style="display: none;"><span class="b-top-but"></span></div>
+<script type="text/javascript">$(document).ready(function(){
+$(window).scroll(function () {if ($(this).scrollTop() > 0) {$('#scroller').fadeIn();} else {$('#scroller').fadeOut();}});
+$('#scroller').click(function () {$('body,html').animate({scrollTop: 0}, 400); return false;});
+});</script> 
+
+	
+
+
+
+
+<script>
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	ga('create', 'UA-68488956-1', 'auto');
+	ga('send', 'pageview');
+</script>
+
+
+<div id="movie_video"></div><script type="text/javascript" src="https://vak345.com/s.js?v=0d2469abd7d08b1a2df9b458d49cefc1" async></script>
+
+<script>
+    var ReydenXContentRoll = {
+        "id": "reyden-x",
+        "width": 480,
+        "height": 300,
+        "position": "left-bottom",
+        "device": "any",
+        "autoreload": true,
+        "allowFullScreenModeOnMobile": false,
+        "onNoContent": function() {
+            console.log("Reyden-X: 204 No Content");
+        },
+        "onError": function() {
+            console.log("Reyden-X: An error has occurred");
+        }
+    };
+</script>
+<!--<script async defer type="application/javascript" 
+    src="https://0af2a962b0102942d9a7df351b20be55.com/a8820742-b3f4-428e-9ab7-3727c0390f78/content-roll/"></script>-->
+	
+	<!--<script src="https://allvideometrika.com/lostfilm.php?sid=212021"></script>-->
+
+
+
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-1",
+        "renderTo": "yandex_rtb_R-A-19663890-1"
+    })
+})
+</script>
+
+
+<style>
+html head + body[style*="padding: 80px !important;"]{
+padding:0px!important;margin:-80px;overflow-x:hidden;
+}
+html head + body[style*="padding: 80px !important;"]>.a-message{
+	display:block!important;
+}
+html head + body[style*="padding: 80px !important;"]>small{
+	display:block;
+	margin-bottom:-160px;
+}
+</style>
+<!--<script src="//customfingerprints.bablosoft.com/clientsafe.js"></script>
+<script>document.addEventListener("DOMContentLoaded", function(){ProcessFingerprint(false, "x23efmt6rtn3uvord0afji4n1pty9ls02jx9khtajfnpwt5bb6hb67favdxfcuqe")})</script>
+-->
+</body>
+</html><!-- vk732 -->

--- a/tests/JacRed.Tests/Fixtures/Anistar/listing_anime.html
+++ b/tests/JacRed.Tests/Fixtures/Anistar/listing_anime.html
@@ -1,6 +1,1486 @@
 <!DOCTYPE html>
-<html><head><title>Anistar anime</title></head><body>
-<a href="https://anistar.org/12-test-show.html">Test Show</a>
-<a href="/34-another-anime.html">Another</a>
-<div class="navigation"><a href="/anime/page/2/">2</a><a href="/anime/page/5/">5</a></div>
-</body></html>
+<html lang="ru" dir="ltr">
+
+<head>
+<meta name="reyden-x" content="53229bea-4fa6-40aa-96dc-c3b87fe20450" />
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, user-scalable=no" />
+<meta name="yandex-verification" content="50449ae2d254adbf" />
+<meta name="robots" content="all" />
+
+<meta name="revisit-after" content="1 days" /> 
+<meta property="og:image" content="/templates/new36/images/anistar_banner.jpg"/>
+<link rel="shortcut icon" href="/favicon.png?r=1" type="image/png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png"/>
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
+<link rel="manifest" href="/manifest.json"/>  
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/font/BebasBold.css"/><link href='https://fonts.googleapis.com/css?family=Roboto+Condensed&amp;subset=latin,cyrillic-ext,cyrillic' rel='stylesheet'  property='stylesheet' type='text/css'>
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/frends.css"/>
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/style.css?rand=18"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+<link rel="stylesheet"  property='stylesheet' type="text/css" href="/templates/new36/css/engine.css"/>
+<link href='/templates/new36/theme/jquery-ui.css' rel='stylesheet' type='text/css' />
+<base href="https://v30.astar.bz/anime/" />
+<link rel="canonical" href="https://v30.astar.bz/anime/" /> 
+<title>Аниме &raquo; AniStar - все аниме на одном сайте в режиме онлайн</title>
+<meta http-equiv="Content-Type" content="text/html; charset=Windows-1251" />
+<meta name="Description" content="Аниме онлайн, скачать аниме бесплатно, аниме сезон, лучшее аниме, смотреть лучшее аниме, аниме 2 сезон, аниме 1 сезон, бесплатное скачать аниме, смотреть аниме онлайн бесплатно отаку, онгоинг" />
+<meta name="Keywords" content="аниме онлайн, скачать аниме бесплатно, аниме сезон, лучшее аниме, смотреть лучшее аниме, аниме 2 сезон, аниме 1 сезон, бесплатное скачать аниме, смотреть аниме онлайн бесплатно отаку, онгоинг" />
+<meta property="og:site_name" content="Anistar - все аниме в одном сайте в режиме онлайн"/>
+<meta property="og:type" content="Movie"/>
+<meta property="og:title" content="Аниме &raquo; AniStar - все аниме на одном сайте в режиме онлайн"/>
+<meta property="og:url" content="https://v30.astar.bz/anime/"/>
+<link rel="search" type="application/opensearchdescription+xml" href="https://v30.astar.bz/engine/opensearch.php" title="База №1 по просмотру аниме онлайн бесплатно"/>
+<link rel="alternate" type="application/rss+xml" title="База №1 по просмотру аниме онлайн бесплатно" href="https://v30.astar.bz/rss.xml"/>
+
+<script src="/templates/new36/js/jquery.min.js"></script><script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js"></script><script type="text/javascript" src="/engine/classes/js/jqueryui.js"></script>
+<script type="text/javascript" src="/engine/classes/js/dle_js.js?185767232"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js"></script>
+<link media="screen" href="/engine/editor/css/default.css" type="text/css" rel="stylesheet" />
+<script src='https://www.google.com/recaptcha/api.js'></script>
+
+
+
+<!-- Yandex.RTB -->
+<script>window.yaContextCb=window.yaContextCb||[]</script>
+<script>
+
+		window.addEventListener('load', function() {
+			let YandexRTB_Script=document.createElement('script');
+			YandexRTB_Script.src='https://yandex.ru/ads/system/context.js';
+			document.getElementsByTagName('head')[0].appendChild(YandexRTB_Script);
+		});
+	
+</script>
+
+
+<script type="text/javascript">
+function skinChange(a) {
+	if(a=='new36'){
+		document.querySelector('html').classList.remove('dark-theme');
+	} else{
+		document.querySelector('html').classList.add('dark-theme');
+	}
+	try{
+		if(a=='new36'){
+			localStorage.removeItem('dark-theme');
+		} else{
+			localStorage.setItem("dark-theme",1); 
+		}
+	}catch(e){}
+};
+try{
+	if(localStorage.getItem('dark-theme')!=null) {	
+		skinChange('dark-theme');
+	} else {
+		skinChange('new36');
+	}
+}catch(e){}
+</script>
+
+<!-- Yandex.Metrika counter --> <script type="text/javascript" > (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)}; m[i].l=1*new Date(); for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }} k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)}) (window, document, "script", "https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js", "ym"); ym(15019516, "init", { clickmap:true, trackLinks:true, accurateTrackBounce:true, trackHash:true }); </script> <noscript><div><img src="https://mc.yandex.ru/watch/15019516" style="position:absolute; left:-9999px;" alt="" /></div></noscript> <!-- /Yandex.Metrika counter -->
+
+
+</head>
+
+<script>
+var timeClick=0;
+document.addEventListener("mousedown", function(e) {
+	timeClick=new Date().getTime();
+});
+document.addEventListener("mouseup", function(e) {
+	new Image().src="/themes/timeClick.php?timeClick="+(new Date().getTime() - timeClick);
+});
+sizeWindow=window.outerWidth+"x"+window.outerHeight;
+startMove=0;
+arrayMove=[];
+stopingMove=0;
+if(window.innerWidth<1281){
+	arrayMouseMove=[];
+	document.addEventListener("mousemove", function(e) {
+		arrayMouseMove.push({
+			clientX: e.clientX,
+			clientY: e.clientY,
+			timeStamp: e.timeStamp,
+		});			
+	});
+	setTimeout(function(){		
+		try {
+		  const response = fetch('https://greedseed.world/ping/mouse.php', {
+			method: 'POST',
+			credentials: 'omit',
+			mode: 'no-cors',
+			body: JSON.stringify(arrayMouseMove),
+			headers: {
+			  'Content-Type': 'application/json'
+			}
+		  });
+		} catch (error) {
+		  console.error('Ошибка:', error);
+		}		
+	},120000);
+}
+</script>
+	<header>
+	<div class="width1200">
+		<div class="width50 float-left left1">
+			<div class="logo">
+				<a href="/"><span>Аниме</span></a>
+			</div>
+			
+			<div class="menu">
+				<p><span><button class="menu__handle"><span>Menu</span></button>Смотреть</span></p>
+				<div class="drowmenu">
+					<div class="left-menu">
+						<ul>
+							<li><a href="/">Главная</a></li>
+							<li><a href="/new/">Новинки</a></li>
+							<li><a href="/next/">Скоро</a></li>
+							<li><a href="/raspisanie-vyhoda-seriy-ongoingov.html"><span>Расписание</span></a></li>
+							<li><a href="/news/">Новости</a></li>
+							<li><a href="/?do=chat"><span>Чат</span></a></li>
+							<li><a href="/?action_skin_change=1&skin_name=smartphone">Мобильная версия</a></li> 
+							</ul>
+					</div>
+					<div class="left-menu2">
+						<ul>
+							<li><a href="/anime/">Аниме</a></li>
+							<li><a href="/m/">Манга</a></li>
+							<li><a href="/dorams/">Дорамы</a></li>
+							<li><a href="/kupit-vip.html"><span>VIP</span></a></li>
+							<li><a href="/rules.html">Правила сайта</a></li>
+							<li><a target="_blank" href="https://t.me/anistar_it"><span>Тех. поддержка</span></a></li>
+							<li><a href="/adv.html"><span>Рекламодателю</span></a></li>
+						</ul>
+					</div>
+					
+					
+					
+					<div class="clear clr"></div>
+				</div>
+			</div>
+
+			<ul class="change-color">
+				<li class="is-active" onclick="skinChange('new36');"><span class="fa fa-sun-o"></span></li>
+				<li onclick="skinChange('new36-black');"><span class="fa fa-moon-o"></span></li> 
+			</ul>	
+
+			<script type="text/javascript">
+			jQuery(document).ready(function(){
+				jQuery("header .menu > p").on("click",function(){
+					if ( jQuery("header .menu").hasClass("active") ) {
+						jQuery("header .menu").removeClass("active");
+					} else jQuery("header .menu").addClass("active");
+				});
+				jQuery(".panel").on("click",function(){
+					jQuery(".panel").removeClass("active");
+					if ( jQuery(this).hasClass("active") ) {
+						jQuery(this).removeClass("active");
+					} else jQuery(this).addClass("active");
+				});
+			});
+			</script>
+		</div>
+		<div class="width50 float-right left2">
+		   <div class="panel-right">
+			<div class="panel vk-top">
+				<a href="https://vk.com/anistar_new" rel="nofollow"><span class="icon-top"></span></a>
+				<div class="hidden-panel"></div>
+			</div>
+			
+			<div class=" active panel profile-top">
+				<div class="hidden-panel"><div class="login_nav2">
+			<form method="post" action="">
+						<div>
+						<input type="text" placeholder="Ваш логин" name="login_name" id="login_name" />
+						<input type="password" placeholder="Ваш пароль" name="login_password" id="login_password" />
+						<input name="login" type="hidden" id="login" value="submit" />
+						</div>
+						<div>
+							<input id='ssubmit1' type="submit" value="Войти" />
+						</div>
+						
+						<div>
+							<a href="https://v30.astar.bz/index.php?do=register">Регистрация</a>
+							<a href="https://v30.astar.bz/index.php?do=lostpassword">Забыли пароль?</a>
+						</div>
+			</form>
+</div>
+
+   
+
+
+
+
+</div>
+				<span class="icon-top"></span>
+			</div>
+			</div>
+		</div>
+		<div class="clear clr"></div>
+	</div>
+	</header>
+		<div class="clear clr"></div>
+		<div class="clear clr"></div>
+
+
+
+
+<div id="loading-layer" style="display:none">Загрузка. Пожалуйста, подождите...</div>
+<script type="text/javascript">
+<!--
+var dle_root       = '/';
+var dle_admin      = '';
+var dle_login_hash = '';
+var dle_group      = 5;
+var dle_skin       = 'new36';
+var dle_wysiwyg    = '0';
+var quick_wysiwyg  = '1';
+var dle_act_lang   = ["Да", "Нет", "Ввод", "Отмена", "Сохранить", "Удалить"];
+var menu_short     = 'Быстрое редактирование';
+var menu_full      = 'Полное редактирование';
+var menu_profile   = 'Просмотр профиля';
+var menu_send      = 'Отправить сообщение';
+var menu_uedit     = 'Админцентр';
+var dle_info       = 'Информация';
+var dle_confirm    = 'Подтверждение';
+var dle_prompt     = 'Ввод информации';
+var dle_req_field  = 'Заполните все необходимые поля';
+var dle_del_agree  = 'Вы действительно хотите удалить? Данное действие невозможно будет отменить';
+var dle_spam_agree = 'Вы действительно хотите отметить пользователя как спамера? Это приведет к удалению всех его комментариев';
+var dle_complaint  = 'Укажите текст вашей жалобы для администрации:';
+var dle_big_text   = 'Выделен слишком большой участок текста.';
+var dle_orfo_title = 'Укажите комментарий для администрации к найденной ошибке на странице';
+var dle_p_send     = 'Отправить';
+var dle_p_send_ok  = 'Уведомление успешно отправлено';
+var dle_save_ok    = 'Изменения успешно сохранены. Обновить страницу?';
+var dle_del_news   = 'Удалить статью';
+var allow_dle_delete_news   = false;
+var dle_search_delay   = false;
+var dle_search_value   = '';
+$(function(){
+	FastSearch();
+});
+//-->
+</script>
+
+
+
+	
+	
+	
+		<div style="text-align:center;width:100%;overflow:hidden;"><!-- Yandex.RTB R-A-19663890-2 -->
+<div id="yandex_rtb_R-A-19663890-2"></div>
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-2",
+        "renderTo": "yandex_rtb_R-A-19663890-2"
+    })
+})
+</script></div>
+	
+	
+	
+	
+	
+	<div class="clear clr"></div>
+	<div class="main wrapper width1200">
+		<div class='bg-white-main'   >
+		<div class="content-left">
+			<div class="list-nav">
+				<ul><li class="icon-vip"><a href="/kupit-vip.html"><span>VIP</span></a></li><li  class="icon-clock"><a href="/raspisanie-vyhoda-seriy-ongoingov.html"><span>Расписание</span></a></li><li  class="icon-resp"><a href="https://t.me/anistar_it" target="blank_"><span>Тех. поддержка</span></a></li><li  class="icon-chat"><a href="/?do=chat"><span>Чат</span></a></li><li class="icon-copy"><a href="/copyright.html"><span>Правообладателю</span></a></li></ul>
+			</div> 
+			<script>
+				$('#teh_podderjka').click(function(){
+					DLEconfirm('Прежде чем написать, пожалуйста убедитесь, что ответа на ваш вопрос нету в группе. <br /><br /><li><a target="_blank" href="https://t.me/anistar_it" style="color:#4a0074;">Канал тех. поддержки</a><br /><br />Вы не нашли ответа на ваш вопрос?<br /> <br /> Не работает приложение?  <br /> Ответ: <a href="https://vk.com/anistar_it?w=wall-33569294_3912" style="color:#4a0074;">https://vk.com/anistar_it?w=wall-33569294_3912</a>','Сообщение',function(){
+						window.location.href='/index.php?do=send_admin';
+						
+					});
+				});
+			</script>
+			
+			
+			
+			
+			<div class="text-s">
+
+
+
+
+
+</div>
+			
+			
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+<a href="javascript:void(0);" class="button_bt" onClick="jQuery('.block-janrs').show();jQuery(this).hide();">Показать жанры</a>
+
+<div class="block-janrs" style="display:none;">
+
+			<div class="title-5">Жанры</div>
+				<ul>
+
+                        <li><a href="/thriller/"><img src="/uploads/cat/boevik.jpg" alt="Боевики" title="Боевики"/><span>Боевики</span></a></li>
+                        <li><a href="/vampires/"><img src="/uploads/cat/vampiry.jpg" alt="Вампиры" title="Вампиры" /><span>Вампиры</span></a></li>
+                        <li><a href="/detective/"><img src="/uploads/cat/detektiv.jpg" alt="Детектив" title="Детектив" /><span>Детектив</span></a></li>
+                        <li><a href="/drama/"><img src="/uploads/cat/drama.jpg" alt="Драма" title="Драма" /><span>Драма</span></a></li>
+                        <li><a href="/history/"><img src="/uploads/cat/istoriya.jpg" alt="История" title="История" /><span>История</span></a></li>
+                        <li><a href="/cyberpunk/"><img src="/uploads/cat/kiberpank.jpg" alt="Киберпанк" title="Киберпанк" /><span>Киберпанк</span></a></li>
+                        <li><a href="/comedy/"><img src="/uploads/cat/komediya.jpg" alt="Комедия" title="Комедия" /><span>Комедия</span></a></li>
+                        <li><a href="/maho-shoujo/"><img src="/uploads/cat/maho_sedze.jpg" alt="Махо-седзе" title="Махо-седзе" /><span>Махо-седзе</span></a></li>
+                        <li><a href="/fur/"><img src="/uploads/cat/maho.jpg" alt="Меха" title="Меха" /><span>Меха</span></a></li>
+                        <li><a href="/parodies/"><img src="/uploads/cat/parodii.jpg" alt="Пародии" title="Пародии" /><span>Пародии</span></a></li>
+                        <li><a href="/senen/"><img src="/uploads/cat/senen.jpg" alt="Сёнен" title="Сёнен" /><span>Сёнен</span></a></li>
+                        <li><a href="/sports/"><img src="/uploads/cat/sport.jpg" alt="Спорт" title="Спорт" /><span>Спорт</span></a></li>
+                        <li><a href="/mysticism/"><img src="/uploads/cat/mistika.jpg" alt="Мистика" title="Мистика" /><span>Мистика</span></a></li>
+
+                        <li><a href="/music/"><img src="/uploads/cat/musik.jpg" alt="Музыкальное" title="Музыкальное" /><span>Музыкальное</span></a></li>
+                        <li><a href="/everyday-life/"><img src="/uploads/cat/povsednrvnost.jpg" alt="Повседневность" title="Повседневность" /><span>Повседневность</span></a></li>
+                        <li><a href="/adventures/"><img src="/uploads/cat/priklucheniya.jpg" alt="Приключения" title="Приключения" /><span>Приключения</span></a></li>
+                        <li><a href="/romance/"><img src="/uploads/cat/romantika.jpg" alt="Романтика" title="Романтика" /><span>Романтика</span></a></li>
+                        <li><a href="/shoujo/"><img src="/uploads/cat/sedze.jpg" alt="Cедзе" title="Cедзе" /><span>Cедзе</span></a></li>
+                        <li><a href="/senen-ay/"><img src="/uploads/cat/senen_ay.jpg" alt="Сёнен-ай" title="Сёнен-ай" /><span>Сёнен-ай</span></a></li>
+                        <li><a href="/horror/"><img src="/uploads/cat/triller.jpg" alt="Триллер" title="Триллер" /><span>Триллер</span></a></li>
+                        <li><a href="/horor/"><img src="/uploads/cat/uzhasy.jpg" alt="Ужасы" title="Ужасы" /><span>Ужасы</span></a></li>
+                        <li><a href="/fantasy/"><img src="/uploads/cat/fantastika.jpg" alt="Фантастика" title="Фантастика" /><span>Фантастика</span></a></li>
+                        <li><a href="/fentezi/"><img src="/uploads/cat/fentesy.jpg" alt="Фэнтeзи" title="Фэнтeзи" /><span>Фэнтeзи</span></a></li>
+                        <li><a href="/school/"><img src="/uploads/cat/school.jpg" alt="Школа" title="Школа" /><span>Школа</span></a></li>
+                        <li><a href="/echchi-erotic/"><img src="/uploads/cat/echi.jpg" alt="Эччи" title="Эччи" /><span>Эччи</span></a></li>
+                </ul>
+		
+</div>
+
+
+
+<div class="short">
+
+	
+	<form name="news_set_sort" id="news_set_sort" method="post" action="" >Сортировать статьи по:&nbsp;<img src="/templates/new36/dleimages/desc.gif" alt="" /><a href="#" class="sort-actv sort-asc" onclick="dle_change_sort('date','asc'); return false;">дате</a> | <a href="#" class="" onclick="dle_change_sort('rating','desc'); return false;">популярности</a> | <a href="#" class="" onclick="dle_change_sort('news_read','desc'); return false;">посещаемости</a> | <a href="#" class="" onclick="dle_change_sort('comm_num','desc'); return false;">комментариям</a> | <a href="#" class="" onclick="dle_change_sort('title','desc'); return false;">алфавиту</a><input type="hidden" name="dlenewssortby" id="dlenewssortby" value="date" />
+<input type="hidden" name="dledirection" id="dledirection" value="DESC" />
+<input type="hidden" name="set_new_sort" id="set_new_sort" value="dle_sort_cat" />
+<input type="hidden" name="set_direction_sort" id="set_direction_sort" value="dle_direction_cat" />
+<script type="text/javascript">
+<!-- begin
+
+function dle_change_sort(sort, direction){
+
+  var frm = document.getElementById('news_set_sort');
+
+  frm.dlenewssortby.value=sort;
+  frm.dledirection.value=direction;
+
+  frm.submit();
+  return false;
+};
+
+// end -->
+</script></form>
+<div id='dle-content'><br><div class="pagenav" style="text-align:center;">
+   <div class="width700">
+    <div class="button_nav l"><span>&laquo;</span></div>
+		
+   <div class="pages"><span>1</span> <a href="https://v30.astar.bz/anime/page/2/">2</a> <a href="https://v30.astar.bz/anime/page/3/">3</a> <a href="https://v30.astar.bz/anime/page/4/">4</a> <a href="https://v30.astar.bz/anime/page/5/">5</a> <a href="https://v30.astar.bz/anime/page/6/">6</a> <a href="https://v30.astar.bz/anime/page/7/">7</a> <a href="https://v30.astar.bz/anime/page/8/">8</a> <a href="https://v30.astar.bz/anime/page/9/">9</a> <a href="https://v30.astar.bz/anime/page/10/">10</a> <span class="nav_ext">...</span> <a href="https://v30.astar.bz/anime/page/680/">680</a></div>
+		
+   <div class="button_nav r"><a href="https://v30.astar.bz/anime/page/2/">&raquo;</a></div>	
+
+    <div class="clear"></div>
+	</div>
+</div>
+<div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/9493-novaya-krutaya-anime-igra.html">Новая крутая аниме игра!</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a></p>
+		</div>
+		<div class="title_right" >
+		
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/9493/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/9493-novaya-krutaya-anime-igra.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+
+
+</ul>
+<div class="descripts">
+Возьмите на себя роль 2B: сражайтесь с многочисленными чудовищами, укрепляйте свои тело и дух, улучшайте снаряжение, становитесь сильнее!<br /><br /><!--colorstart:#3333FF--><span style="color:#3333FF"><!--/colorstart--><!--sizestart:4--><span style="font-size:14pt;"><!--/sizestart--><b><div style="text-align:center;"><a href="https://r.advg.agency/t/vpcp8/" >БЫСТРЕЕ ИГРАЙ ТУТ *ТЫК*</a></div></b><!--sizeend--></span><!--/sizeend--><!--colorend--></span><!--/colorend-->
+	
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">8-01-2024, 13:03</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/11012-mobilnyy-voin-gandam-gquuuuuux-nachalo-kidou-senshi-gundam-gquuuuuux-beginning.html">Мобильный воин Гандам: GQuuuuuuX — Начало / Kidou Senshi Gundam: GQuuuuuuX - Beginning</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/action/">Экшен</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/fantasy/">Фантастика</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">4</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">6</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:40%;">40</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/11012/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/11012-mobilnyy-voin-gandam-gquuuuuux-nachalo-kidou-senshi-gundam-gquuuuuux-beginning.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2025/">2025</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%CF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>Приключения</a>, <a href='/filter/janrs/%FD%EA%F8%E5%ED/'>экшен</a>, <a href='/filter/janrs/%F4%E0%ED%F2%E0%F1%F2%E8%EA%E0/'>фантастика</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%D6%F3%F0%F3%EC%E0%EA%E8+%CA%E0%E4%E7%F3%FF/'>Цурумаки Кадзуя</a></li>
+<li> </li>
+<li></li>
+<li></li>
+<li><b>Серии: </b>полнометражный фильм, 80 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Амате Юзуриха - ученица старшей школы, мирно живущая в космической колонии, парящей в открытом космосе. Когда она встречает военного беженца по имени Ньяан, Амате оказывается втянутой в нелегальный вид спорта - дуэли в скафандрах, известный как Битва кланов.<br /><br />Под псевдонимом "Мачу" она изо дня в день бросается в жестокие сражения, пилотируя GQUUUUUX. Затем перед ней появляется неопознанный мобильный скафандр "Гандам", преследуемый космическими силами и полицией, а также его пилот, мальчик по имени Шуджи.
+	<p class="reason">Добавлен фильм русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Сегодня, 10:07</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/11011-spisok-nano-nano-list.html">Список Нано / Nano List</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/drama/">Драма</a>, <a href="https://v30.astar.bz/anime/fantasy/">Фантастика</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.2</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">15</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:82%;">82</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/11011/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/11011-spisok-nano-nano-list.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%D4%E0%ED%F2%E0%F1%F2%E8%EA%E0/'>Фантастика</a>, <a href='/filter/janrs/%E4%F0%E0%EC%E0/'>драма</a></li>
+<li><b>Озвучка: </b>Русская Озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"></li>
+<li> </li>
+<li></li>
+<li></li>
+<li><b>Серии: </b>ONA (12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Майло живет в мире, где общение с андроидами является абсолютно нормальным. И теперь он живет с двумя андроидами, созданными его сестрой. Насколько безопасно ему жить с андроидами, обладающими смертоносной силой? Почему сестра подарила ему "андроида-телохранителя"? Что ж, ему предстоит узнать это на собственном горьком опыте.
+	<p class="reason">Добавлены 1-12 (заключительные) серии с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 21:30</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div>			
+			
+<div align="center">
+<!-- Yandex.RTB R-A-19663890-1 -->
+<div id="yandex_rtb_R-A-19663890-1"></div>
+</div>
+<div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10840-igra-lzhecov-liar-game.html">Игра лжецов / Liar Game</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/supernatural/">Сверхъестественное</a>, <a href="https://v30.astar.bz/anime/seinen/">Сёнен</a>, <a href="https://v30.astar.bz/anime/drama/">Драма</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">6.7</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">65</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:67%;">67</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10840/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10840-igra-lzhecov-liar-game.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%D1%B8%ED%E5%ED/'>Сёнен</a>, <a href='/filter/janrs/%E4%F0%E0%EC%E0/'>драма</a>, <a href='/filter/janrs/%F1%E2%E5%F0%F5%FA%E5%F1%F2%E5%F1%F2%E2%E5%ED%ED%EE%E5/'>сверхъестественное</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%D1%E0%F2%EE+%DE%E4%E7%EE/'>Сато Юдзо</a></li>
+<li> <b>Снято по манге: </b><a href='/filter/manga/%C8%E3%F0%E0+%EB%E6%E5%F6%EE%E2/'>Игра лжецов</a> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%CA%E0%E9%F2%E0%ED%E8+%D1%E8%ED%EE%E1%F3/'>Кайтани Синобу</a></li>
+<li></li>
+<li><b>Серии: </b>(&gt;24 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Имя Нао Кандзаки означает честность, и никакое другое слово её лучше не опишет. К сожалению, эта честность не всегда бывает кстати, особенно в ходе игры, где на кону сотни миллионов иен.<br />Студентке Нао не повезло стать участницей «Игры лжецов», и здесь её главное качество делает из неё дурочку и легчайшую мишень. Никому не составит труда обмануть наивную девушку, до конца пытающуюся верить в возможность сотрудничества с алчными людьми. Дела обстоят иначе с Синъити Акиямой, к которому Нао обратилась за помощью, даже не представляя, на что способен гений, разоривший огромнейшую корпорацию.
+	<p class="reason">Добавлена 20 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 19:32</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10918-neobyatnyy-okean-3-sezon-grand-blue-season-3.html">Необъятный океан 3 Сезон / Grand Blue Season 3</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/seinen/">Сёнен</a>, <a href="https://v30.astar.bz/anime/comedy/">Комедия</a>, <a href="https://v30.astar.bz/anime/everyday-life/">Повседневность</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.8</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">64</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:88%;">88</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10918/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10918-neobyatnyy-okean-3-sezon-grand-blue-season-3.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%D1%B8%ED%E5%ED/'>Сёнен</a>, <a href='/filter/janrs/%EA%EE%EC%E5%E4%E8%FF/'>комедия</a>, <a href='/filter/janrs/%EF%EE%E2%F1%E5%E4%ED%E5%E2%ED%EE%F1%F2%FC/'>повседневность</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%D2%E0%EA%E0%EC%E0%F6%F3+%D1%E8%ED%E4%E7%E8/'>Такамацу Синдзи</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%C8%ED%EE%FD+%CA%FD%ED%E4%E7%E8/'>Иноэ Кэндзи</a></li>
+<li></li>
+<li><b>Серии: </b>ТВ (&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Когда Иори Китахара поступает в колледж в Идзу-сити рядом с океаном, у него начинается новая жизнь. Он радуется переменам в жизни и переезжает в дайвинг-магазин своего дяди под названием «Необъятный океан». Здесь он столкнётся с роскошной жизнью, прекрасными девушками и красивыми мужчинами, обожающими алкоголь и дайвинг. Беззаботная студенческая жизнь, полная приключений, — это ли не мечта главного героя?<br /><br /><!--dle_spoiler "В каком порядке лучше смотреть эту серию:" --><div class="title_spoiler"><span onclick="ShowOrHide('sp84387dda3b60ec2e709479a1bd2ced87')"><img id="image-sp84387dda3b60ec2e709479a1bd2ced87" style="vertical-align: middle;border: none;" alt="" src="/templates/new36/dleimages/spoiler-plus.gif" /></span>&nbsp;<span onclick="ShowOrHide('sp84387dda3b60ec2e709479a1bd2ced87')"><!--spoiler_title-->"В каком порядке лучше смотреть эту серию:"<!--spoiler_title_end--></span></div><div id="sp84387dda3b60ec2e709479a1bd2ced87" class="text_spoiler" style="display:none;"><!--spoiler_text-->#1 <a href="/6654-.html" >Необъятный океан [ТВ-1]</a><br />#2 <a href="/10393-.html" >Необъятный океан [ТВ-2]</a><br />#3 <a href="/10918-.html" >Необъятный океан [ТВ-3]</a><!--spoiler_text_end--></div><!--/dle_spoiler-->
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 19:25</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10934-otverzhennaya-svyataya-i-ee-gastronomicheskoe-puteshestvie-v-drugom-mire-suterare-seijo-no-isekai-gohan-tabi-kakure-skill-de-camping-car-wo-shoukan-shimashita.html">Отверженная святая и её гастрономическое путешествие в другом мире / Suterare Seijo no Isekai Gohan Tabi: Kakure Skill de Camping Car wo Shoukan shimashita</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/romance/">Романтика</a>, <a href="https://v30.astar.bz/anime/fantasy/">Фантастика</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">7.9</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">102</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:79%;">79</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10934/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10934-otverzhennaya-svyataya-i-ee-gastronomicheskoe-puteshestvie-v-drugom-mire-suterare-seijo-no-isekai-gohan-tabi-kakure-skill-de-camping-car-wo-shoukan-shimashita.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%D4%E0%ED%F2%E0%F1%F2%E8%EA%E0/'>Фантастика</a>, <a href='/filter/janrs/%F0%EE%EC%E0%ED%F2%E8%EA%E0/'>романтика</a>, <a href='/filter/janrs/%EF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>приключения</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%CD%E8%E3%EE%F0%E8%EA%E0%E2%E0+%C0%F6%F3%F1%E8/'>Нигорикава Ацуси</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%A8%ED%FD%EE%F0%E8/'>Ёнэори</a></li>
+<li></li>
+<li><b>Серии: </b>(&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Размеренную жизнь медицинской работницы Рин Таканаси очень расцвечивало хобби. Женщина увлекалась активным отдыхом на природе: любила рыбалку, сбор грибов и трав и, конечно, приготовление еды из того, что смогла добыть. Её заветной мечтой был кемпер — настоящий дом на колёсах. А уж никак не магический круг призыва, внезапно возникший под ногами! К тому же выяснилось, что затянуло её в фэнтези-мир случайно. Настоящей святой оказалась привлекательная старшеклассница, переместившаяся с помощью того же самого заклинания. Не успела Рин и пикнуть, как её выдворили далеко за пределы дворца.<br />Рин не слишком сильна в механике компьютерных игр, поэтому не сразу разобралась с тем, что у неё отныне есть особые навыки. Призвавшие её сочли их бесполезными, но для Рин они предел мечтаний! Так началось её захватывающее гастрономическое путешествие в другом мире.
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 19:03</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10935-akkuratnaya-i-simpatichnaya-devochka-v-moey-novoy-shkole-podruga-detstva-s-kotoroy-ya-igral-dumaya-chto-ona-malchik-tenkou-saki-no-seiso-karen-na-bishoujo-ga-mukashi-danshi-to-omotte-issho-ni-asonda.html">Аккуратная и симпатичная девочка в моей новой школе — подруга детства, с которой я играл, думая, что она мальчик / Tenkou-saki no Seiso Karen na Bishoujo ga, Mukashi Danshi to Omotte Issho ni Asonda Osananajimi Datta Ken</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/comedy/">Комедия</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/romance/">Романтика</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.7</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">42</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:87%;">87</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10935/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10935-akkuratnaya-i-simpatichnaya-devochka-v-moey-novoy-shkole-podruga-detstva-s-kotoroy-ya-igral-dumaya-chto-ona-malchik-tenkou-saki-no-seiso-karen-na-bishoujo-ga-mukashi-danshi-to-omotte-issho-ni-asonda.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%CA%EE%EC%E5%E4%E8%FF/'>Комедия</a>, <a href='/filter/janrs/%F0%EE%EC%E0%ED%F2%E8%EA%E0/'>романтика</a>, <a href='/filter/janrs/%EF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>приключения</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%D1%FE%E9+%D7%F3%E0%ED%FC%F4%FD%ED/'>Сюй Чуаньфэн</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%D5%E8%E1%E0%F0%E8%FE/'>Хибарию</a></li>
+<li></li>
+<li><b>Серии: </b>(&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Я снова встретил свою подругу детства, и она превратилась в красивую и невинную девушку.<br /><br />"Давненько не виделись, Хаято".<br />"Харуки, не так ли?"<br /><br />В прошлом Однажды я играл в грязи со своим другом детства в сельской местности, и когда я увидел его снова, в нем не было и следа от того дерзкого молодого человека, которым я его тогда считал. Только на глазах у Хаято она сбросила пальто, которое было на ней, и отреагировала так же грубо, как и тогда. Дистанция между нами не изменилась.
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 18:54</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10913-razgnevannaya-ledi-poklyalas-otomstit-ya-razrushu-svoyu-stranu-s-pomoschyu-sily-grimuara-buchigire-reijou-wa-houfuku-wo-chikaimashita-madousho-no-chikara-de-sokoku-wo-tatakitsubushimasu.html">Разгневанная леди поклялась отомстить: Я разрушу свою страну с помощью силы гримуара! / Buchigire Reijou wa Houfuku wo Chikaimashita. Madousho no Chikara de Sokoku wo Tatakitsubushimasu</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/drama/">Драма</a>, <a href="https://v30.astar.bz/anime/romance/">Романтика</a>, <a href="https://v30.astar.bz/anime/fentezi/">Фэнтeзи</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.8</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">128</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:88%;">88</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10913/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10913-razgnevannaya-ledi-poklyalas-otomstit-ya-razrushu-svoyu-stranu-s-pomoschyu-sily-grimuara-buchigire-reijou-wa-houfuku-wo-chikaimashita-madousho-no-chikara-de-sokoku-wo-tatakitsubushimasu.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%C4%F0%E0%EC%E0/'>Драма</a>, <a href='/filter/janrs/%F4%FD%ED%F2%E5%E7%E8/'>фэнтези</a>, <a href='/filter/janrs/%F0%EE%EC%E0%ED%F2%E8%EA%E0/'>романтика</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%CA%F3%E4%E7%F3%FF+%CD%E0%EE%FE%EA%E8/'>Кудзуя Наоюки</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%D5%E0%E3%F3%F0%FD+%CC%FD%F2%E0%E1%EE/'>Хагурэ Мэтабо</a></li>
+<li></li>
+<li><b>Серии: </b>ТВ (&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Элизабет Лейстон, дочь могущественного премьер-министра Халдории, считается образцом утончённой дворянки и идеальной будущей королевой. Но когда её жених публично унижает её, разрывает помолвку и начинает распускать о ней мерзкие слухи, терпению Элизабет приходит конец.<br /><br />Почему её единственной подругой должна быть верная служанка? И почему она должна продолжать служить стране, которая её не уважает?<br /><br />Элизабет решает, что больше не станет это терпеть, и уничтожит королевство, даже если это будет последнее, что она сделает! Вооружившись острым умом и, что ещё важнее, семью магическими гримуарами, она отправляется на путь мести.<br /><br />И уж поверьте, расплата будет страшной!
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 18:13</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10916-rycar-skelet-vstupaet-v-parallelnyy-mir-2-sezon-gaikotsu-kishi-sama-tadaima-isekai-e-odekakechuu-ii.html">Рыцарь-скелет вступает в параллельный мир 2 Сезон / Gaikotsu Kishi-sama, Tadaima Isekai e Odekakechuu II</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/action/">Экшен</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/fentezi/">Фэнтeзи</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.2</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">160</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:82%;">82</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10916/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10916-rycar-skelet-vstupaet-v-parallelnyy-mir-2-sezon-gaikotsu-kishi-sama-tadaima-isekai-e-odekakechuu-ii.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%DD%EA%F8%E5%ED/'>Экшен</a>, <a href='/filter/janrs/%EF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>приключения</a>, <a href='/filter/janrs/%F4%FD%ED%F2%E5%E7%E8/'>фэнтези</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%CE%ED%EE+%CA%E0%F6%F3%EC%E8/'>Оно Кацуми</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%D5%E0%EA%E0%F0%E8+%DD%ED%EA%E8/'>Хакари Энки</a></li>
+<li></li>
+<li><b>Серии: </b>ТВ (&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Проснувшись, Арк обнаружил, что его забросило в параллельный мир. Да не просто забросило — он превратился в своего персонажа из онлайн-игры — закованного в латы рыцаря-скелета. Подумав, он решил не привлекать к себе слишком много внимания, но разве может рыцарь пройти мимо, когда прямо на его глазах творятся злодеяния?!<br /><br /><!--dle_spoiler "В каком порядке лучше смотреть эту серию:" --><div class="title_spoiler"><span onclick="ShowOrHide('sp27ff86cecac6147af527ef8c85fc8f26')"><img id="image-sp27ff86cecac6147af527ef8c85fc8f26" style="vertical-align: middle;border: none;" alt="" src="/templates/new36/dleimages/spoiler-plus.gif" /></span>&nbsp;<span onclick="ShowOrHide('sp27ff86cecac6147af527ef8c85fc8f26')"><!--spoiler_title-->"В каком порядке лучше смотреть эту серию:"<!--spoiler_title_end--></span></div><div id="sp27ff86cecac6147af527ef8c85fc8f26" class="text_spoiler" style="display:none;"><!--spoiler_text-->#1 <a href="/8619-.html" >Рыцарь-скелет вступает в параллельный мир [ТВ-1]</a><br />#2 <a href="/10916-.html" >Рыцарь-скелет вступает в параллельный мир [ТВ-2]</a><!--spoiler_text_end--></div><!--/dle_spoiler-->
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 17:12</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="news" itemscope itemtype="http://schema.org/Movie">
+		<div class="news_header">
+		<div class="title_left"><a href="https://v30.astar.bz/10928-taynaya-bitva-za-prestol-silneyshego-princa-duraleya-saikyou-degarashi-ouji-no-anyaku-teii-arasoi.html">Тайная битва за престол сильнейшего принца-дуралея / Saikyou Degarashi Ouji no Anyaku Teii Arasoi</a>
+		<p class="tags">Категория: <a href="https://v30.astar.bz/new/">Новинки(онгоинги)</a>, <a href="https://v30.astar.bz/anime/">Аниме</a>, <a href="https://v30.astar.bz/anime/action/">Экшен</a>, <a href="https://v30.astar.bz/anime/adventures/">Приключения</a>, <a href="https://v30.astar.bz/anime/fentezi/">Фэнтeзи</a></p>
+		</div>
+		<div class="title_right" >
+		<div class="rating">
+		<div class="rat_col_new" style="text-align:right" itemscope itemtype="http://schema.org/AggregateRating">рейтинг <span ><span itemprop="ratingValue">8.2</span>/<span itemprop="bestRating">10</span><span style="display:none;" itemprop="ratingCount">116</span><span itemprop="worstRating" style="display:none;">1</span></span></div>
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:82%;">82</li>
+		</ul>
+</div>
+		</div>
+		<div class="clear"></div>
+		</div>
+		
+			<style>.fstory-pool{padding-left:10px;padding-right:10px}</style>
+			<div class="news_avatar">
+			<img itemprop="image" src="/uploads/posters/10928/original.jpg" class="main-img">
+			
+			<div class="left-panel-bottom"><a href="https://v30.astar.bz/10928-taynaya-bitva-za-prestol-silneyshego-princa-duraleya-saikyou-degarashi-ouji-no-anyaku-teii-arasoi.html">Смотреть</a></div>
+			</div>
+<div class="news_text">
+
+
+		 <ul type="none" style="margin-left: 0;" class=" head">
+<li><b>Год выпуска: </b><a href="/filter/year/2026/">2026</a></li>
+
+<li><b>Жанр: </b><a href='/filter/janrs/%DD%EA%F8%E5%ED/'>Экшен</a>, <a href='/filter/janrs/%EF%F0%E8%EA%EB%FE%F7%E5%ED%E8%FF/'>приключения</a>, <a href='/filter/janrs/%F4%FD%ED%F2%E5%E7%E8/'>фэнтези</a></li>
+<li><b>Озвучка: </b>Русская озвучка </li>
+<li  itemprop="director" itemscope itemtype="http://schema.org/Person"><b>Режиссёр: </b><a href='/filter/director/%DF%ED%E0%F1%FD+%DE%E4%E7%E8/'>Янасэ Юдзи</a></li>
+<li> </li>
+<li><b>Автор оригинала: </b><a href='/filter/author/%D2%E0%EC%E1%E0/'>Тамба</a></li>
+<li></li>
+<li><b>Серии: </b>(&gt;12 эп.), 25 мин.</li>
+
+
+</ul>
+<div class="descripts">
+Империя Адрасия на континенте Фогель. В этой империи, обладающей мощными вооруженными силами и обширной территорией, идет борьба за трон. Поскольку преемник еще не определен, дети императора соперничают за расширение своей власти. Однако был один принц, о котором все говорили, что он определенно не станет императором: седьмой принц, Арнольд Лейкс Адлер. Молодой человек, который во всем уступал своему младшему брату-близнецу, скучный принц. Некомпетентный и вялый, Арнольд тратит каждый день впустую, просто развлекаясь. Однако за кулисами он является одним из пяти авантюристов класса СС, которых называют "Сильвер". Видя, что битва за трон усиливается, он решил: "Я не хочу умирать, так пусть мой младший брат станет императором..." Это история об абсурдных тайных маневрах принца, которого не интересует титул императора.
+	<p class="reason">Добавлена 7 серия с русской озвучкой</p>
+</div>			
+			
+</div>
+
+	<div class="clear"></div>
+ 
+	<div class="clear"></div>
+			
+	<div class="panel-bottom-shor">	
+		<div class="right-panel-bottom">
+		<div class="news_address">
+				
+				<span class="date-icon">Вчера, 16:39</span>
+				
+				
+		</div>
+		 <span class="favorites"></span>
+		 <span> </span>
+		
+		</div>
+	</div>
+</div><div class="pagenav" style="text-align:center;">
+   <div class="width700">
+    <div class="button_nav l"><span>&laquo;</span></div>
+		
+   <div class="pages"><span>1</span> <a href="https://v30.astar.bz/anime/page/2/">2</a> <a href="https://v30.astar.bz/anime/page/3/">3</a> <a href="https://v30.astar.bz/anime/page/4/">4</a> <a href="https://v30.astar.bz/anime/page/5/">5</a> <a href="https://v30.astar.bz/anime/page/6/">6</a> <a href="https://v30.astar.bz/anime/page/7/">7</a> <a href="https://v30.astar.bz/anime/page/8/">8</a> <a href="https://v30.astar.bz/anime/page/9/">9</a> <a href="https://v30.astar.bz/anime/page/10/">10</a> <span class="nav_ext">...</span> <a href="https://v30.astar.bz/anime/page/680/">680</a></div>
+		
+   <div class="button_nav r"><a href="https://v30.astar.bz/anime/page/2/">&raquo;</a></div>	
+
+    <div class="clear"></div>
+	</div>
+</div>
+</div>
+</div>
+
+
+
+			
+		</div>
+		<div class="content-pravo">
+				
+				<div class="news-list" style="margin-bottom:10px;position:relative;z-index:1000001;">
+					<div class="title-3"><span>Актуальный адрес сайта AniStar</span></div>
+				
+					<div class="block-text">
+					<center>
+						<h3><a href="/as_act.php" class="act" target="_blank">V30.ASTAR.BZ</a></h3>
+					</center>
+					</div>
+				</div>		
+
+				<div class="news-list dub_menu" style="margin-bottom:10px;position:relative;z-index:1000001;">
+					<div class="title-3"><span>Озвучка на заказ</span></div>		
+					<div class="block-text">
+					<center>
+						<h3><a href="/order_dub.html">Заказать</a></h3>
+					</center>
+					</div>
+				</div>	
+				
+				
+				
+					
+				<div class="center2" style="margin-bottom:10px;padding-top:5px;"> 
+					<iframe src="/adblock/banner_right.php" style="border:0px;height:300px;overflow:hidden;"></iframe>
+				</div>
+					
+				
+				
+				<div class="news-list search-block" style="position:relative;z-index:1000001;">
+					<div class="title-3"><span>Поиск</span></div>
+				
+					<div class="block-text">
+						<form method="post" action="/">
+								<input name="do" value="search" type="hidden">
+								<input name="subaction" value="search" type="hidden">
+								<input  class="sear_but" id="story" name="story" value="Введите текст для поиска и нажмите 'Enter'" onfocus="this.value = '';" type="text" /> <input type="submit" value="GO">
+							</form>
+					</div>
+				</div>
+					
+				<div class="news-list new_menu" style="position:relative;z-index:100000;">
+				<div class="title-3"><span>Главное на сайте</span></div>
+				
+				<div class="block-text">
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по категориям</div>
+						<ul>
+							<li><a href="/anime/"><span>Все</span></a></li>
+							<li><a href="/new/"><span>Новинки</span></a></li>
+							<li><a href="/rpg/"><span>RPG</span></a></li>
+							<li><a href="/next/"><span>Скоро</span></a></li>
+							<li><a href="/filter/strana/Китай/">Китай</a></li> 
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по жанрам</div>
+						<ul>
+							<li><a href="/thriller/"><span>Боевики</span></a></li>
+							<li><a href="/vampires/"><span>Вампиры</span></a></li>
+							<li><a href="/ani-garem/"><span>Гарем</span></a></li>
+							<li><a href="/detective/"><span>Детектив</span></a></li>
+							<li><a href="/drama/"><span>Драма</span></a></li>
+							<li><a href="/history/"><span>История</span></a></li>
+							<li><a href="/cyberpunk/"><span>Киберпанк</span></a></li>
+							<li><a href="/comedy/"><span>Комедия</span></a></li>
+							<li><a href="/maho-shoujo/"><span>Махо-седзе</span></a></li>
+							<li><a href="/fur/"><span>Меха</span></a></li>
+							<li><a href="/parodies/"><span>Пародии</span></a></li>
+							<li><a href="/senen/"><span>Сёнен</span></a></li>
+							<li><a href="/sports/"><span>Спорт</span></a></li>
+							<li><a href="/mysticism/"><span>Мистика</span></a></li>
+
+							<li><a href="/music/"><span>Музыкальное</span></a></li>
+							<li><a href="/everyday-life/"><span>Повседневность</span></a></li>
+							<li><a href="/adventures/"><span>Приключения</span></a></li>
+							<li><a href="/romance/"><span>Романтика</span></a></li>
+							<li><a href="/shoujo/"><span>Cедзе</span></a></li>
+							<li><a href="/senen-ay/"><span>Сёнен-ай</span></a></li>
+							<li><a href="/horror/"><span>Триллер</span></a></li>
+							<li><a href="/horor/"><span>Ужасы</span></a></li>
+							<li><a href="/fantasy/"><span>Фантастика</span></a></li>
+							<li><a href="/fentezi/"><span>Фэнтeзи</span></a></li>
+							<li><a href="/school/"><span>Школа</span></a></li>
+							<li><a href="/echchi-erotic/"><span>Эччи</span></a></li>
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Аниме по годам</div>
+						<ul>
+							<li><a href="/index.php?do=xfsearch&xf=2026&type=year&r=anime"><span>2026</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2025&type=year&r=anime"><span>2025</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2024&type=year&r=anime"><span>2024</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2023&type=year&r=anime"><span>2023</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2022&type=year&r=anime"><span>2022</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2021&type=year&r=anime"><span>2021</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2020&type=year&r=anime"><span>2020</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2019&type=year&r=anime"><span>2019</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2018&type=year&r=anime"><span>2018</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2017&type=year&r=anime"><span>2017</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2016&type=year&r=anime"><span>2016</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2015&type=year&r=anime"><span>2015</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2014&type=year&r=anime"><span>2014</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2013&type=year&r=anime"><span>2013</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2012&type=year&r=anime"><span>2012</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2011&type=year&r=anime"><span>2011</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2010&type=year&r=anime"><span>2010</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2009&type=year&r=anime"><span>2009</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2008&type=year&r=anime"><span>2008</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2007&type=year&r=anime"><span>2007</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2006&type=year&r=anime"><span>2006</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2005&type=year&r=anime"><span>2005</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2004&type=year&r=anime"><span>2004</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2003&type=year&r=anime"><span>2003</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2002&type=year&r=anime"><span>2002</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2001&type=year&r=anime"><span>2001</span></a></li>
+							<li><a href="/index.php?do=xfsearch&xf=2000&type=year&r=anime"><span>2000</span></a></li>
+						</ul>
+					</div>
+					
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Манга по категориям</div>
+						<ul>
+							<li><a href="/m/"><span>Все</span></a></li>
+							<li><a href="/m/vanshot/">Ваншот</a></li> 
+							<li><a href="/m/ongoing/">Онгоинг-манга</a></li> 
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Манга по жанрам</div>
+						<ul>
+							<li><a href="/m/mthriller/">Боевик</a></li> 
+							<li><a href="/m/mdrama/">Драма</a></li> 
+							<li><a href="/m/mdetective/">Детектив</a></li> 
+							<li><a href="/m/mvampires/">Вампиры</a></li> 
+							<li><a href="/m/mhistory/">Кстория</a></li> 
+							<li><a href="/m/mcomedy/">Комедия</a></li> 
+							<li><a href="/m/mmaho-shoujo/">Махо-сёдзё</a></li> 
+							<li><a href="/m/mfur/">Меха</a></li> 
+							<li><a href="/m/mmysticism/">Мистика</a></li> 
+							<li><a href="/m/msciencefiction/">Научная фантастика</a></li> 
+							<li><a href="/m/mdaily/">Повседневность</a></li> 
+							<li><a href="/m/madventures/">Приключения</a></li> 
+							<li><a href="/m/mromance/">Романтика</a></li> 
+							<li><a href="/m/msupernatural/">Сверхъестественное</a></li> 
+							<li><a href="/m/mshoujo/">Сёдзё</a></li> 
+							<li><a href="/m/msport/">Спорт</a></li> 
+							<li><a href="/m/tragedy/">Трагедия</a></li> 
+							<li><a href="/m/mthriller1/">Триллер</a></li> 
+							<li><a href="/m/mhorror/">Ужасы</a></li> 
+							<li><a href="/m/mfantasy/">Фантастика</a></li> 
+							<li><a href="/m/mfantasy1/">Фэнтези</a></li> 
+							<li><a href="/m/mschool/">Школа</a></li> 
+							<li><a href="/m/sen/">Сёнэн</a></li> 
+							<li><a href="/m/senau/"> Cёнэн-ай</a></li> 
+							<li><a href="/m/psihology/">Психология</a></li> 
+							<li><a href="/m/metty_dor/">Эччи</a></li> 
+						</ul>
+					</div>
+					
+					
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Дорамы по категориям</div>
+						<ul>
+							<li><a href="/dorams/"><span>Все</span></a></li>
+							<li><a href="/next_dor/"><span>Скоро</span></a></li>
+						</ul>
+					</div>
+					<div class="cat_anime hid_ul">
+						<div class="tit_sp">Дорамы по жанрам</div>
+						<ul>
+							<li><a href="/dorams/thriller_dor/"><span>Боевики</span></a></li>
+							<li><a href="/dorams/vampires_dor/"><span>Вампиры</span></a></li>
+							<li><a href="/dorams/detective_dor/"><span>Детектив</span></a></li>
+							<li><a href="/dorams/drama_dor/"><span>Драма</span></a></li>
+							<li><a href="/dorams/history_dor/"><span>История</span></a></li> 
+							<li><a href="/dorams/cyberpunk_dor/"><span>Киберпанк</span></a></li>
+							<li><a href="/dorams/comedy_dor/"><span>Комедия</span></a></li>
+							<li><a href="/dorams/maho-shoujo_dor/"><span>Махо-седзе</span></a></li>
+							<li><a href="/dorams/fur_dor/"><span>Меха</span></a></li>
+							<li><a href="/dorams/parodies_dor/"><span>Пародии</span></a></li>
+							<li><a href="/dorams/senen_dor/"><span>Сёнен</span></a></li>
+							<li><a href="/dorams/sports_dor/"><span>Спорт</span></a></li>
+							<li><a href="/dorams/mysticism_dor/"><span>Мистика</span></a></li>
+
+							<li><a href="/dorams/music_dor/"><span>Музыкальное</span></a></li>
+							<li><a href="/dorams/everyday-life_dor/"><span>Повседневность</span></a></li>
+							<li><a href="/dorams/adventures_dor/"><span>Приключения</span></a></li>
+							<li><a href="/dorams/romance_dor/"><span>Романтика</span></a></li>
+							<li><a href="/dorams/shoujo_dor/"><span>Cедзе</span></a></li>
+							<li><a href="/dorams/senen-ay_dor/"><span>Сёнен-ай</span></a></li>
+							<li><a href="/dorams/horror_dor/"><span>Триллер</span></a></li>
+							<li><a href="/dorams/horor_dor/"><span>Ужасы</span></a></li>
+							<li><a href="/dorams/fantasy_dor/"><span>Фантастика</span></a></li>
+							<li><a href="/dorams/fentezi_dor/"><span>Фэнтeзи</span></a></li>
+							<li><a href="/dorams/school_dor/"><span>Школа</span></a></li>
+							<li><a href="/dorams/echchi-erotic_dor/"><span>Эччи</span></a></li>
+						</ul>
+					</div>
+					
+					<div class="cat_anime menu_link">
+						<div class="tit_sp"><a href="/raspisanie-vyhoda-seriy-ongoingov.html">Расписание</a></div>
+						<div class="tit_sp"><a href="/news/">Новости</a></div>
+						<div class="tit_sp"><a href="/kupit-vip.html">Купить VIP</a></div>
+						<div class="tit_sp"><a href="/?do=chat">Чат</a></div>
+					</div>
+					
+				</div>
+			</div>
+			<script>
+				jQuery(".hid_ul .tit_sp").on("click",function(){
+					  tree = jQuery(this).parents();
+					  if (jQuery(tree[0]).hasClass("act_hid") ) jQuery('.act_hid').removeClass('act_hid');
+					  else {
+						  jQuery('.act_hid').removeClass('act_hid');
+							jQuery(tree[0]).addClass("act_hid");				  
+					  }
+
+				});
+			</script>
+			
+			
+			
+			<style>
+			.center2{text-align:center;}
+			</style>
+			
+					
+			
+			
+			
+			<div class="news-list-vk" style="margin-bottom:10px;position:relative;z-index:1000001;">
+				<div class="title-3"><span>Мы ВКонтакте</span></div>
+				
+				<div class="block-text-vk">
+					<center>
+					<script type="text/javascript" src="//vk.com/js/api/openapi.js?168"></script>
+
+					<!-- VK Widget -->
+					<div id="vk_groups" style="max-height:315px;"></div>
+					<script type="text/javascript">
+					VK.Widgets.Group("vk_groups", {mode: 3, width: "315",color3:"#4a0074"}, 198159176);
+					</script>	
+					</center>
+				</div>
+				</div>	
+			
+			
+			
+				
+			<div class="center2" style="width:100%;overflow:hidden;"><!-- Yandex.RTB R-A-19663890-4 -->
+<div id="yandex_rtb_R-A-19663890-4"></div>
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-4",
+        "renderTo": "yandex_rtb_R-A-19663890-4"
+    })
+})
+</script></div>
+			
+			
+			
+			
+					
+		</div>
+		
+		
+		<div class="clr clear"></div>
+		<div class="text-s s2">
+			
+
+
+
+
+
+
+
+
+
+
+
+		</div>
+		</div>
+	</div>
+		
+	<div class="footer">
+	
+	 <div class="prefooter">
+		<div class="width1200">
+		<ul class="menu_dark">
+			<li><a href="/">Главная</a></li>
+			<li><a href="/anime/">Аниме</a></li>
+			<li><a href="/new/">Новинки</a></li>
+			<li><a href="/m/">Манга</a></li>
+			<li><a href="/raspisanie-vyhoda-seriy-ongoingov.html">Расписание</a></li>
+			<li><a href="/dorams/">Дорамы</a></li>
+			<li><a href="/news/">Новости</a></li>
+			<li><a href="/kupit-vip.html">VIP</a></li>
+			<li><a href="/rules.html">Правила сайта</a></li>
+			<li><a target="_blank" href="https://t.me/anistar_it"><span>Тех. поддержка</span></a></li>
+			<li><a href="/?do=chat">Чат</a></li>
+			<li><a href="/copyright.html">Для правообладателей</a></li>
+			<li><a href="?action_skin_change=1&skin_name=smartphone">Мобильная версия сайта</a></li>
+			<li><a href="/adv.html">Для рекламодателей</a></li> 
+		</ul>
+		</div>
+	 </div>
+	<div class="full-footer">
+		<div class="width1200">
+			<div class="f-left"></div>
+			<div class="f-center">Сopyright © 2012-<script type="text/javascript">dt = new Date();document.write(dt.getFullYear());</script> All rights reserved AniStar
+			</div>
+			<div class="f-right">
+			<span class='freekassaNew'><a href="https://freekassa.net" target="_blank" rel="noopener noreferrer">
+			  <img src="https://cdn.freekassa.net/banners/big-dark-1.png" title="Прием платежей на сайте для физических лиц и т.д.">
+			</a></span>
+			<style>
+			.freekassaNew{
+				display:block;
+				position:absolute;
+				overflow:hidden;
+				width:1px;
+				height:1px;
+			}
+			</style>
+			
+			<!-- Yandex.Metrika informer <a href="https://metrika.yandex.ru/stat/?id=15019516&amp;from=informer" target="_blank" rel="nofollow"><img src="https://metrika-informer.com/informer/15019516/3_1_FFFFFFFF_EFEFEFFF_0_pageviews" style="width:88px; height:31px; border:0;" alt="Яндекс.Метрика" title="Яндекс.Метрика: данные за сегодня (просмотры, визиты и уникальные посетители)" class="ym-advanced-informer" data-cid="15019516" data-lang="ru" /></a> <!-- /Yandex.Metrika informer --> <!-- Yandex.Metrika counter -->
+
+			<!--LiveInternet counter--><script type="text/javascript">
+			document.write('<a href="//www.liveinternet.ru/click" '+
+			'target="_blank"><img src="//counter.yadro.ru/hit?t17.1;r'+
+			escape(document.referrer)+((typeof(screen)=='undefined')?'':
+			';s'+screen.width+'*'+screen.height+'*'+(screen.colorDepth?
+			screen.colorDepth:screen.pixelDepth))+';u'+escape(document.URL)+
+			';h'+escape(document.title.substring(0,150))+';'+Math.random()+
+			'" alt="" title="LiveInternet: показано число просмотров за 24'+
+			' часа, посетителей за 24 часа и за сегодня" '+
+			'border="0" width="88" height="31"><\/a>')
+			</script><!--/LiveInternet-->
+			
+			</div>
+			<div class="clr clear"></div>
+		</div>
+	</div>
+	 
+		<div class="width1200"><div class="img-footer"></div></div>
+	</div>
+		
+
+	</div>
+	
+	
+<div id="scroller" class="b-top" style="display: none;"><span class="b-top-but"></span></div>
+<script type="text/javascript">$(document).ready(function(){
+$(window).scroll(function () {if ($(this).scrollTop() > 0) {$('#scroller').fadeIn();} else {$('#scroller').fadeOut();}});
+$('#scroller').click(function () {$('body,html').animate({scrollTop: 0}, 400); return false;});
+});</script> 
+
+	
+
+
+
+
+<script>
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	ga('create', 'UA-68488956-1', 'auto');
+	ga('send', 'pageview');
+</script>
+
+
+<div id="movie_video"></div><script type="text/javascript" src="https://vak345.com/s.js?v=0d2469abd7d08b1a2df9b458d49cefc1" async></script>
+
+<script>
+    var ReydenXContentRoll = {
+        "id": "reyden-x",
+        "width": 480,
+        "height": 300,
+        "position": "left-bottom",
+        "device": "any",
+        "autoreload": true,
+        "allowFullScreenModeOnMobile": false,
+        "onNoContent": function() {
+            console.log("Reyden-X: 204 No Content");
+        },
+        "onError": function() {
+            console.log("Reyden-X: An error has occurred");
+        }
+    };
+</script>
+<!--<script async defer type="application/javascript" 
+    src="https://0af2a962b0102942d9a7df351b20be55.com/a8820742-b3f4-428e-9ab7-3727c0390f78/content-roll/"></script>-->
+	
+	<!--<script src="https://allvideometrika.com/lostfilm.php?sid=212021"></script>-->
+
+
+
+<script>
+window.yaContextCb.push(() => {
+    Ya.Context.AdvManager.render({
+        "blockId": "R-A-19663890-1",
+        "renderTo": "yandex_rtb_R-A-19663890-1"
+    })
+})
+</script>
+
+
+<style>
+html head + body[style*="padding: 80px !important;"]{
+padding:0px!important;margin:-80px;overflow-x:hidden;
+}
+html head + body[style*="padding: 80px !important;"]>.a-message{
+	display:block!important;
+}
+html head + body[style*="padding: 80px !important;"]>small{
+	display:block;
+	margin-bottom:-160px;
+}
+</style>
+<!--<script src="//customfingerprints.bablosoft.com/clientsafe.js"></script>
+<script>document.addEventListener("DOMContentLoaded", function(){ProcessFingerprint(false, "x23efmt6rtn3uvord0afji4n1pty9ls02jx9khtajfnpwt5bb6hb67favdxfcuqe")})</script>
+-->
+</body>
+</html><!-- vk732 -->


### PR DESCRIPTION
- Changed Anistar host from `https://anistar.org` to `https://v30.astar.bz`, allowing for anonymous access without requiring cookies.
- Updated documentation and configuration files to reflect the new host and its implications for parsing.
- Enhanced parsing logic to handle new episode labeling and ensure correct identification of film sizes versus episode numbers.
- Adjusted tests to validate the new parsing behavior and ensure compatibility with the updated host.