### PR TITLE
feat(indexers): implement NumQueryParser

### DIFF
--- a/Application/Search/JackettCardMatcher.cs
+++ b/Application/Search/JackettCardMatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using JacRed.Application.Index;
+using JacRed.Infrastructure.Indexers;
 using JacRed.Infrastructure.Persistence;
 using JacRed.Infrastructure.Utils;
 using JacRed.Models.Details;
@@ -27,36 +28,20 @@ namespace JacRed.Application.Search
             var torrents = new Dictionary<string, TorrentDetails>();
 
             #region Запрос с NUM
-            if (rqnum && query != null)
+            // NUM / Lampa free-text: "Ru En Year", "Ru En", or "Ru Year" → card title fields.
+            // Cyrillic+year must NOT empty-return (legacy bug); parse title+year and continue.
+            if (rqnum && !string.IsNullOrWhiteSpace(query)
+                && string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(title_original))
             {
-                var mNum = Regex.Match(query, "^([^a-z-A-Z]+) ([^а-я-А-Я]+) ([0-9]{4})$");
-
-                if (mNum.Success)
+                var parsed = NumQueryParser.Parse(query);
+                if (parsed.Matched)
                 {
-                    if (Regex.IsMatch(mNum.Groups[2].Value, "[a-zA-Z0-9]{2}"))
-                    {
-                        var g = mNum.Groups;
-                        title = g[1].Value;
-                        title_original = g[2].Value;
-                        year = int.Parse(g[3].Value);
-                    }
-                }
-                else
-                {
-                    if (Regex.IsMatch(query, "^([^a-z-A-Z]+) ((19|20)[0-9]{2})$"))
-                        return torrents;
-
-                    mNum = Regex.Match(query, "^([^a-z-A-Z]+) ([^а-я-А-Я]+)$");
-
-                    if (mNum.Success)
-                    {
-                        if (Regex.IsMatch(mNum.Groups[2].Value, "[a-zA-Z0-9]{2}"))
-                        {
-                            var g = mNum.Groups;
-                            title = g[1].Value;
-                            title_original = g[2].Value;
-                        }
-                    }
+                    if (!string.IsNullOrWhiteSpace(parsed.Title))
+                        title = parsed.Title;
+                    if (!string.IsNullOrWhiteSpace(parsed.TitleOriginal))
+                        title_original = parsed.TitleOriginal;
+                    if (parsed.Year > 0 && year <= 0)
+                        year = parsed.Year;
                 }
             }
             #endregion

--- a/Application/Search/JackettSearchService.cs
+++ b/Application/Search/JackettSearchService.cs
@@ -37,6 +37,8 @@ namespace JacRed.Application.Search
                 return new List<Result>();
 
             var req = IndexerSearchHelper.BuildRequest(q, request.ApiKey, rqnum, query, title, title_original, year, is_serial);
+            // NUM app sends query-only Jackett requests (Chrome/106 UA); promote into card fields.
+            NumQueryParser.ApplyToRequest(req);
             TrackerNameMatching.ApplyIndexerPathFilter(req, request.IndexerPath);
             var results = await IndexerSearchEngine.SearchCombinedAsync(req, cache, this);
             return IndexerSearchHelper.ApplyPostFilters(results, q, req);

--- a/Infrastructure/Indexers/IndexerSearchEngine.cs
+++ b/Infrastructure/Indexers/IndexerSearchEngine.cs
@@ -17,6 +17,9 @@ namespace JacRed.Infrastructure.Indexers
     {
         public static async Task<List<Result>> SearchCombinedAsync(IndexerSearchRequest req, IMemoryCache cache, IJackettSearchService jackettSearch)
         {
+            // Belt-and-suspenders: NUM query-only → card fields (also applied in JackettSearchService).
+            NumQueryParser.ApplyToRequest(req);
+
             var settings = IndexerSearchOptions.Resolve();
             string query = IndexerRequestParams.NormalizeQuery(req.Query);
 
@@ -57,13 +60,13 @@ namespace JacRed.Infrastructure.Indexers
                 if (card.Count == 0)
                 {
                     foreach (var variant in BuildQueryVariants(query, titleRu, titleEn, settings))
-                        batches.Add(jackettSearch.SearchResults(req.ApiKey, variant, null, null, 0, null, isSerial, false, cache));
+                        batches.Add(jackettSearch.SearchResults(req.ApiKey, variant, null, null, 0, null, isSerial, req.RqNum, cache));
                 }
             }
             else
             {
                 foreach (var variant in BuildQueryVariants(query, titleRu, titleEn, settings))
-                    batches.Add(jackettSearch.SearchResults(req.ApiKey, variant, null, null, 0, null, isSerial, false, cache));
+                    batches.Add(jackettSearch.SearchResults(req.ApiKey, variant, null, null, 0, null, isSerial, req.RqNum, cache));
             }
 
             foreach (var pair in V1Pairs(query, titleRu, titleEn, settings, req.CardMode))

--- a/Infrastructure/Indexers/NumQueryParser.cs
+++ b/Infrastructure/Indexers/NumQueryParser.cs
@@ -1,0 +1,164 @@
+using System.Text.RegularExpressions;
+
+namespace JacRed.Infrastructure.Indexers
+{
+    /// <summary>
+    /// Parses NUM / Lampa-style plain Jackett <c>query</c> strings into card fields
+    /// (<c>title</c>, <c>title_original</c>, <c>year</c>) so exact FileDB matching works.
+    /// NUM sends query-only requests like <c>Криминальное чтиво Pulp Fiction 1994</c>
+    /// with Chrome/106 User-Agent (<see cref="IndexerSearchRequest.RqNum"/>).
+    /// </summary>
+    public static class NumQueryParser
+    {
+        // "Русское English 1999"
+        static readonly Regex RuEnYear = new(
+            @"^([^a-zA-Z]+) ([^а-яА-ЯёЁ]+) ((?:19|20)\d{2})$",
+            RegexOptions.Compiled);
+
+        // "Русское English"
+        static readonly Regex RuEn = new(
+            @"^([^a-zA-Z]+) ([^а-яА-ЯёЁ]+)$",
+            RegexOptions.Compiled);
+
+        static readonly Regex TrailingYear = new(
+            @"^(.+?)\s+((?:19|20)\d{2})$",
+            RegexOptions.Compiled);
+
+        public sealed class Parsed
+        {
+            public string Title { get; set; }
+            public string TitleOriginal { get; set; }
+            public int Year { get; set; }
+            public bool Matched { get; set; }
+        }
+
+        /// <summary>
+        /// Best-effort parse of NUM/Lampa free-text into title / original / year.
+        /// </summary>
+        public static Parsed Parse(string query)
+        {
+            var result = new Parsed();
+            if (string.IsNullOrWhiteSpace(query))
+                return result;
+
+            string q = query.Trim();
+
+            var slash = IndexerRequestParams.SplitBilingualQuery(q);
+            if (!string.IsNullOrWhiteSpace(slash.ru) || !string.IsNullOrWhiteSpace(slash.en))
+            {
+                string ru = slash.ru;
+                string en = slash.en;
+                if (TryTakeTrailingYear(ru, out var ruStripped, out int y) && y > 0)
+                {
+                    result.Year = y;
+                    ru = ruStripped;
+                }
+                else if (TryTakeTrailingYear(en, out var enStripped, out y) && y > 0)
+                {
+                    result.Year = y;
+                    en = enStripped;
+                }
+
+                result.Title = ru;
+                result.TitleOriginal = en;
+                result.Matched = !string.IsNullOrWhiteSpace(ru) || !string.IsNullOrWhiteSpace(en);
+                return result;
+            }
+
+            // "Русское English 1999" (English token must contain a letter, not digits-only)
+            var mYear = RuEnYear.Match(q);
+            if (mYear.Success && HasLatinToken(mYear.Groups[2].Value))
+            {
+                result.Title = mYear.Groups[1].Value.Trim();
+                result.TitleOriginal = mYear.Groups[2].Value.Trim();
+                if (int.TryParse(mYear.Groups[3].Value, out int y) && y > 0)
+                    result.Year = y;
+                result.Matched = true;
+                return result;
+            }
+
+            // Strip trailing year before RuEn so "Константин 2005" is not misread as original="2005"
+            string body = q;
+            if (TryTakeTrailingYear(q, out string stripped, out int trailingYear) && trailingYear > 0)
+            {
+                result.Year = trailingYear;
+                body = stripped;
+            }
+
+            // "Русское English"
+            var mRuEn = RuEn.Match(body);
+            if (mRuEn.Success && HasLatinToken(mRuEn.Groups[2].Value))
+            {
+                result.Title = mRuEn.Groups[1].Value.Trim();
+                result.TitleOriginal = mRuEn.Groups[2].Value.Trim();
+                result.Matched = true;
+                return result;
+            }
+
+            if (Regex.IsMatch(body, @"[а-яА-ЯёЁ]"))
+                result.Title = body;
+            else
+                result.TitleOriginal = body;
+
+            result.Matched = !string.IsNullOrWhiteSpace(result.Title)
+                || !string.IsNullOrWhiteSpace(result.TitleOriginal)
+                || result.Year > 0;
+            return result;
+        }
+
+        static bool HasLatinToken(string value) =>
+            !string.IsNullOrWhiteSpace(value) && Regex.IsMatch(value, "[a-zA-Z]");
+
+        /// <summary>
+        /// When <see cref="IndexerSearchRequest.RqNum"/> and no explicit card titles were provided,
+        /// promote free-text <see cref="IndexerSearchRequest.Query"/> into card fields and enable CardMode.
+        /// </summary>
+        public static bool ApplyToRequest(IndexerSearchRequest req)
+        {
+            if (req == null || !req.RqNum)
+                return false;
+            if (!string.IsNullOrWhiteSpace(req.Title) || !string.IsNullOrWhiteSpace(req.TitleOriginal))
+                return false;
+            if (string.IsNullOrWhiteSpace(req.Query))
+                return false;
+
+            var parsed = Parse(req.Query);
+            if (!parsed.Matched)
+                return false;
+
+            if (!string.IsNullOrWhiteSpace(parsed.Title))
+                req.Title = parsed.Title;
+            if (!string.IsNullOrWhiteSpace(parsed.TitleOriginal))
+                req.TitleOriginal = parsed.TitleOriginal;
+            if (parsed.Year > 0 && req.Year <= 0)
+                req.Year = parsed.Year;
+
+            req.CardMode = IndexerRequestParams.IsCardMetadataSearch(
+                req.Title,
+                req.TitleOriginal,
+                req.IsSerial >= 0 ? req.IsSerial : (int?)null,
+                req.Categories,
+                req.Genres);
+
+            return req.CardMode;
+        }
+
+        static bool TryTakeTrailingYear(string value, out string stripped, out int year)
+        {
+            stripped = value;
+            year = 0;
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            var m = TrailingYear.Match(value.Trim());
+            if (!m.Success || !int.TryParse(m.Groups[2].Value, out year) || year < 1900 || year > 2100)
+            {
+                year = 0;
+                return false;
+            }
+
+            stripped = m.Groups[1].Value.Trim();
+            return !string.IsNullOrWhiteSpace(stripped);
+        }
+    }
+}

--- a/Infrastructure/Indexers/NumQueryParser.cs
+++ b/Infrastructure/Indexers/NumQueryParser.cs
@@ -5,8 +5,7 @@ namespace JacRed.Infrastructure.Indexers
     /// <summary>
     /// Parses NUM / Lampa-style plain Jackett <c>query</c> strings into card fields
     /// (<c>title</c>, <c>title_original</c>, <c>year</c>) so exact FileDB matching works.
-    /// NUM sends query-only requests like <c>Криминальное чтиво Pulp Fiction 1994</c>
-    /// with Chrome/106 User-Agent (<see cref="IndexerSearchRequest.RqNum"/>).
+    /// Covers Ru-first (NUM / Lampa <c>lg_df*</c>) and En-first (Lampa <c>df_lg*</c> / clarification).
     /// </summary>
     public static class NumQueryParser
     {
@@ -18,6 +17,16 @@ namespace JacRed.Infrastructure.Indexers
         // "Русское English"
         static readonly Regex RuEn = new(
             @"^([^a-zA-Z]+) ([^а-яА-ЯёЁ]+)$",
+            RegexOptions.Compiled);
+
+        // "English Русское 1999" (Lampa df_lg_year)
+        static readonly Regex EnRuYear = new(
+            @"^([^а-яА-ЯёЁ]+) ([^a-zA-Z]+) ((?:19|20)\d{2})$",
+            RegexOptions.Compiled);
+
+        // "English Русское" (Lampa df_lg)
+        static readonly Regex EnRu = new(
+            @"^([^а-яА-ЯёЁ]+) ([^a-zA-Z]+)$",
             RegexOptions.Compiled);
 
         static readonly Regex TrailingYear = new(
@@ -65,19 +74,33 @@ namespace JacRed.Infrastructure.Indexers
                 return result;
             }
 
-            // "Русское English 1999" (English token must contain a letter, not digits-only)
-            var mYear = RuEnYear.Match(q);
-            if (mYear.Success && HasLatinToken(mYear.Groups[2].Value))
+            // "Русское English 1999"
+            var mRuEnYear = RuEnYear.Match(q);
+            if (mRuEnYear.Success && HasLatinToken(mRuEnYear.Groups[2].Value))
             {
-                result.Title = mYear.Groups[1].Value.Trim();
-                result.TitleOriginal = mYear.Groups[2].Value.Trim();
-                if (int.TryParse(mYear.Groups[3].Value, out int y) && y > 0)
+                result.Title = mRuEnYear.Groups[1].Value.Trim();
+                result.TitleOriginal = mRuEnYear.Groups[2].Value.Trim();
+                if (int.TryParse(mRuEnYear.Groups[3].Value, out int y) && y > 0)
                     result.Year = y;
                 result.Matched = true;
                 return result;
             }
 
-            // Strip trailing year before RuEn so "Константин 2005" is not misread as original="2005"
+            // "English Русское 1999"
+            var mEnRuYear = EnRuYear.Match(q);
+            if (mEnRuYear.Success
+                && HasLatinToken(mEnRuYear.Groups[1].Value)
+                && HasCyrillicToken(mEnRuYear.Groups[2].Value))
+            {
+                result.TitleOriginal = mEnRuYear.Groups[1].Value.Trim();
+                result.Title = mEnRuYear.Groups[2].Value.Trim();
+                if (int.TryParse(mEnRuYear.Groups[3].Value, out int y) && y > 0)
+                    result.Year = y;
+                result.Matched = true;
+                return result;
+            }
+
+            // Strip trailing year before bilingual so "Константин 2005" / "Pulp Fiction 1994" work
             string body = q;
             if (TryTakeTrailingYear(q, out string stripped, out int trailingYear) && trailingYear > 0)
             {
@@ -91,6 +114,18 @@ namespace JacRed.Infrastructure.Indexers
             {
                 result.Title = mRuEn.Groups[1].Value.Trim();
                 result.TitleOriginal = mRuEn.Groups[2].Value.Trim();
+                result.Matched = true;
+                return result;
+            }
+
+            // "English Русское"
+            var mEnRu = EnRu.Match(body);
+            if (mEnRu.Success
+                && HasLatinToken(mEnRu.Groups[1].Value)
+                && HasCyrillicToken(mEnRu.Groups[2].Value))
+            {
+                result.TitleOriginal = mEnRu.Groups[1].Value.Trim();
+                result.Title = mEnRu.Groups[2].Value.Trim();
                 result.Matched = true;
                 return result;
             }
@@ -109,13 +144,17 @@ namespace JacRed.Infrastructure.Indexers
         static bool HasLatinToken(string value) =>
             !string.IsNullOrWhiteSpace(value) && Regex.IsMatch(value, "[a-zA-Z]");
 
+        static bool HasCyrillicToken(string value) =>
+            !string.IsNullOrWhiteSpace(value) && Regex.IsMatch(value, @"[а-яА-ЯёЁ]");
+
         /// <summary>
-        /// When <see cref="IndexerSearchRequest.RqNum"/> and no explicit card titles were provided,
-        /// promote free-text <see cref="IndexerSearchRequest.Query"/> into card fields and enable CardMode.
+        /// When no explicit card titles were provided, promote free-text
+        /// <see cref="IndexerSearchRequest.Query"/> into card fields and enable CardMode
+        /// (NUM query-only and Lampa clarification). Skips when title/title_original already set.
         /// </summary>
         public static bool ApplyToRequest(IndexerSearchRequest req)
         {
-            if (req == null || !req.RqNum)
+            if (req == null)
                 return false;
             if (!string.IsNullOrWhiteSpace(req.Title) || !string.IsNullOrWhiteSpace(req.TitleOriginal))
                 return false;

--- a/Infrastructure/Indexers/ProwlarrQueryParser.cs
+++ b/Infrastructure/Indexers/ProwlarrQueryParser.cs
@@ -27,19 +27,6 @@ namespace JacRed.Infrastructure.Indexers
             @"\{((?:author\:)(?<author>[^{]+)|(?:publisher\:)(?<publisher>[^{]+)|(?:title\:)(?<title>[^{]+)|(?:year\:)(?<year>[^{]+)|(?:genre\:)(?<genre>[^{]+))\}",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        // Lampa parse_lang / Jackett NUM: "Русское English 1999" or "Русское English"
-        static readonly Regex RuEnYear = new(
-            @"^([^a-zA-Z]+) ([^а-яА-ЯёЁ]+) ((?:19|20)\d{2})$",
-            RegexOptions.Compiled);
-
-        static readonly Regex RuEn = new(
-            @"^([^a-zA-Z]+) ([^а-яА-ЯёЁ]+)$",
-            RegexOptions.Compiled);
-
-        static readonly Regex TrailingYear = new(
-            @"^(.+?)\s+((?:19|20)\d{2})$",
-            RegexOptions.Compiled);
-
         public sealed class Parsed
         {
             public string Query { get; set; }
@@ -162,82 +149,14 @@ namespace JacRed.Infrastructure.Indexers
         /// </summary>
         static void EnrichPlainQuery(Parsed result, string q)
         {
-            var slash = IndexerRequestParams.SplitBilingualQuery(q);
-            if (!string.IsNullOrWhiteSpace(slash.ru) || !string.IsNullOrWhiteSpace(slash.en))
-            {
-                string ru = slash.ru;
-                string en = slash.en;
-                if (!result.Year.HasValue)
-                {
-                    if (TryTakeTrailingYear(ru, out var ruStripped, out int y) && y > 0)
-                    {
-                        result.Year = y;
-                        ru = ruStripped;
-                    }
-                    else if (TryTakeTrailingYear(en, out var enStripped, out y) && y > 0)
-                    {
-                        result.Year = y;
-                        en = enStripped;
-                    }
-                }
-                result.Title ??= ru;
-                result.TitleOriginal ??= en;
+            var parsed = NumQueryParser.Parse(q);
+            if (!parsed.Matched)
                 return;
-            }
 
-            // "Русское English 1999"
-            var mYear = RuEnYear.Match(q);
-            if (mYear.Success && Regex.IsMatch(mYear.Groups[2].Value, "[a-zA-Z0-9]{2}"))
-            {
-                result.Title ??= mYear.Groups[1].Value.Trim();
-                result.TitleOriginal ??= mYear.Groups[2].Value.Trim();
-                if (!result.Year.HasValue && int.TryParse(mYear.Groups[3].Value, out int y) && y > 0)
-                    result.Year = y;
-                return;
-            }
-
-            // "Русское English"
-            var mRuEn = RuEn.Match(q);
-            if (mRuEn.Success && Regex.IsMatch(mRuEn.Groups[2].Value, "[a-zA-Z0-9]{2}"))
-            {
-                result.Title ??= mRuEn.Groups[1].Value.Trim();
-                result.TitleOriginal ??= mRuEn.Groups[2].Value.Trim();
-                return;
-            }
-
-            string single = q;
-            if (!result.Year.HasValue && TryTakeTrailingYear(q, out string stripped, out int trailingYear) && trailingYear > 0)
-            {
-                result.Year = trailingYear;
-                single = stripped;
-            }
-
-            // Single-language query → use as card title for exact match.
-            if (string.IsNullOrWhiteSpace(result.Title) && string.IsNullOrWhiteSpace(result.TitleOriginal))
-            {
-                if (Regex.IsMatch(single, @"[а-яА-ЯёЁ]"))
-                    result.Title = single;
-                else
-                    result.TitleOriginal = single;
-            }
-        }
-
-        static bool TryTakeTrailingYear(string value, out string stripped, out int year)
-        {
-            stripped = value;
-            year = 0;
-            if (string.IsNullOrWhiteSpace(value))
-                return false;
-
-            var m = TrailingYear.Match(value.Trim());
-            if (!m.Success || !int.TryParse(m.Groups[2].Value, out year) || year < 1900 || year > 2100)
-            {
-                year = 0;
-                return false;
-            }
-
-            stripped = m.Groups[1].Value.Trim();
-            return !string.IsNullOrWhiteSpace(stripped);
+            result.Title ??= parsed.Title;
+            result.TitleOriginal ??= parsed.TitleOriginal;
+            if (!result.Year.HasValue && parsed.Year > 0)
+                result.Year = parsed.Year;
         }
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,11 +42,14 @@ Swagger UI по умолчанию загружает **`/openapi.yaml`**; в в
 
 Сводная таблица «клиент → URL → формат» — в [Torznab XML](configuration.md#torznab-xml-torznab).
 
-- **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa** и др.).
+- **`GET /api/v2.0/indexers/{status}/results`** — поиск в формате Jackett JSON (**Lampa**, **NUM** и др.).
   - `{status}`: `all` или Jackett-селектор `status:healthy` (Lampa «только доступные трекеры») — агрегат; иначе slug трекера.
   - Combined search (`search.*`): v2 card/fuzzy + v1 fuzzy (только fuzzy mode при `mergeV1: auto`) + IMDB/KP/TMDB exact (Alloha v2 ID→title, alternative_name, type hint) + card fallback. Fuzzy `q`/`Query` с `S01`/`S01E01` расширяется до имени шоу при `search.stripSeasonEpisode` (по умолчанию `true`).
   - Параметры Lampa: `Query`, `title`, `title_original`, `year`, `is_serial`, `genres`, `Category[]`, `Tracker[]`, `season`, `ep`, `limit`, `offset`, `apikey`.
-  - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true`.
+  - **Card mode (Lampa карточка):** явные `title` + `title_original` (+ `year` / `is_serial` / `genres` / `Category[]`). Поле `Query` при этом не переписывается (в т.ч. при любом `parse_lang`: original / локализованное / комбинации ± year).
+  - **Free-text → card:** если `title` / `title_original` **нет**, `Query`/`query` поднимается в card-поля (`NumQueryParser`): `Ru En Year`, `En Ru Year`, `Ru En` / `En Ru`, `title Year` / `original Year`, одноязычный title. Покрывает **NUM** (только `query`) и Lampa «уточнить» (Query без title).
+  - **NUM (`rqnum`):** User-Agent ровно `Mozilla/5.0 … Chrome/106.0.0.0 …` и в query string **нет** `&is_serial=`. В ответе `info` / `ffprobe` опускаются (`null`); merge дубликатов — `mergenumduplicates`.
+  - Ответ: `{ "Results": [...], "jacred": true }` с `ffprobe`, `languages`, `info` при `tracks: true` (кроме режима NUM выше).
 - **`GET /api/v2.0/indexers`** — список индексаторов (Jackett/Prowlarr).
 - **`GET /api/v1/indexer`** — список индексаторов в формате Prowlarr REST API (qui/autobrr discover fallback).
 - **`GET /api/v1/indexer/{id}`** — детали индексатора Prowlarr (`id=1`, для qui backend=prowlarr).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,7 +260,7 @@ globalproxy:
 | `skipSeasonEpisodeFilter` | Не фильтровать по `season`/`ep` на сервере (AIOStreams) | `false` |
 | `skipCatFilter` | Не фильтровать по `cat` / `Category[]` на сервере | `true` |
 
-**`mergeV1: auto`** — v1 fuzzy **только в fuzzy mode** (Torznab text search, Lampa global search). Card mode (Lampa: `title` + `title_original`) — только v2 exact, без v1 fuzzy.
+**`mergeV1: auto`** — v1 fuzzy **только в fuzzy mode** (Torznab text search, Lampa global search). Card mode (Lampa: `title` + `title_original`, либо free-text `Query` без title — NUM / Lampa «уточнить», см. [api.md](api.md)) — только v2 exact, без v1 fuzzy.
 
 **AIOStreams / Sonarr-style `q=Show S01E01`:** при `stripSeasonEpisode: true` fuzzy ищет и полное `q`, и имя шоу без сезона/эпизода (`silo S01` → `silo`; `укрытие 2023 S01E01` → `укрытие 2023` → `укрытие` вместе с `stripTrailingYear`). `skipSeasonEpisodeFilter: true` отдаёт все релизы шоу — клиент фильтрует эпизоды сам.
 
@@ -307,7 +307,8 @@ Jackett JSON (`/api/v2.0/indexers/.../results`) **всегда** использ�
 
 | Клиент | URL (относительно `http://host:9117`) | Формат |
 | --- | --- | --- |
-| **Lampa** | `/api/v2.0/indexers/all/results` или `/api/v2.0/indexers/status:healthy/results` (`status:healthy` ≡ `all`) | Jackett JSON (`Results[]`). Тип парсера в Lampa: **Jackett**, не Prowlarr/Torznab |
+| **Lampa** | `/api/v2.0/indexers/all/results` или `/api/v2.0/indexers/status:healthy/results` (`status:healthy` ≡ `all`) | Jackett JSON (`Results[]`). Тип парсера в Lampa: **Jackett**, не Prowlarr/Torznab. Card: `title`+`title_original`; «уточнить» — только `Query` (поднимается в card на сервере) |
+| **NUM** | тот же Jackett JSON, обычно `query` + UA Chrome/106 без `is_serial` | Free-text → card; в ответе без `info`/`ffprobe` (`rqnum`) |
 | **Sonarr / Radarr** | `/torznab/api` | Torznab XML (Generic Torznab indexer) |
 | **AIOStreams** | `/torznab/api` | Torznab XML; `q=Show S01` stripping; `skipSeasonEpisodeFilter: true` если клиент фильтрует эпизоды |
 | **Prowlarr** (ручная настройка Generic Torznab) | `/torznab/api` | Torznab XML |

--- a/tests/JacRed.Tests/Indexers/NumQueryParserTests.cs
+++ b/tests/JacRed.Tests/Indexers/NumQueryParserTests.cs
@@ -1,0 +1,131 @@
+using JacRed.Infrastructure.Indexers;
+using Xunit;
+
+namespace JacRed.Tests.Indexers;
+
+public class NumQueryParserTests
+{
+    [Fact]
+    public void Parse_RuEnYear_ExtractsTitleOriginalAndYear()
+    {
+        var p = NumQueryParser.Parse("Криминальное чтиво Pulp Fiction 1994");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Криминальное чтиво", p.Title);
+        Assert.Equal("Pulp Fiction", p.TitleOriginal);
+        Assert.Equal(1994, p.Year);
+    }
+
+    [Fact]
+    public void Parse_RuEn_ExtractsTitles()
+    {
+        var p = NumQueryParser.Parse("Константин Constantine");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Константин", p.Title);
+        Assert.Equal("Constantine", p.TitleOriginal);
+        Assert.Equal(0, p.Year);
+    }
+
+    [Fact]
+    public void Parse_RuEnYear_Constantine()
+    {
+        var p = NumQueryParser.Parse("Константин Constantine 2005");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Константин", p.Title);
+        Assert.Equal("Constantine", p.TitleOriginal);
+        Assert.Equal(2005, p.Year);
+    }
+
+    [Fact]
+    public void Parse_CyrillicTrailingYear_DoesNotEmpty_SetsTitleAndYear()
+    {
+        var p = NumQueryParser.Parse("Константин 2005");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Константин", p.Title);
+        Assert.True(string.IsNullOrEmpty(p.TitleOriginal));
+        Assert.Equal(2005, p.Year);
+    }
+
+    [Fact]
+    public void Parse_CyrillicOnly_SetsTitle()
+    {
+        var p = NumQueryParser.Parse("Криминальное чтиво");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Криминальное чтиво", p.Title);
+        Assert.Equal(0, p.Year);
+    }
+
+    [Fact]
+    public void ApplyToRequest_RqNum_PromotesQueryToCardMode()
+    {
+        var req = new IndexerSearchRequest
+        {
+            Query = "Криминальное чтиво Pulp Fiction 1994",
+            RqNum = true,
+            IsSerial = -1
+        };
+
+        Assert.True(NumQueryParser.ApplyToRequest(req));
+        Assert.True(req.CardMode);
+        Assert.Equal("Криминальное чтиво", req.Title);
+        Assert.Equal("Pulp Fiction", req.TitleOriginal);
+        Assert.Equal(1994, req.Year);
+    }
+
+    [Fact]
+    public void ApplyToRequest_CyrillicYear_EnablesCardMode()
+    {
+        var req = new IndexerSearchRequest
+        {
+            Query = "Константин 2005",
+            RqNum = true
+        };
+
+        Assert.True(NumQueryParser.ApplyToRequest(req));
+        Assert.True(req.CardMode);
+        Assert.Equal("Константин", req.Title);
+        Assert.Equal(2005, req.Year);
+    }
+
+    [Fact]
+    public void ApplyToRequest_SkipsWhenNotRqNum()
+    {
+        var req = new IndexerSearchRequest
+        {
+            Query = "Криминальное чтиво Pulp Fiction 1994",
+            RqNum = false
+        };
+
+        Assert.False(NumQueryParser.ApplyToRequest(req));
+        Assert.False(req.CardMode);
+        Assert.True(string.IsNullOrEmpty(req.Title));
+    }
+
+    [Fact]
+    public void ApplyToRequest_SkipsWhenTitleAlreadySet()
+    {
+        var req = new IndexerSearchRequest
+        {
+            Query = "Криминальное чтиво Pulp Fiction 1994",
+            Title = "Already",
+            RqNum = true
+        };
+
+        Assert.False(NumQueryParser.ApplyToRequest(req));
+        Assert.Equal("Already", req.Title);
+    }
+
+    [Fact]
+    public void Prowlarr_PlainRuEnYear_StillEnriches()
+    {
+        var parsed = ProwlarrQueryParser.Parse("Криминальное чтиво Pulp Fiction 1994", "search");
+
+        Assert.Equal("Криминальное чтиво", parsed.Title);
+        Assert.Equal("Pulp Fiction", parsed.TitleOriginal);
+        Assert.Equal(1994, parsed.Year);
+    }
+}

--- a/tests/JacRed.Tests/Indexers/NumQueryParserTests.cs
+++ b/tests/JacRed.Tests/Indexers/NumQueryParserTests.cs
@@ -17,6 +17,39 @@ public class NumQueryParserTests
     }
 
     [Fact]
+    public void Parse_EnRuYear_LampaDfLgYear()
+    {
+        var p = NumQueryParser.Parse("Pulp Fiction Криминальное чтиво 1994");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Криминальное чтиво", p.Title);
+        Assert.Equal("Pulp Fiction", p.TitleOriginal);
+        Assert.Equal(1994, p.Year);
+    }
+
+    [Fact]
+    public void Parse_EnRu_LampaDfLg()
+    {
+        var p = NumQueryParser.Parse("Pulp Fiction Криминальное чтиво");
+
+        Assert.True(p.Matched);
+        Assert.Equal("Криминальное чтиво", p.Title);
+        Assert.Equal("Pulp Fiction", p.TitleOriginal);
+        Assert.Equal(0, p.Year);
+    }
+
+    [Fact]
+    public void Parse_OriginalTrailingYear_SetsTitleOriginalAndYear()
+    {
+        var p = NumQueryParser.Parse("Pulp Fiction 1994");
+
+        Assert.True(p.Matched);
+        Assert.True(string.IsNullOrEmpty(p.Title));
+        Assert.Equal("Pulp Fiction", p.TitleOriginal);
+        Assert.Equal(1994, p.Year);
+    }
+
+    [Fact]
     public void Parse_RuEn_ExtractsTitles()
     {
         var p = NumQueryParser.Parse("Константин Constantine");
@@ -77,6 +110,24 @@ public class NumQueryParserTests
     }
 
     [Fact]
+    public void ApplyToRequest_WithoutRqNum_PromotesWhenTitlesAbsent()
+    {
+        // Lampa clarification: Query only, no title params (RqNum false due to is_serial).
+        var req = new IndexerSearchRequest
+        {
+            Query = "Pulp Fiction Криминальное чтиво 1994",
+            RqNum = false,
+            IsSerial = 1
+        };
+
+        Assert.True(NumQueryParser.ApplyToRequest(req));
+        Assert.True(req.CardMode);
+        Assert.Equal("Криминальное чтиво", req.Title);
+        Assert.Equal("Pulp Fiction", req.TitleOriginal);
+        Assert.Equal(1994, req.Year);
+    }
+
+    [Fact]
     public void ApplyToRequest_CyrillicYear_EnablesCardMode()
     {
         var req = new IndexerSearchRequest
@@ -89,20 +140,6 @@ public class NumQueryParserTests
         Assert.True(req.CardMode);
         Assert.Equal("Константин", req.Title);
         Assert.Equal(2005, req.Year);
-    }
-
-    [Fact]
-    public void ApplyToRequest_SkipsWhenNotRqNum()
-    {
-        var req = new IndexerSearchRequest
-        {
-            Query = "Криминальное чтиво Pulp Fiction 1994",
-            RqNum = false
-        };
-
-        Assert.False(NumQueryParser.ApplyToRequest(req));
-        Assert.False(req.CardMode);
-        Assert.True(string.IsNullOrEmpty(req.Title));
     }
 
     [Fact]
@@ -123,6 +160,16 @@ public class NumQueryParserTests
     public void Prowlarr_PlainRuEnYear_StillEnriches()
     {
         var parsed = ProwlarrQueryParser.Parse("Криминальное чтиво Pulp Fiction 1994", "search");
+
+        Assert.Equal("Криминальное чтиво", parsed.Title);
+        Assert.Equal("Pulp Fiction", parsed.TitleOriginal);
+        Assert.Equal(1994, parsed.Year);
+    }
+
+    [Fact]
+    public void Prowlarr_PlainEnRuYear_StillEnriches()
+    {
+        var parsed = ProwlarrQueryParser.Parse("Pulp Fiction Криминальное чтиво 1994", "search");
 
         Assert.Equal("Криминальное чтиво", parsed.Title);
         Assert.Equal("Pulp Fiction", parsed.TitleOriginal);


### PR DESCRIPTION
- Introduced NumQueryParser to parse NUM/Lampa-style queries into structured card fields (title, title_original, year).
- Updated JackettCardMatcher and JackettSearchService to utilize NumQueryParser for improved query processing.
- Refactored ProwlarrQueryParser to integrate NumQueryParser for consistent query enrichment.
- Added unit tests for NumQueryParser to ensure accurate parsing and request promotion.