### PR TITLE
fix(tracks): eliminate SelectBestServer batch-race host starvation

### DIFF
--- a/Infrastructure/Tracks/TracksAnalyzer.Remote.cs
+++ b/Infrastructure/Tracks/TracksAnalyzer.Remote.cs
@@ -23,6 +23,15 @@ namespace JacRed.Infrastructure.Tracks
 
         static readonly TimeSpan ListCacheTtl = TimeSpan.FromSeconds(10);
 
+        // Torrents picked but not yet reflected in a fresh GetTorrentList response (add is still
+        // in flight over the network, or sitting inside the ListCacheTtl window). Without this,
+        // every SelectBestServer call racing within that window sees the same stale count and
+        // all pile onto the same host — see selectBestServer tie/race notes below.
+        static readonly ConcurrentDictionary<string, int> _inFlightCounts =
+            new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        static readonly object _selectLock = new object();
+
         static TimeSpan GetTracksReadTimeout() =>
             TimeSpan.FromSeconds(Math.Max(1, AppInit.conf?.tracksreadtimeout ?? 30));
 
@@ -130,7 +139,15 @@ namespace JacRed.Infrastructure.Tracks
                 {
                     if (_analyzeConcurrency == null || _analyzeConcurrencyLimit != limit)
                     {
-                        _analyzeConcurrency?.Dispose();
+                        // Deliberately not disposing the old semaphore: AcquireAnalyzeSlotAsync
+                        // callers already holding a slot on it (acquired before this config
+                        // change was observed) call Release() on that same instance when their
+                        // analysis finishes. Disposing it here races those in-flight releases —
+                        // ObjectDisposedException, observed live when tracksconcurrency was
+                        // bumped 20->32 under an active batch. SemaphoreSlim.Dispose() is only
+                        // meaningful if AvailableWaitHandle was used (never is, here), so leaving
+                        // the old instance for the GC once its last holder drains is correct, not
+                        // a leak.
                         _analyzeConcurrency = new SemaphoreSlim(limit, limit);
                         _analyzeConcurrencyLimit = limit;
                     }
@@ -307,7 +324,32 @@ namespace JacRed.Infrastructure.Tracks
             if (validServers.Count == 0)
                 return null;
 
-            return validServers.OrderBy(r => r.count).First().server;
+            // The count+ordering+increment must happen as one atomic step: GetTorrentList above
+            // is async and can race across many concurrently-dispatched Add() calls (a batch of
+            // ~tracksconcurrency torrents all select at once, long before any of their adds land
+            // on the server and change the real count). Folding in _inFlightCounts and picking
+            // under a lock makes each concurrent caller see the picks made just microseconds
+            // earlier by the others in the same batch, instead of all racing the same stale
+            // snapshot and all choosing the same "least loaded" host.
+            // Random.Shared.Next() as the final tiebreaker: OrderBy is a stable sort, so without
+            // it, servers still tied after the above always resolve in tsuri list order, starving
+            // whichever tied host comes later in the config.
+            lock (_selectLock)
+            {
+                string chosen = validServers
+                    .OrderBy(r => r.count + _inFlightCounts.GetValueOrDefault(NormalizeTsuriKey(r.server)))
+                    .ThenBy(_ => Random.Shared.Next())
+                    .First().server;
+
+                _inFlightCounts.AddOrUpdate(NormalizeTsuriKey(chosen), 1, (_, v) => v + 1);
+                return chosen;
+            }
+        }
+
+        static void ReleaseInFlight(string tsuri)
+        {
+            string key = NormalizeTsuriKey(tsuri);
+            _inFlightCounts.AddOrUpdate(key, 0, (_, v) => Math.Max(0, v - 1));
         }
 
         static void AddBasicAuthHeader(HttpClient client, string url)

--- a/Infrastructure/Tracks/TracksAnalyzer.Workflow.cs
+++ b/Infrastructure/Tracks/TracksAnalyzer.Workflow.cs
@@ -112,9 +112,19 @@ namespace JacRed.Infrastructure.Tracks
                             cancellationTokenSource.CancelAfter(overallTimeout);
                             var token = cancellationTokenSource.Token;
 
-                            (bool torrentAdded, bool torrentExistsInCorrectCategory, bool serverError, bool addAttempted) =
-                                await AddTorrentToServer(tsuri, magnet, infohash, expectedCategory, token, typetask)
-                                    .ConfigureAwait(false);
+                            bool torrentAdded, torrentExistsInCorrectCategory, serverError, addAttempted;
+                            try
+                            {
+                                (torrentAdded, torrentExistsInCorrectCategory, serverError, addAttempted) =
+                                    await AddTorrentToServer(tsuri, magnet, infohash, expectedCategory, token, typetask)
+                                        .ConfigureAwait(false);
+                            }
+                            finally
+                            {
+                                // Only needs to cover the pick→server-reflects-it race window, not
+                                // the whole (possibly minutes-long) analysis that follows.
+                                ReleaseInFlight(tsuri);
+                            }
 
                             if (serverError)
                             {


### PR DESCRIPTION
## Problem

Under a concurrently-dispatched tracks-analysis batch (multiple torrents selecting a `tsuri` host at roughly the same time, capped by `tracksconcurrency`), `SelectBestServer()` picks a per-torrent "least loaded" host, but each host's `count` comes from a network round-trip (`GetTorrentList`). Its cache is only invalidated *after* a successful `add` response comes back — not at the moment of picking.

Every concurrent `SelectBestServer` call within that window sees the same pre-add snapshot of real server-side counts and independently converges on the same host, so most (sometimes effectively all) of a batch lands on one `tsuri` server instead of spreading across the configured pool. This is a genuine race, not just a tie-break artifact — though a stable `OrderBy` tie-break on ties (very common at `count=0`) compounds it, since it always favors whichever host is listed earliest in `tsuri:`.

Observed live on a real deployment: a 60s sample of `add torrent` calls during an active batch showed one `tsuri` host completely starved (0 adds) while another absorbed the bulk of the traffic (dozens of adds), despite all hosts being healthy and reachable.

## Fix

- Track an in-flight reservation count per host (`_inFlightCounts`). Picking (`count + inFlight`, ordering, and incrementing the winner's reservation) happens as one atomic step under a lock, so concurrent callers within the same batch see each other's just-made picks immediately instead of all racing the same stale snapshot.
- Added `Random.Shared.Next()` as a final tiebreaker, since `OrderBy` is a stable sort and would otherwise always resolve remaining ties by `tsuri:` list position.
- The reservation is released right after the `add` call returns (success or failure) via `try/finally` in `AddCore`, not after the full (possibly minutes-long) tracks analysis that follows — it only needs to cover the pick→server-reflects-it window.

**Verified live**: post-fix sample under the same conditions (active batch, same 4-host pool) showed a roughly even spread across all hosts, including the one that was previously stuck at zero.

## Bonus fix (same area, surfaced while testing)

`AnalyzeConcurrency` disposed the old `SemaphoreSlim` immediately on a `tracksconcurrency` config hot-reload (this project polls `init.yaml` every 10s and applies changes live). Any torrent whose analysis was in flight and holding a slot on the old semaphore threw `ObjectDisposedException` on `Release()` once the limit changed under load — reproduced live by bumping `tracksconcurrency` on an active instance (~19 occurrences over ~15s while the old slot-holders drained). Caught by the per-item error handler in `TracksCron.Run` so it doesn't crash the worker, but it's misleading log noise for work that actually completed fine.

`SemaphoreSlim.Dispose()` is only meaningful if `AvailableWaitHandle` was used, which it isn't here, so simply not disposing the old instance (letting it get GC'd once its last holder drains) removes the race without any real resource cost.

## Testing

- Built with the exact flags from `reusable-build.yml` (`net10.0`, `linux-x64`, self-contained, single-file) against this exact base commit.
- Smoke-tested the built binary standalone (clean startup, all workers started, `/version` reachable, a full `typetask=1` start→end cycle with zero errors) before deploying.
- Deployed to a real production instance backed by the existing torrent DB (fastdb ~1.29M keys); verified clean startup and no regressions in `journalctl`.
- Live-verified the host-starvation fix and the semaphore fix each against real traffic, as described above.