### PR TITLE
feat(trackers): implement TorrentBy pagination logic and tests

### DIFF
--- a/Infrastructure/Trackers/TorrentBy/TorrentByPagination.cs
+++ b/Infrastructure/Trackers/TorrentBy/TorrentByPagination.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace JacRed.Infrastructure.Trackers.TorrentBy
+{
+    sealed class TorrentByPager
+    {
+        public int CurrentDisplay { get; init; }
+        public int MaxPageIndex { get; init; }
+        public bool HasTrailingEllipsis { get; init; }
+        public int? EllipsisJumpPage { get; init; }
+    }
+
+    /// <summary>
+    /// torrent.by listing pager: 0-based <c>?page=</c>, chips in <c>circle_page</c> spans,
+    /// last chip often <c>...</c> (not the true last page).
+    /// </summary>
+    static class TorrentByPagination
+    {
+        public const int MaxEllipsisHops = 40;
+
+        /// <summary>Pre-circle_page UpdateTasksParse regex. Does not match live HTML.</summary>
+        public const string LegacyMaxPageRegex =
+            "href=\"\\?page=([0-9]+)\">[0-9]+</a>([\\t ]+)?</center></td>";
+
+        static readonly Regex PagerBlockRe = new(
+            @"Страницы:(.*?)</center>",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+        static readonly Regex PageHrefRe = new(
+            @"href=""\?page=([0-9]+)""",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        static readonly Regex CircleChipRe = new(
+            @"<span class=""circle_page""[^>]*>([^<]*)</span>",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        static readonly Regex CurrentChipRe = new(
+            @"<span class=""circle_page""[^>]*background[^>]*>([0-9]+)</span>",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        static readonly Regex PageLinkRe = new(
+            @"<a[^>]*href=""\?page=([0-9]+)""[^>]*>\s*<span class=""circle_page""[^>]*>([^<]*)</span>",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static TorrentByPager ParsePager(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+                return Empty();
+
+            var blockMatch = PagerBlockRe.Match(html);
+            string block = blockMatch.Success ? blockMatch.Groups[1].Value : "";
+            if (string.IsNullOrWhiteSpace(block))
+                return Empty();
+
+            int maxHref = 0;
+            bool anyHref = false;
+            foreach (Match m in PageHrefRe.Matches(block))
+            {
+                if (!int.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int n))
+                    continue;
+                anyHref = true;
+                if (n > maxHref)
+                    maxHref = n;
+            }
+
+            int currentDisplay = 1;
+            var current = CurrentChipRe.Match(block);
+            if (current.Success
+                && int.TryParse(current.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int cur))
+            {
+                currentDisplay = cur;
+            }
+            else
+            {
+                var first = CircleChipRe.Match(block);
+                if (first.Success
+                    && int.TryParse(first.Groups[1].Value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int firstN))
+                {
+                    currentDisplay = firstN;
+                }
+            }
+
+            var chips = CircleChipRe.Matches(block);
+            string lastChip = chips.Count > 0 ? chips[^1].Groups[1].Value.Trim() : "";
+            bool ellipsis = lastChip is "..." or "…";
+
+            int? jump = null;
+            if (ellipsis)
+            {
+                Match lastLink = null;
+                foreach (Match m in PageLinkRe.Matches(block))
+                    lastLink = m;
+                if (lastLink != null
+                    && int.TryParse(lastLink.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int j))
+                    jump = j;
+                else if (anyHref)
+                    jump = maxHref;
+            }
+
+            int currentIndex = Math.Max(0, currentDisplay - 1);
+            int maxPageIndex = Math.Max(currentIndex, anyHref ? maxHref : 0);
+
+            return new TorrentByPager
+            {
+                CurrentDisplay = currentDisplay,
+                MaxPageIndex = maxPageIndex,
+                HasTrailingEllipsis = ellipsis,
+                EllipsisJumpPage = jump
+            };
+        }
+
+        static TorrentByPager Empty() => new()
+        {
+            CurrentDisplay = 1,
+            MaxPageIndex = 0,
+            HasTrailingEllipsis = false,
+            EllipsisJumpPage = null
+        };
+    }
+}

--- a/Infrastructure/Trackers/TorrentBy/TorrentBySyncService.cs
+++ b/Infrastructure/Trackers/TorrentBy/TorrentBySyncService.cs
@@ -77,33 +77,60 @@ namespace JacRed.Infrastructure.Trackers.TorrentBy
         {
             return Task.FromResult(TrackerSyncHelpers.RunUpdateTasksParseInBackground(TrackerName, _updateTasksWork, checkDisabled: false, async ct =>
             {
+                string host = AppInit.conf.TorrentBy.rqHost().TrimEnd('/');
+
                 foreach (string cat in TorrentByCategories.Ids)
                 {
                     ct.ThrowIfCancellationRequested();
 
-                    string html = await HttpClient.Get($"{AppInit.conf.TorrentBy.rqHost()}/{cat}/", timeoutSeconds: 10, useproxy: AppInit.conf.TorrentBy.useproxy, cancellationToken: ct);
-                    if (html == null)
-                        continue;
+                    int last = await DiscoverLastPageAsync(host, cat, ct);
+                    if (!taskParse.ContainsKey(cat))
+                        taskParse[cat] = new List<TaskParse>();
 
-                    int.TryParse(System.Text.RegularExpressions.Regex.Match(html, "href=\"\\?page=([0-9]+)\">[0-9]+</a>([\t ]+)?</center></td>").Groups[1].Value, out int maxpages);
-
-                    for (int page = 0; page <= maxpages; page++)
+                    var val = taskParse[cat];
+                    for (int page = 0; page <= last; page++)
                     {
-                        try
-                        {
-                            if (!taskParse.ContainsKey(cat))
-                                taskParse.Add(cat, new List<TaskParse>());
-
-                            var val = taskParse[cat];
-                            if (val.FirstOrDefault(i => i.page == page) == null)
-                                val.Add(new TaskParse(page));
-                        }
-                        catch { }
+                        if (val.FirstOrDefault(i => i.page == page) == null)
+                            val.Add(new TaskParse(page));
                     }
+
+                    taskParse[cat] = val.OrderBy(x => x.page).ToList();
+                    ParserLog.Write(TrackerName, $"UpdateTasksParse cat={cat}: maxPage={last}, total={taskParse[cat].Count}");
                 }
 
                 PersistTaskParse();
             }));
+        }
+
+        static async Task<int> DiscoverLastPageAsync(string host, string cat, CancellationToken ct)
+        {
+            int last = 0;
+            int page = 0;
+            for (int hop = 0; hop <= TorrentByPagination.MaxEllipsisHops; hop++)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (hop > 0 && AppInit.conf.TorrentBy.parseDelay > 0)
+                    await Task.Delay(AppInit.conf.TorrentBy.parseDelay, ct);
+
+                string url = page <= 0 ? $"{host}/{cat}/" : $"{host}/{cat}/?page={page}";
+                string html = await HttpClient.Get(url, timeoutSeconds: 10, useproxy: AppInit.conf.TorrentBy.useproxy, cancellationToken: ct);
+                if (html == null)
+                    break;
+
+                var pager = TorrentByPagination.ParsePager(html);
+                if (pager.MaxPageIndex > last)
+                    last = pager.MaxPageIndex;
+
+                if (!pager.HasTrailingEllipsis || pager.EllipsisJumpPage == null)
+                    break;
+
+                int jump = pager.EllipsisJumpPage.Value;
+                if (jump <= page)
+                    break;
+                page = jump;
+            }
+
+            return last;
         }
 
         public Task<string> ParseAllTaskAsync(CancellationToken cancellationToken = default)

--- a/docs/trackers/torrentby.mdx
+++ b/docs/trackers/torrentby.mdx
@@ -37,6 +37,14 @@ TorrentBy:
 50 4,16 * * *  /opt/jacred/Data/run-job.sh torrentby-ParseAllTask http://127.0.0.1:9117/cron/torrentby/ParseAllTask 60
 ```
 
+`ParseAllTask` обходит только страницы из `Data/temp/torrentby_taskParse.json`. Карту собирает `UpdateTasksParse`: читает пейджер `circle_page` и переходит по ссылкам `...`, пока не найдёт последнюю страницу. После обновления JacRed один раз вызовите:
+
+```bash
+curl "http://127.0.0.1:9117/cron/torrentby/UpdateTasksParse"
+```
+
+Новые страницы дописываются к уже существующим (`page: 0` не удаляется). Следующий `ParseAllTask` обработает только ещё не пройденные страницы текущего цикла.
+
 ## Диагностика
 
 ```bash

--- a/tests/JacRed.Tests/TorrentBy/TorrentByPaginationTests.cs
+++ b/tests/JacRed.Tests/TorrentBy/TorrentByPaginationTests.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+using JacRed.Infrastructure.Trackers.TorrentBy;
+using Xunit;
+
+namespace JacRed.Tests.TorrentBy;
+
+public class TorrentByPaginationTests
+{
+    [Fact]
+    public void LegacyMaxPageRegex_DoesNotMatch_FilmsFixture()
+    {
+        string html = FixtureLoader.Read("TorrentBy/browse_films.html");
+        Assert.False(Regex.Match(html, TorrentByPagination.LegacyMaxPageRegex).Success);
+    }
+
+    [Fact]
+    public void ParsePager_FilmsFixture_HasTrailingEllipsisJump10()
+    {
+        string html = FixtureLoader.Read("TorrentBy/browse_films.html");
+        var pager = TorrentByPagination.ParsePager(html);
+
+        Assert.Equal(1, pager.CurrentDisplay);
+        Assert.Equal(10, pager.MaxPageIndex);
+        Assert.True(pager.HasTrailingEllipsis);
+        Assert.Equal(10, pager.EllipsisJumpPage);
+    }
+
+    [Theory]
+    [InlineData("browse_anime.html", 1)]
+    [InlineData("browse_tv.html", 1)]
+    public void ParsePager_AnimeAndTvFixtures_EllipsisJumpIs1(string fixture, int jump)
+    {
+        string html = FixtureLoader.Read($"TorrentBy/{fixture}");
+        var pager = TorrentByPagination.ParsePager(html);
+
+        Assert.True(pager.HasTrailingEllipsis);
+        Assert.Equal(jump, pager.EllipsisJumpPage);
+        Assert.Equal(jump, pager.MaxPageIndex);
+    }
+
+    [Fact]
+    public void ParsePager_LastPageWithoutEllipsis_UsesCurrentDisplay()
+    {
+        const string html = """
+            <center style="margin-top:5px;">Страницы:
+            <a href="?page=47"><span class="circle_page">48</span></a>
+            <a href="?page=48"><span class="circle_page">49</span></a>
+            <span class="circle_page" style="background:#BFDBFF;">50</span>
+            </center></td>
+            """;
+
+        var pager = TorrentByPagination.ParsePager(html);
+
+        Assert.Equal(50, pager.CurrentDisplay);
+        Assert.Equal(49, pager.MaxPageIndex);
+        Assert.False(pager.HasTrailingEllipsis);
+        Assert.Null(pager.EllipsisJumpPage);
+    }
+
+    [Fact]
+    public void ParsePager_MissingPager_ReturnsPageZero()
+    {
+        var pager = TorrentByPagination.ParsePager("<table><tr class=\"ttable_col1\"></tr></table>");
+        Assert.Equal(0, pager.MaxPageIndex);
+        Assert.False(pager.HasTrailingEllipsis);
+        Assert.Null(pager.EllipsisJumpPage);
+    }
+}


### PR DESCRIPTION
- Added `TorrentByPagination` class to handle parsing of pagination from HTML.
- Introduced `TorrentByPager` struct to encapsulate pagination details.
- Implemented `DiscoverLastPageAsync` method to determine the last page dynamically.
- Created unit tests for pagination logic to ensure correct behavior with various HTML fixtures.
- Updated `TorrentBySyncService` to utilize the new pagination logic for task parsing.