### PR TITLE
feat(networking): enhance proxy handling

### DIFF
--- a/Infrastructure/Networking/HttpClient.cs
+++ b/Infrastructure/Networking/HttpClient.cs
@@ -29,23 +29,39 @@ namespace JacRed.Infrastructure.Networking
             }
 
             proxyRandomList.TryTake(out string proxyip);
-
-            ICredentials credentials = null;
-
-            if (AppInit.conf.proxy.useAuth)
-                credentials = new NetworkCredential(AppInit.conf.proxy.username, AppInit.conf.proxy.password);
-
-            return new WebProxy(proxyip, AppInit.conf.proxy.BypassOnLocal, null, credentials);
+            return CreateWebProxy(proxyip, AppInit.conf.proxy);
         }
 
-        static WebProxy CreateWebProxy(string proxyUrl, ProxySettings settings)
+        /// <summary>
+        /// HttpClientHandler.Proxy only speaks HTTP CONNECT. SOCKS5 needs
+        /// SocketsHttpHandler, which understands socks4/socks4a/socks5 schemes.
+        /// curl-style socks5h:// is rewritten to socks5:// (remote DNS still happens).
+        /// </summary>
+        internal static Uri NormalizeProxyAddress(string proxyUrl)
+        {
+            if (string.IsNullOrWhiteSpace(proxyUrl))
+                throw new ArgumentException("Proxy URL is empty.", nameof(proxyUrl));
+
+            proxyUrl = proxyUrl.Trim();
+
+            if (proxyUrl.StartsWith("socks5h://", StringComparison.OrdinalIgnoreCase))
+                proxyUrl = "socks5://" + proxyUrl["socks5h://".Length..];
+            else if (proxyUrl.StartsWith("socks://", StringComparison.OrdinalIgnoreCase))
+                proxyUrl = "socks5://" + proxyUrl["socks://".Length..];
+            else if (proxyUrl.IndexOf("://", StringComparison.Ordinal) < 0)
+                proxyUrl = "http://" + proxyUrl;
+
+            return new Uri(proxyUrl);
+        }
+
+        internal static WebProxy CreateWebProxy(string proxyUrl, ProxySettings settings)
         {
             ICredentials credentials = null;
 
             if (settings != null && settings.useAuth)
                 credentials = new NetworkCredential(settings.username, settings.password);
 
-            return new WebProxy(proxyUrl, settings?.BypassOnLocal ?? false, null, credentials);
+            return new WebProxy(NormalizeProxyAddress(proxyUrl), settings?.BypassOnLocal ?? false, null, credentials);
         }
 
         static List<WebProxy> ResolveProxies(string url, bool useproxy, WebProxy proxyOverride)
@@ -78,14 +94,17 @@ namespace JacRed.Infrastructure.Networking
             return new List<WebProxy>();
         }
 
-        static HttpClientHandler CreateHandler(WebProxy proxy, DecompressionMethods decompression)
+        internal static SocketsHttpHandler CreateHandler(WebProxy proxy, DecompressionMethods decompression, bool allowAutoRedirect = true)
         {
-            var handler = new HttpClientHandler()
+            var handler = new SocketsHttpHandler
             {
-                AutomaticDecompression = decompression
+                AutomaticDecompression = decompression,
+                AllowAutoRedirect = allowAutoRedirect,
+                SslOptions =
+                {
+                    RemoteCertificateValidationCallback = static (_, _, _, _) => true
+                }
             };
-
-            handler.ServerCertificateCustomValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
 
             if (proxy != null)
             {
@@ -391,10 +410,7 @@ namespace JacRed.Infrastructure.Networking
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    var handler = CreateHandler(px, DecompressionMethods.Brotli | DecompressionMethods.GZip | DecompressionMethods.Deflate);
-                    handler.AllowAutoRedirect = true;
-
-                    using (handler)
+                    using (var handler = CreateHandler(px, DecompressionMethods.Brotli | DecompressionMethods.GZip | DecompressionMethods.Deflate))
                     using (var client = new System.Net.Http.HttpClient(handler))
                     {
                         client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);

--- a/docs/configuration/proxy.mdx
+++ b/docs/configuration/proxy.mdx
@@ -42,8 +42,12 @@ proxy:
 </ParamField>
 
 <ParamField path="proxy.list" type="array">
-  Список адресов прокси. Форматы: `ip:port` (HTTP), `socks5://ip:port` (SOCKS5). JacRed случайным образом выбирает один адрес из списка на каждый запрос.
+  Список адресов прокси. Форматы: `ip:port` или `http://ip:port` (HTTP CONNECT), `socks5://ip:port` (SOCKS5). JacRed случайным образом выбирает один адрес из списка на каждый запрос. Запись `socks5h://` (как в curl) приводится к `socks5://`; DNS резолвится на стороне прокси.
 </ParamField>
+
+<Note>
+  SOCKS5 не работает через HTTP CONNECT. Указывайте схему `socks5://`, а не голый `host:port` — без схемы JacRed считает адрес HTTP-прокси.
+</Note>
 
 ## Правила по URL: globalproxy
 
@@ -83,7 +87,7 @@ globalproxy:
 </ParamField>
 
 <ParamField path="list" type="array">
-  Список адресов прокси. Форматы: `ip:port` (HTTP) или `socks5://ip:port` (SOCKS5).
+  Список адресов прокси. Форматы: `ip:port` или `http://ip:port` (HTTP CONNECT), `socks5://ip:port` (SOCKS5). `socks5h://` приводится к `socks5://`.
 </ParamField>
 
 ## Прокси для конкретного трекера

--- a/docs/operations/troubleshooting.mdx
+++ b/docs/operations/troubleshooting.mdx
@@ -78,7 +78,7 @@ journalctl -u jacred -n 100 --no-pager
     ss -ltnp | grep ':9050'
     ```
 
-    Для Tor используйте URI вида `socks5://127.0.0.1:9050`. Подробнее читайте в разделе [Прокси](/configuration/proxy).
+    Для Tor и любого SOCKS5 используйте URI со схемой, например `socks5://127.0.0.1:9050`. Запись `host:port` без схемы идёт как HTTP-прокси и на SOCKS5-сервере не работает. Если для HTTP-прокси включён `useAuth`, а SOCKS5 авторизацию не принимает, поставьте `useAuth: false`. Подробнее читайте в разделе [Прокси](/configuration/proxy).
   </Accordion>
 
   <Accordion title="JacRed потребляет много памяти">

--- a/tests/JacRed.Tests/Networking/ProxyHandlerTests.cs
+++ b/tests/JacRed.Tests/Networking/ProxyHandlerTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http;
+using JacRed.Models.AppConf;
+using Xunit;
+using JacHttp = JacRed.Infrastructure.Networking.HttpClient;
+
+namespace JacRed.Tests.Networking;
+
+public class ProxyHandlerTests
+{
+    [Theory]
+    [InlineData("socks5://10.0.0.2:1080", "socks5")]
+    [InlineData("socks5h://127.0.0.1:9050", "socks5")]
+    [InlineData("socks://127.0.0.1:1080", "socks5")]
+    [InlineData("http://10.0.0.1:8080", "http")]
+    [InlineData("10.0.0.1:8080", "http")]
+    public void NormalizeProxyAddress_keeps_or_maps_scheme(string raw, string scheme)
+    {
+        Uri uri = JacHttp.NormalizeProxyAddress(raw);
+        Assert.Equal(scheme, uri.Scheme);
+    }
+
+    [Fact]
+    public void CreateWebProxy_preserves_socks5_and_auth()
+    {
+        var settings = new ProxySettings
+        {
+            useAuth = true,
+            username = "user",
+            password = "secret",
+            BypassOnLocal = true
+        };
+
+        WebProxy proxy = JacHttp.CreateWebProxy("socks5://10.0.0.2:1080", settings);
+
+        Assert.Equal("socks5", proxy.Address.Scheme);
+        Assert.Equal(1080, proxy.Address.Port);
+        Assert.True(proxy.BypassProxyOnLocal);
+        Assert.NotNull(proxy.Credentials);
+        var creds = proxy.Credentials.GetCredential(proxy.Address, "socks");
+        Assert.Equal("user", creds.UserName);
+        Assert.Equal("secret", creds.Password);
+    }
+
+    [Fact]
+    public void CreateHandler_uses_sockets_handler_for_socks5()
+    {
+        WebProxy proxy = JacHttp.CreateWebProxy("socks5://127.0.0.1:1080", null);
+
+        using SocketsHttpHandler handler = JacHttp.CreateHandler(proxy, DecompressionMethods.GZip);
+
+        Assert.True(handler.UseProxy);
+        Assert.Same(proxy, handler.Proxy);
+        Assert.True(handler.AllowAutoRedirect);
+    }
+}


### PR DESCRIPTION
- Updated `HttpClient` to normalize proxy addresses, supporting `socks5h://` and `socks://` schemes.
- Improved `CreateWebProxy` method to utilize normalized proxy addresses.
- Refactored `CreateHandler` to use `SocketsHttpHandler` for SOCKS5 proxies, allowing for better handling of proxy connections.
- Added unit tests for proxy address normalization and web proxy creation to ensure correct behavior.
- Updated documentation to clarify proxy address formats and usage.