### PR TITLE
feat(trackers): enhance Kinozal support with FlareSolverr integration

### DIFF
--- a/.cursor/skills/jacred-tracker-parser/reference.md
+++ b/.cursor/skills/jacred-tracker-parser/reference.md
@@ -16,7 +16,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 
 | Auth | Slugs | Gotcha |
 |------|-------|--------|
-| CF + FlareSolverr | rutracker | Warmup ~5m before parse; not for Anistar |
+| CF + FlareSolverr | rutracker, kinozal | Warmup ~5m before parse; not for Anistar |
 | Public anon HTML | anistar (`host` + `alias`) | FDB on `host`; fetch via `alias` mirror |
 | Login and/or cookie | kinozal, baibako, rudub, animelayer, anifilm, korsars (`bb_data`), selezen, toloka, mazepa, lostfilm | Prefer config cookie when set |
 | Anon only | anibelka | Never login — passkeys in torrents |
@@ -39,7 +39,7 @@ Read this when choosing a clone target or auth/magnet policy. Keep SKILL.md for 
 
 - **rutracker** — CF Flare · trio · magnet · warmup + `alias`
 - **rutor** — anon · trio · magnet list · classic template
-- **kinozal** — login/cookie · trio · hash→magnet · cp1251, domain churn
+- **kinozal** — login/cookie · trio · hash→magnet via GET `get_srv_details` · cp1251 · CF FlareSolverr
 - **nnmclub** — anon (+onion alias) · trio · magnet · cp1251
 - **megapeer** — anon · trio · t→M · cp1251 + cat Referer
 - **bitru** — anon API · parse+backfill · t→M · cursor files

--- a/Configuration/Schema/ConfigSchema.cs
+++ b/Configuration/Schema/ConfigSchema.cs
@@ -138,7 +138,7 @@ namespace JacRed.Configuration.Schema
                         Field("proxy.list", "stringList", "Proxy list", "ip:port или socks5://…"),
                         Field("globalproxy", "json", "Global proxy", "JSON-массив ProxySettings")
                     }),
-                    Group("flaresolverr", "FlareSolverr", "Cloudflare bypass через безголовый браузер (Rutracker)", new[]
+                    Group("flaresolverr", "FlareSolverr", "Cloudflare bypass через безголовый браузер (Rutracker, Kinozal)", new[]
                     {
                         Field("flaresolverr.enable", "bool", "Включить", "Ходить на CF-хосты через браузер"),
                         Field("flaresolverr.url", "string", "URL", "http://127.0.0.1:8191/v1 или http://flaresolverr:8191/v1"),

--- a/Infrastructure/Networking/CloudflareClearance.cs
+++ b/Infrastructure/Networking/CloudflareClearance.cs
@@ -349,6 +349,11 @@ namespace JacRed.Infrastructure.Networking
             if (IsChallengeBody(html))
                 return (FetchOutcome.PageFailed, null, "challenge html in solution");
 
+            // Origin nginx 503 behind CF: FS still reports solution.status=200.
+            if (html.Length < 2000
+                && html.Contains("503 Service Temporarily Unavailable", StringComparison.OrdinalIgnoreCase))
+                return (FetchOutcome.PageFailed, null, "origin 503");
+
             return (FetchOutcome.Ok, html, null);
         }
 

--- a/Infrastructure/Trackers/Kinozal/KinozalParser.cs
+++ b/Infrastructure/Trackers/Kinozal/KinozalParser.cs
@@ -280,6 +280,67 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
         }
 
         /// <summary>
+        /// Info hash from <c>get_srv_details.php?id=&amp;action=2</c>.
+        /// FlareSolverr GET returns a short UTF-8 fragment with «Инфо хеш».
+        /// Ignore browse-sized HTML (stale Chromium tab) so we do not mint a fake magnet.
+        /// </summary>
+        public static string ParseInfoHash(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+                return null;
+
+            var labeled = Regex.Match(html, "<ul><li>Инфо хеш:\\s*([A-Fa-f0-9]{40})</li>");
+            if (labeled.Success)
+                return labeled.Groups[1].Value;
+
+            if (html.Length > 8000)
+                return null;
+
+            var loose = Regex.Match(html, "([A-Fa-f0-9]{40})");
+            return loose.Success ? loose.Groups[1].Value : null;
+        }
+
+        public static bool IsLoggedIn(string html) =>
+            !string.IsNullOrEmpty(html) && html.Contains(">Выход</a>");
+
+        /// <summary>
+        /// Null, nginx 503 behind Cloudflare, or a CF interstitial — retry, do not TakeLogin.
+        /// </summary>
+        public static bool IsTransientBrowseFailure(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+                return true;
+
+            if (html.Contains("Just a moment", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("Один момент", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return html.Length < 2000
+                && html.Contains("503 Service Temporarily Unavailable", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsLoginWall(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html) || IsTransientBrowseFailure(html) || IsLoggedIn(html))
+                return false;
+
+            return html.Contains("takelogin.php", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("take_login", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("name=\"username\"", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Empty listing → done. Rows that still need a magnet → not done until every row is resolved.
+        /// </summary>
+        public static bool ShouldMarkPageDone(int parsedCount, int resolvedCount)
+        {
+            if (parsedCount <= 0)
+                return true;
+
+            return resolvedCount >= parsedCount;
+        }
+
+        /// <summary>
         /// Кинозал при добавлении серий/озвучек перехеширует .torrent (новый info hash),
         /// но title в списке часто не меняется — раньше hash не перезапрашивался.
         /// createTime = date from browse «Залит» column: Обновлен if present on details,

--- a/Infrastructure/Trackers/Kinozal/KinozalSyncService.cs
+++ b/Infrastructure/Trackers/Kinozal/KinozalSyncService.cs
@@ -213,7 +213,7 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
                             {
                                 _cookie = cookieHeader;
                                 _lastLoginError = null;
-                                ParserLog.Write(TrackerName, $"TakeLogin OK {_cookie}");
+                                ParserLog.Write(TrackerName, "TakeLogin OK");
                                 return true;
                             }
 
@@ -253,6 +253,16 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
                 referer: $"{AppInit.conf.Kinozal.host}/",
                 useproxy: AppInit.conf.Kinozal.useproxy,
                 cancellationToken: cancellationToken);
+        }
+
+        async Task<string> GetBrowseHtmlRetryingTransient(string browseUrl, CancellationToken cancellationToken)
+        {
+            string html = await GetBrowseHtml(browseUrl, cancellationToken);
+            if (!KinozalParser.IsTransientBrowseFailure(html))
+                return html;
+
+            await Task.Delay(1500, cancellationToken);
+            return await GetBrowseHtml(browseUrl, cancellationToken);
         }
 
         public async Task<string> ParseAsync(int page)
@@ -423,44 +433,61 @@ namespace JacRed.Infrastructure.Trackers.Kinozal
                 return false;
 
             string browseUrl = $"{AppInit.conf.Kinozal.host}/browse.php?c={cat}&page={page}" + arg;
-            string html = await GetBrowseHtml(browseUrl, cancellationToken);
-            if (!IsValidBrowsePage(html) || !html.Contains(">Выход</a>"))
+            string html = await GetBrowseHtmlRetryingTransient(browseUrl, cancellationToken);
+
+            if (KinozalParser.IsTransientBrowseFailure(html))
+            {
+                ParserLog.Write(TrackerName, $"browse transient failure, skip login: {browseUrl}");
+                return false;
+            }
+
+            if (KinozalParser.IsLoginWall(html) || (IsValidBrowsePage(html) && !KinozalParser.IsLoggedIn(html)))
             {
                 _cookie = null;
                 if (!await TakeLogin())
                     return false;
 
-                html = await GetBrowseHtml(browseUrl, cancellationToken);
-                if (!IsValidBrowsePage(html))
+                html = await GetBrowseHtmlRetryingTransient(browseUrl, cancellationToken);
+                if (KinozalParser.IsTransientBrowseFailure(html) || !IsValidBrowsePage(html))
                     return false;
+            }
+            else if (!IsValidBrowsePage(html))
+            {
+                return false;
             }
 
             var torrents = KinozalParser.ParseTorrentsFromPage(html, cat);
+            int resolved = 0;
 
             await FileDB.AddOrUpdate(torrents, async (t, db) =>
             {
                 if (db.TryGetValue(t.url, out TorrentDetails cached) && KinozalParser.ShouldSkipHashFetch(cached, t))
-                    return true;
-
-                string id = Regex.Match(t.url, "\\?id=([0-9]+)").Groups[1].Value;
-                string srv_details = await HttpClient.Post($"{AppInit.conf.Kinozal.host}/get_srv_details.php?id={id}&action=2", $"id={id}&action=2", CookieHeader(), useproxy: AppInit.conf.Kinozal.useproxy, cancellationToken: cancellationToken);
-                if (srv_details != null)
                 {
-                    string torrentHash = new Regex("<ul><li>Инфо хеш:\\s*([A-Fa-f0-9]{40})</li>").Match(srv_details).Groups[1].Value;
-                    if (string.IsNullOrWhiteSpace(torrentHash))
-                        torrentHash = new Regex("([A-Fa-f0-9]{40})").Match(srv_details).Groups[1].Value;
-
-                    if (!string.IsNullOrWhiteSpace(torrentHash))
-                    {
-                        t.magnet = $"magnet:?xt=urn:btih:{torrentHash.ToUpperInvariant()}";
-                        return true;
-                    }
+                    resolved++;
+                    return true;
                 }
 
-                return false;
+                string id = Regex.Match(t.url, "\\?id=([0-9]+)").Groups[1].Value;
+                // GET: id/action already in the query. HttpClient.Get routes guarded
+                // Cloudflare hosts through FlareSolverr. request.post is flaky in the
+                // shared Chromium session (returns the previous browse tab).
+                string srv_details = await HttpClient.Get(
+                    $"{AppInit.conf.Kinozal.host}/get_srv_details.php?id={id}&action=2",
+                    encoding: PageEncoding,
+                    cookie: CookieHeader(),
+                    useproxy: AppInit.conf.Kinozal.useproxy,
+                    cancellationToken: cancellationToken);
+
+                string torrentHash = KinozalParser.ParseInfoHash(srv_details);
+                if (string.IsNullOrWhiteSpace(torrentHash))
+                    return false;
+
+                t.magnet = $"magnet:?xt=urn:btih:{torrentHash.ToUpperInvariant()}";
+                resolved++;
+                return true;
             });
 
-            return torrents.Count > 0;
+            return KinozalParser.ShouldMarkPageDone(torrents.Count, resolved);
         }
     }
 }

--- a/docs/configuration/flaresolverr.mdx
+++ b/docs/configuration/flaresolverr.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Настройка FlareSolverr для Rutracker"
+title: "Настройка FlareSolverr"
 sidebarTitle: "FlareSolverr"
-description: "FlareSolverr обходит Cloudflare-защиту Rutracker через постоянную браузерную сессию. Настройте блок flaresolverr в init.yaml и cron-прогрев сессии."
-keywords: ["JacRed", "конфигурация", "FlareSolverr", "init.yaml"]
+description: "FlareSolverr обходит Cloudflare для Rutracker и Kinozal через постоянную браузерную сессию. Настройте блок flaresolverr в init.yaml и cron-прогрев сессии."
+keywords: ["JacRed", "конфигурация", "FlareSolverr", "init.yaml", "Rutracker", "Kinozal"]
 ---
 
-Rutracker защищён Cloudflare. Прямой `HttpClient` не может обойти `cf_clearance` cookie (отличается TLS fingerprint). FlareSolverr запускает реальный браузер Chromium для получения clearance и передаёт его JacRed.
+Rutracker и Kinozal защищены Cloudflare. Прямой `HttpClient` не может обойти `cf_clearance` cookie (отличается TLS fingerprint). FlareSolverr запускает реальный браузер Chromium для получения clearance и передаёт HTML в JacRed.
 
 ## Принцип работы
 

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -144,7 +144,7 @@ torznab:
 #   token: ""
 #   cacheHours: 24
 
-# FlareSolverr (для Rutracker)
+# FlareSolverr (Rutracker, Kinozal)
 flaresolverr:
   enable: true
   url: http://127.0.0.1:8191/v1
@@ -189,7 +189,7 @@ curl -X POST "http://localhost:9117/api/v1.0/config" \
   </Card>
 
   <Card title="FlareSolverr" icon="cloud" href="/configuration/flaresolverr">
-    Обход Cloudflare для Rutracker через реальный браузер.
+    Обход Cloudflare для Rutracker и Kinozal через реальный браузер.
   </Card>
 
   <Card title="Alloha TV" icon="film" href="/configuration/alloha">

--- a/docs/configuration/trackers.mdx
+++ b/docs/configuration/trackers.mdx
@@ -86,7 +86,7 @@ TrackerName:
 | Трекер | Slug | Рекомендуемый способ |
 | --- | --- | --- |
 | Rutracker | `rutracker` | FlareSolverr (CF-защита) |
-| Kinozal | `kinozal` | cookie или login/password |
+| Kinozal | `kinozal` | cookie или login/password + FlareSolverr (Cloudflare) |
 | Toloka | `toloka` | cookie или login/password |
 | Mazepa | `mazepa` | cookie или login/password |
 | Lostfilm | `lostfilm` | cookie или login/password |

--- a/docs/operations/troubleshooting.mdx
+++ b/docs/operations/troubleshooting.mdx
@@ -71,6 +71,16 @@ journalctl -u jacred -n 100 --no-pager
     Первый warmup может выполняться несколько минут. На VPS с датацентровым IP challenge может потребовать residential/ISP-прокси для FlareSolverr. См. [настройку Rutracker](/trackers/rutracker).
   </Accordion>
 
+  <Accordion title="Kinozal парсится, но новых раздач нет">
+    `kinozal.guru` за Cloudflare. Списки и info-hash идут через FlareSolverr GET. Проверьте:
+
+    ```bash
+    python3 scripts/flaresolverr_kinozal_cf_check.py
+    ```
+
+    Прямой curl получит `403` / «Just a moment». В FlareSolverr нужны listing rows и `Инфо хеш` на шаге GET. См. [Kinozal](/trackers/kinozal).
+  </Accordion>
+
   <Accordion title="Прокси или Tor не работает">
     Проверьте порт Tor, URI прокси и регулярное выражение `globalproxy.pattern`:
 

--- a/docs/trackers/kinozal.mdx
+++ b/docs/trackers/kinozal.mdx
@@ -2,7 +2,7 @@
 title: "Настройка трекера Kinozal"
 sidebarTitle: "Kinozal"
 icon: "/images/trackers/kinozal.ico"
-description: "Kinozal требует авторизации. Настройте cookie или login/password в блоке Kinozal в init.yaml. Кодировка cp1251. Trio-кластер, ~550k раздач."
+description: "Kinozal требует cookie или login и FlareSolverr: kinozal.guru за Cloudflare. Кодировка cp1251. Trio-кластер, ~550k раздач."
 keywords: ["JacRed", "Kinozal", "трекер", "парсинг"]
 ---
 
@@ -47,6 +47,12 @@ Kinozal:
   Cookie протухает при явном выходе из аккаунта или смене пароля. При пустых результатах парсинга проверьте актуальность cookie.
 </Warning>
 
+## Cloudflare
+
+`kinozal.guru` отдаёт `403` с `cf-mitigated: challenge`. Прямой HTTP из JacRed не проходит. Списки (`browse.php`) и info-hash (`get_srv_details.php`) идут через FlareSolverr **GET** — тот же путь, что у Rutracker. `request.post` в общей сессии `jacred` часто возвращает предыдущую вкладку, а не хеш.
+
+Нужны cookie (или login) и `flaresolverr.enable: true`. Подробнее: [FlareSolverr](/configuration/flaresolverr).
+
 ## Расписание cron
 
 ```crontab
@@ -65,12 +71,15 @@ Kinozal:
 В релизе 3.9.3 домен по умолчанию — `kinozal.guru`. Обновляйте `host`, если рабочее зеркало изменилось.
 
 <Note>
-  Магниты извлекаются из страниц топиков через hash-to-magnet конвертацию, а не из страницы списка. Это занимает больше времени, чем у трекеров с магнитами в списке.
+Магниты берутся из `get_srv_details.php` (hash-to-magnet), а не из списка. Запрос — GET через FlareSolverr, поэтому полный проход медленнее, чем у трекеров с магнитом в листинге.
 </Note>
 
 ## Диагностика
 
 ```bash
+# Обход Cloudflare: listing + info-hash через FlareSolverr
+python3 scripts/flaresolverr_kinozal_cf_check.py
+
 # Ручной запуск парсинга
 curl "http://localhost:9117/cron/kinozal/parse"
 

--- a/docs/trackers/overview.mdx
+++ b/docs/trackers/overview.mdx
@@ -14,7 +14,7 @@ JacRed 3.9.3 включает 25 встроенных slug трекеров. Е�
 | Slug | Хост | Авторизация | Объём | Особенности |
 | --- | --- | --- | --- | --- |
 | [`rutracker`](/trackers/rutracker) | rutracker.org | FlareSolverr | ~1.5M | Cloudflare |
-| [`kinozal`](/trackers/kinozal) | kinozal.guru | cookie или login | ~550k | cp1251 |
+| [`kinozal`](/trackers/kinozal) | kinozal.guru | cookie или login + FlareSolverr | ~550k | Cloudflare, cp1251 |
 | [`rutor`](/trackers/rutor) | rutor.info | нет | ~550k | Магниты в списке |
 | [`nnmclub`](/trackers/nnmclub) | nnmclub.to | нет | ~145k | cp1251, .onion |
 | [`megapeer`](/trackers/megapeer) | megapeer.vip | нет | ~113k | cp1251 |

--- a/scripts/flaresolverr_kinozal_cf_check.py
+++ b/scripts/flaresolverr_kinozal_cf_check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Compare FlareSolverr vs plain HTTP for Kinozal Cloudflare.
+
+JacRed already GETs browse.php through FlareSolverr. Magnets need
+get_srv_details.php (info hash). FlareSolverr request.post is flaky in the
+shared `jacred` session (often returns the previous browse tab). Prefer GET
+of the same URL (id/action are query params).
+
+Run on the host where FlareSolverr listens (default :8191). Session name
+matches JacRed (`jacred`) so Chromium already has tracker cookies if the
+crawler is running. Login/password is not needed when the browse flags show
+logged_in: True. Do not put uid/pass in this file.
+
+  python3 scripts/flaresolverr_kinozal_cf_check.py
+  BROWSE_URL='https://kinozal.guru/browse.php?c=22&page=0' \\
+    python3 scripts/flaresolverr_kinozal_cf_check.py
+
+Paste the stdout of this script for investigation. Bodies are truncated;
+set SAVE_DIR=/tmp/kz-cf-check to dump full HTML.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+FS_URL = os.environ.get("FS_URL", "http://127.0.0.1:8191/v1")
+SESSION = os.environ.get("FS_SESSION", "jacred")
+# page=0 of a live category — year-filtered ParseAllTask pages are often empty.
+BROWSE_URL = os.environ.get(
+    "BROWSE_URL",
+    "https://kinozal.guru/browse.php?c=22&page=0",
+)
+TORRENT_ID = os.environ.get("TORRENT_ID", "").strip()
+MAX_TIMEOUT_MS = int(os.environ.get("MAX_TIMEOUT_MS", "300000"))
+CURL_MAX = MAX_TIMEOUT_MS / 1000 + 30
+SAVE_DIR = os.environ.get("SAVE_DIR", "").strip()
+SNIPPET = 400
+
+CTX = ssl.create_default_context()
+CTX.check_hostname = False
+CTX.verify_mode = ssl.CERT_NONE
+
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+def cookies_from_env() -> list[dict[str, str]]:
+    uid = os.environ.get("KINOZAL_UID", "").strip()
+    password = os.environ.get("KINOZAL_PASS", "").strip()
+    if not uid or not password:
+        return []
+    return [{"name": "uid", "value": uid}, {"name": "pass", "value": password}]
+
+
+def save(name: str, body: str) -> None:
+    if not SAVE_DIR:
+        return
+    path = Path(SAVE_DIR)
+    path.mkdir(parents=True, exist_ok=True)
+    (path / name).write_text(body, encoding="utf-8", errors="replace")
+
+
+def snippet(body: str) -> str:
+    return body[:SNIPPET].replace("\n", " ")
+
+
+INFO_HASH = re.compile(r"Инфо хеш:\s*([A-Fa-f0-9]{40})")
+# href="/details.php?id=" — do not match userdetails.php?id= (logged-in profile).
+TORRENT_HREF = re.compile(r"""href=["']/?details\.php\?id=(\d+)["']""", re.I)
+
+
+def flags(body: str) -> dict[str, Any]:
+    info = INFO_HASH.search(body)
+    return {
+        "len": len(body),
+        "cf_just_a_moment": "Just a moment" in body or "Один момент" in body,
+        "cf_challenge": "challenge-platform" in body or "cf-browser-verification" in body,
+        "cf_chl_opt": "_cf_chl_opt" in body,
+        "kinozal_rows": "first bg" in body or "class=bg" in body,
+        "details.php": bool(TORRENT_HREF.search(body)),
+        "logged_in": ">Выход</a>" in body,
+        "login_wall": "take_login" in body or "login.php" in body,
+        "not_found": "Торрент файл не найден" in body,
+        "nginx_503": "503 Service Temporarily Unavailable" in body,
+        "info_hash_label": bool(info),
+        "hash40": info.group(1) if info else None,
+        "rutracker_html": "rutracker.org" in body.lower() or "RuTracker.org" in body,
+        "stale_browse": "Раздачи :: Кинозал" in body and not bool(info),
+        "title": (m.group(1) if (m := re.search(r"<title>([^<]+)</title>", body, re.I)) else ""),
+    }
+
+
+def print_flags(label: str, data: dict[str, Any]) -> None:
+    print(f"  {label}:")
+    for key, value in data.items():
+        print(f"    {key}: {value}")
+
+
+def fs_call(cmd: str, url: str, post_data: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "cmd": cmd,
+        "session": SESSION,
+        "url": url,
+        "maxTimeout": MAX_TIMEOUT_MS,
+    }
+    jar = cookies_from_env()
+    if jar:
+        payload["cookies"] = jar
+    if post_data is not None:
+        payload["postData"] = post_data
+
+    raw = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        FS_URL,
+        data=raw,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=CURL_MAX, context=CTX) as resp:
+            return json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return {"status": "error", "message": f"HTTP {exc.code}", "raw": body[:SNIPPET]}
+    except Exception as exc:
+        return {"status": "error", "message": f"{type(exc).__name__}: {exc}"}
+
+
+def fs_solution(root: dict[str, Any]) -> tuple[int | None, str]:
+    solution = root.get("solution") or {}
+    return solution.get("status"), solution.get("response") or ""
+
+
+def direct(url: str, data: bytes | None = None) -> tuple[int | None, dict[str, str], str]:
+    headers = {
+        "User-Agent": UA,
+        "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST" if data else "GET")
+    try:
+        with urllib.request.urlopen(req, timeout=20, context=CTX) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            hdrs = {k.lower(): v for k, v in resp.headers.items()}
+            return resp.status, hdrs, body
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        hdrs = {k.lower(): v for k, v in exc.headers.items()} if exc.headers else {}
+        return exc.code, hdrs, body
+    except Exception as exc:
+        return None, {}, f"{type(exc).__name__}: {exc}"
+
+
+def interesting_headers(hdrs: dict[str, str]) -> dict[str, str]:
+    keep = (
+        "server",
+        "cf-ray",
+        "cf-mitigated",
+        "cf-cache-status",
+        "content-type",
+        "location",
+    )
+    return {k: hdrs[k] for k in keep if k in hdrs}
+
+
+def extract_ids(html: str) -> list[str]:
+    seen: list[str] = []
+    for torrent_id in TORRENT_HREF.findall(html):
+        if torrent_id not in seen:
+            seen.append(torrent_id)
+    return seen
+
+
+def main() -> int:
+    cookies = cookies_from_env()
+    print("== kinozal Cloudflare check ==")
+    print(f"FS_URL: {FS_URL}")
+    print(f"session: {SESSION}")
+    print(f"browse: {BROWSE_URL}")
+    print(f"cookies_from_env: {'uid+pass (values hidden)' if cookies else 'none (reuse Chromium session)'}")
+    if SAVE_DIR:
+        print(f"SAVE_DIR: {SAVE_DIR}")
+    print()
+
+    print("== 1 FlareSolverr GET browse.php ==")
+    browse_fs = fs_call("request.get", BROWSE_URL)
+    http, html = fs_solution(browse_fs)
+    print(f"  status: {browse_fs.get('status')}")
+    print(f"  message: {browse_fs.get('message')}")
+    print(f"  http: {http}")
+    print_flags("body", flags(html))
+    ids = extract_ids(html)
+    print(f"  ids_count: {len(ids)}")
+    print(f"  ids: {','.join(ids[:12]) if ids else '(none)'}")
+    print(f"  snippet: {snippet(html)}")
+    save("1-browse-flaresolverr.html", html)
+    print()
+    if flags(html)["nginx_503"]:
+        print("== stop: FlareSolverr got origin nginx 503 (transient). Re-run in a minute. ==")
+    elif not ids:
+        print("== stop: listing has no torrent href=/details.php?id= ==")
+        print("  This page is empty or still year-filtered. Re-run with:")
+        print("  BROWSE_URL='https://kinozal.guru/browse.php?c=22&page=0' python3 scripts/flaresolverr_kinozal_cf_check.py")
+        print("  Login/password is not required when logged_in is True.")
+    print("== 2 direct GET browse.php (expect CF challenge) ==")
+    code, hdrs, body = direct(BROWSE_URL)
+    print(f"  http: {code}")
+    print(f"  headers: {interesting_headers(hdrs)}")
+    print_flags("body", flags(body))
+    print(f"  snippet: {snippet(body)}")
+    save("2-browse-direct.html", body)
+    print()
+
+    if TORRENT_ID:
+        torrent_id = TORRENT_ID
+        print(f"  TORRENT_ID override: {torrent_id}")
+    elif ids:
+        torrent_id = ids[0]
+    else:
+        print("== stop: no torrent id (empty listing, not a missing login) ==")
+        return 1
+
+    hash_url = f"https://kinozal.guru/get_srv_details.php?id={torrent_id}&action=2"
+    post_data = f"id={torrent_id}&action=2"
+    print(f"== using torrent id {torrent_id} ==")
+    print(f"  hash_url: {hash_url}")
+    print()
+
+    print("== 3 direct POST get_srv_details.php (expect CF challenge) ==")
+    code, hdrs, body = direct(hash_url, data=post_data.encode("utf-8"))
+    print(f"  http: {code}")
+    print(f"  headers: {interesting_headers(hdrs)}")
+    print_flags("body", flags(body))
+    print(f"  snippet: {snippet(body)}")
+    save("3-hash-direct.html", body)
+    print()
+
+    print("== 4 FlareSolverr POST get_srv_details.php (often stale tab) ==")
+    hash_fs = fs_call("request.post", hash_url, post_data=post_data)
+    http, html = fs_solution(hash_fs)
+    print(f"  status: {hash_fs.get('status')}")
+    print(f"  message: {hash_fs.get('message')}")
+    print(f"  http: {http}")
+    print_flags("body", flags(html))
+    print(f"  snippet: {snippet(html)}")
+    save("4-hash-flaresolverr-post.html", html)
+    print()
+
+    print("== 5 FlareSolverr GET get_srv_details.php (JacRed path) ==")
+    hash_get = fs_call("request.get", hash_url)
+    get_http, get_html = fs_solution(hash_get)
+    print(f"  status: {hash_get.get('status')}")
+    print(f"  message: {hash_get.get('message')}")
+    print(f"  http: {get_http}")
+    print_flags("body", flags(get_html))
+    print(f"  snippet: {snippet(get_html)}")
+    save("5-hash-flaresolverr-get.html", get_html)
+    print()
+
+    print("== verdict ==")
+    browse_flags = flags(fs_solution(browse_fs)[1])
+    post_flags = flags(html)
+    get_flags = flags(get_html)
+    browse_ok = browse_flags["kinozal_rows"] and bool(ids) and not browse_flags["cf_just_a_moment"]
+    direct_blocked = (code in (403, 503)) or flags(body)["cf_just_a_moment"]
+    post_ok = bool(post_flags["hash40"]) and not post_flags["rutracker_html"] and not post_flags["not_found"]
+    get_ok = bool(get_flags["hash40"]) and not get_flags["rutracker_html"] and not get_flags["not_found"]
+    print(f"  browse_via_flaresolverr: {'OK' if browse_ok else 'FAIL'}")
+    print(f"  hash_direct_blocked: {'YES' if direct_blocked else 'NO / unexpected'}")
+    print(f"  hash_via_flaresolverr_post: {'OK' if post_ok else 'FAIL'}")
+    print(f"  hash_via_flaresolverr_get: {'OK' if get_ok else 'FAIL'}")
+    if post_flags["stale_browse"] or get_flags["stale_browse"]:
+        print("  note: hash call returned a browse listing (shared jacred session / POST did not navigate).")
+    if post_flags["rutracker_html"] or get_flags["rutracker_html"]:
+        print("  note: FlareSolverr returned rutracker HTML (shared jacred session). Re-run when parse is idle.")
+    if browse_ok and get_ok and direct_blocked:
+        print("  next: JacRed should GET get_srv_details.php through FlareSolverr (not POST).")
+    elif browse_ok and post_ok and not get_ok:
+        print("  next: POST worked, GET did not — paste this stdout.")
+    elif browse_ok and not get_ok:
+        print("  next: listing works; FlareSolverr hash GET failed — paste this stdout.")
+    else:
+        print("  next: paste this stdout; listing or FS session needs another look.")
+    return 0 if browse_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/JacRed.Tests/Kinozal/KinozalParserFixtureTests.cs
+++ b/tests/JacRed.Tests/Kinozal/KinozalParserFixtureTests.cs
@@ -91,6 +91,60 @@ public class KinozalParserFixtureTests
     }
 
     [Fact]
+    public void ParseInfoHash_FlareSolverrFragment_ReturnsLabeledHash()
+    {
+        const string html = "<html><head></head><body><ul><li>Инфо хеш: 7C4FCE77B05BC2711C8445C0B1E47011CF4214CE</li>"
+            + "<li>Размер части торрента: 1 МБ</li></ul></body></html>";
+
+        Assert.Equal("7C4FCE77B05BC2711C8445C0B1E47011CF4214CE", KinozalParser.ParseInfoHash(html));
+    }
+
+    [Fact]
+    public void ParseInfoHash_BrowseSizedHtml_DoesNotUseLooseHex()
+    {
+        string html = new string('x', 9000) + "0123456789abcdef0123456789abcdef01234567";
+        Assert.Null(KinozalParser.ParseInfoHash(html));
+    }
+
+    [Fact]
+    public void ParseInfoHash_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(KinozalParser.ParseInfoHash(null));
+        Assert.Null(KinozalParser.ParseInfoHash(""));
+        Assert.Null(KinozalParser.ParseInfoHash("Торрент файл не найден."));
+    }
+
+    [Fact]
+    public void IsTransientBrowseFailure_NullAndNginx503()
+    {
+        Assert.True(KinozalParser.IsTransientBrowseFailure(null));
+        Assert.True(KinozalParser.IsTransientBrowseFailure(""));
+        Assert.True(KinozalParser.IsTransientBrowseFailure(
+            "<html><head><title>503 Service Temporarily Unavailable</title></head></html>"));
+        Assert.True(KinozalParser.IsTransientBrowseFailure("<title>Just a moment...</title>"));
+        Assert.False(KinozalParser.IsTransientBrowseFailure(FixtureLoader.Read("Kinozal/browse_c22.html")));
+    }
+
+    [Fact]
+    public void IsLoginWall_AndLoggedIn_FromFixture()
+    {
+        string listing = FixtureLoader.Read("Kinozal/browse_c22.html");
+        Assert.True(KinozalParser.IsLoggedIn(listing));
+        Assert.False(KinozalParser.IsLoginWall(listing));
+        Assert.True(KinozalParser.IsLoginWall("<form action=\"/takelogin.php\"><input name=\"username\">"));
+        Assert.False(KinozalParser.IsLoginWall("<title>503 Service Temporarily Unavailable</title>"));
+    }
+
+    [Fact]
+    public void ShouldMarkPageDone_EmptyOrFullyResolved()
+    {
+        Assert.True(KinozalParser.ShouldMarkPageDone(0, 0));
+        Assert.True(KinozalParser.ShouldMarkPageDone(10, 10));
+        Assert.False(KinozalParser.ShouldMarkPageDone(10, 0));
+        Assert.False(KinozalParser.ShouldMarkPageDone(10, 9));
+    }
+
+    [Fact]
     public void DryRun_AllFixtures_ReportParseRates()
     {
         foreach (object[] row in FixtureCases())


### PR DESCRIPTION
- Updated KinozalParser to utilize FlareSolverr for fetching info hashes via GET requests, improving reliability against Cloudflare challenges.
- Added methods to handle transient failures and determine login status.
- Enhanced documentation to reflect the new FlareSolverr requirements for Kinozal and updated configuration examples.
- Introduced a new script for checking FlareSolverr functionality with Kinozal.
- Added unit tests to validate new parsing logic and ensure correct handling of various HTML responses.