### PR TITLE
feat(rutracker): enhance parsing logic and update forum categories

### DIFF
--- a/Infrastructure/Trackers/Rutracker/README.md
+++ b/Infrastructure/Trackers/Rutracker/README.md
@@ -74,6 +74,18 @@ Limited smoke (after app + FlareSolverr are up):
 ```bash
 ./scripts/cron_rutracker_smoke.sh
 # or: curl 'http://127.0.0.1:9117/cron/rutracker/parse?page=0&cat=2090&maxTopics=3'
+# After adding forums (e.g. 1669 UHD US/Canada): CAT=1669 ./scripts/cron_rutracker_smoke.sh
+```
+
+Rebuild the page map for new forum ids, then parse that cat so title/size/`createTime` can refresh a stale magnet:
+
+```bash
+curl 'http://127.0.0.1:9117/cron/rutracker/UpdateTasksParse?cat=1669'
+# wait until /health/background-jobs has no rutracker:UpdateTasksParse
+grep -E '"1669"' Data/temp/rutracker_taskParse.json | head
+curl 'http://127.0.0.1:9117/cron/rutracker/parse?page=0&cat=1669&maxTopics=20'
+# Offline map check (no live site): python3 scripts/dry_run_rutracker_parser.py --check-snapshot
+# Live parent→leaf BFS: python3 scripts/dry_run_rutracker_parser.py --probe-tree
 ```
 
 ## Cron endpoints
@@ -81,19 +93,19 @@ Limited smoke (after app + FlareSolverr are up):
 | Action | Code path | What it does |
 | -------- | ----------- | -------------- |
 | `Warmup` | `/cron/cloudflare/Warmup` | FlareSolverr session warm (default `tracker.php?nm=`) |
-| `Parse` | `ParseAsync` | First page (`page=0` by default) of each **QuickParse** forum (~**65**); optional `cat`, `maxTopics` for smoke |
-| `UpdateTasksParse` | `UpdateTasksParseAsync` | Hits forums to learn page counts → `Data/temp/rutracker_taskParse.json`; optional `cat` (smoke: one forum, not all ~211) |
+| `Parse` | `ParseAsync` | First page (`page=0` by default) of each **QuickParse** forum (~**98**); optional `cat`, `maxTopics` for smoke |
+| `UpdateTasksParse` | `UpdateTasksParseAsync` | Hits forums to learn page counts → `Data/temp/rutracker_taskParse.json`; optional `cat` (smoke: one forum, not all ~246) |
 | `ParseLatest` | `ParseLatestAsync` | First *N* pages of **every** cat in `taskParse` (heavy once the map is full) |
 | `ParseAllTask` | `ParseAllTaskAsync` | Full backlog of every page in `taskParse` (multi-hour); optional `cat`, `maxPages` for smoke |
 
 ### Request unit (`parsePage`)
 
 1. **1×** GET forum list  
-2. For each torrent **not** already in FDB with the same title: **1×** GET topic (magnet), with **`parseDelay`** between topic GETs and up to **`topicFetchAttempts`** (default 5) retries until `ApplyTopicPageDetails` succeeds. Exhausted attempts → skip this run (next cron retries; not written to FDB yet).
+2. For each torrent **not** already in FDB with the same title **and** size whose magnet was written at or after the listing timestamp: **1×** GET topic (magnet), with **`parseDelay`** between topic GETs and up to **`topicFetchAttempts`** (default 5) retries until `ApplyTopicPageDetails` succeeds. Exhausted attempts → skip this run (next cron retries; not written to FDB yet). Empty magnet from a failed topic GET does not clobber a stored magnet.
 
 `parseDelay` / `reqMinute` also apply between pages in `ParseLatest` / `ParseAllTask`. Topic-level delay/retry always runs inside `parsePage` (including hourly `Parse`).
 
-Category counts (from `RutrackerCategories`): **211** forums, **65** `QuickParse = true`.
+Category counts (from `RutrackerCategories`): **246** forums, **98** `QuickParse = true`. Parent `viewforum` does **not** list child-forum topics — geographic UHD leaves such as `1669` must be in the map (see `forum_tree_snapshot.json`).
 
 ## Recommended cron (minimize requests, keep useful freshness)
 
@@ -108,10 +120,10 @@ Repo [`Data/crontab`](../../../Data/crontab): morning ParseAll starts a **new** 
 # Warm ~5 min before hourly parse
 55 * * * *    /opt/jacred/Data/run-job.sh cloudflare-warmup http://127.0.0.1:9117/cron/cloudflare/Warmup 300
 
-# Fresh releases: 65 quick forums, first page only (browser path + topic retries — up to 1h wall)
+# Fresh releases: 98 quick forums, first page only (browser path + topic retries — up to 1h wall)
 0 * * * *     /opt/jacred/Data/run-job.sh rutracker-parse http://127.0.0.1:9117/cron/rutracker/parse 3600
 
-# Rebuild page-task map once (211 GETs) — not every few hours
+# Rebuild page-task map once (246 GETs) — not every few hours
 20 3 * * *    /opt/jacred/Data/run-job.sh rutracker-UpdateTasksParse http://127.0.0.1:9117/cron/rutracker/UpdateTasksParse 60
 
 # Deep crawl: new cycle at 04:40 if the last one finished; else continue. Restarts: ResumeParseAll.
@@ -123,7 +135,7 @@ Repo [`Data/crontab`](../../../Data/crontab): morning ParseAll starts a **new** 
 
 - Hourly `UpdateTasksParse` / `ParseAllTask` — over-requests; while a crawl runs cron only gets `work`.
 - Calling ResumeParseAll when pending is 0 — that is idle by design; morning ParseAll is what rotates a finished cycle.  
-- Scheduling `ParseLatest?pages=5` for “light” refresh — with a full `taskParse` it is **heavier** than hourly `parse` (~211×N forum pages).
+- Scheduling `ParseLatest?pages=5` for “light” refresh — with a full `taskParse` it is **heavier** than hourly `parse` (~246×N forum pages).
 - Skipping warmup when FlareSolverr is cold — first CF solve under CPU contention often times out.
 - Destroying the FlareSolverr session on every chromedriver hang — prefer soft fail + topic retries; recycle only after `recycleAfterTimeouts`.
 
@@ -140,14 +152,14 @@ Repo [`Data/crontab`](../../../Data/crontab): morning ParseAll starts a **new** 
 
 ## FlareSolverr / Worker requests / day (recommended cron)
 
-Assumptions: 65 QuickParse, 211 forums, ~**40** pages/cat average for full crawl; topic GETs only when FDB misses title. With FlareSolverr each GET is a browser navigation (serialized).
+Assumptions: 98 QuickParse, 246 forums, ~**40** pages/cat average for full crawl; topic GETs when title/size changed or the listing timestamp is newer than the last magnet write. With FlareSolverr each GET is a browser navigation (serialized).
 
 ### Fixed forum GETs
 
 | Component | Forum GETs |
 | ----------- | ------------ |
-| `parse` hourly | **1 560 / day** (65 × 24) |
-| `UpdateTasksParse` daily | **211 / day** |
+| `parse` hourly | **2 352 / day** (98 × 24) |
+| `UpdateTasksParse` daily | **246 / day** |
 | `ParseAllTask` 1×/day (until done) | listing GETs via cffetch for pending pages; a full ~16k map is one run when the fast path holds |
 | **Forum floor** | **~2–4 000 / day** amortized when ParseAll is still catching up; a finishing day is ~16k listing GETs through cffetch |
 
@@ -172,6 +184,8 @@ Forum floor alone is often **~15k+ / day** if Update/ParseAll fire hourly; prefe
 - `RutrackerSyncService.cs` — cron sync  
 - `RutrackerParser.cs` — HTML → torrents / magnets  
 - `RutrackerCategories.cs` — forum map + QuickParse  
+- `tests/JacRed.Tests/Fixtures/Rutracker/forum_tree_snapshot.json` — live leaf snapshot (P0 must be QuickParse)  
+- `scripts/dry_run_rutracker_parser.py` — sample listings + `--check-snapshot` / `--probe-tree`  
 - `Controllers/Cron/RutrackerController.cs` — HTTP entrypoints  
 - `Controllers/Cron/CloudflareController.cs` — FlareSolverr warmup  
 - `Infrastructure/Networking/CloudflareClearance.cs` — FlareSolverr client  

--- a/Infrastructure/Trackers/Rutracker/RutrackerCategories.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerCategories.cs
@@ -55,12 +55,15 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["718"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["1940"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["271"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["272"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
+            ["775"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["1543"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["101"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["100"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["572"] = new() { Types = new[] { "movie" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
 
             // 3D Мультфильмы / Мультфильмы
+            ["84"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["2343"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["930"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
             ["2365"] = new() { Types = new[] { "multfilm" }, TitleKind = RutrackerTitleKind.Movie, QuickParse = true },
@@ -75,6 +78,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["921"] = new() { Types = new[] { "multserial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["815"] = new() { Types = new[] { "multserial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["1460"] = new() { Types = new[] { "multserial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["498"] = new() { Types = new[] { "multserial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
 
             // Сериалы (зарубежные, русские, HD, LatAm, KR/JP)
             ["842"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
@@ -96,6 +100,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["193"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["1690"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["1459"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["1463"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["825"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["1248"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["1288"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
@@ -120,6 +125,22 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             ["920"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["911"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
             ["2100"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+
+            // Географические UHD/HD-листы под 119 / 2100 / 2366 (добавлены 10.09.2026).
+            //
+            // Повод: Silo S2 UHD (t=6601495) уехала из 2366 в 1669 «Сериалы США и
+            // Канады (UHD Video)». Родитель 119 в карте был, но его viewforum
+            // не содержит тем детей. Jackett-имена для этих id устарели
+            // (переиспользование разделов) — подписи брать с живого сайта.
+            ["1669"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["2393"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["625"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["1949"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["173"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.Serial, QuickParse = true },
+            ["820"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
+            ["1242"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
+            ["717"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
+            ["2412"] = new() { Types = new[] { "serial" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },
 
             // Аниме
             ["1105"] = new() { Types = new[] { "anime" }, TitleKind = RutrackerTitleKind.NonStandard, QuickParse = true },

--- a/Infrastructure/Trackers/Rutracker/RutrackerParser.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerParser.cs
@@ -111,7 +111,8 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             if (createTime != default)
                 t.createTime = createTime;
 
-            string magnet = Regex.Match(fullNews, "href=\"(magnet:[^\"]+)\" class=\"(med )?magnet-link\"").Groups[1].Value;
+            string magnet = HttpUtility.HtmlDecode(
+                Regex.Match(fullNews, "href=\"(magnet:[^\"]+)\" class=\"(med )?magnet-link\"").Groups[1].Value);
             if (!string.IsNullOrWhiteSpace(magnet))
             {
                 t.magnet = magnet;
@@ -119,6 +120,58 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Skip the topic GET when listing title and size match a row that already
+        /// has a magnet written at or after the listing timestamp. Title-only skip
+        /// froze magnets when rutracker replaced the torrent in-place (Silo t=6601495).
+        /// </summary>
+        public static bool ShouldSkipTopicFetch(TorrentDetails cached, TorrentDetails listing)
+        {
+            if (cached == null || listing == null)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(cached.magnet))
+                return false;
+
+            if (!string.Equals(cached.title, listing.title, StringComparison.Ordinal))
+                return false;
+
+            if (!SizeNamesEqual(cached.sizeName, listing.sizeName))
+                return false;
+
+            if (listing.createTime == default || cached.updateTime == default)
+                return false;
+
+            if (AsUtc(listing.createTime) > AsUtc(cached.updateTime))
+                return false;
+
+            return true;
+        }
+
+        static bool SizeNamesEqual(string left, string right)
+        {
+            return string.Equals(NormalizeSizeName(left), NormalizeSizeName(right), StringComparison.OrdinalIgnoreCase);
+        }
+
+        static string NormalizeSizeName(string sizeName)
+        {
+            if (string.IsNullOrWhiteSpace(sizeName))
+                return string.Empty;
+
+            string decoded = HttpUtility.HtmlDecode(sizeName).Replace('\u00a0', ' ').Trim();
+            return Regex.Replace(decoded, @"\s+", " ");
+        }
+
+        static DateTime AsUtc(DateTime value)
+        {
+            return value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
         }
 
         static string MatchRow(string row, string pattern, int index = 1)

--- a/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
+++ b/Infrastructure/Trackers/Rutracker/RutrackerSyncService.cs
@@ -361,7 +361,7 @@ namespace JacRed.Infrastructure.Trackers.Rutracker
                 if (maxTopics > 0 && topicsDone >= maxTopics)
                     return true;
 
-                if (db.TryGetValue(t.url, out TorrentDetails _tcache) && _tcache.title == t.title)
+                if (db.TryGetValue(t.url, out TorrentDetails _tcache) && RutrackerParser.ShouldSkipTopicFetch(_tcache, t))
                     return true;
 
                 for (int attempt = 1; attempt <= topicAttempts; attempt++)

--- a/docs/trackers/rutracker.mdx
+++ b/docs/trackers/rutracker.mdx
@@ -65,7 +65,7 @@ Rutracker:
 */15 * * * *  /opt/jacred/Data/run-job.sh parseall-resume http://127.0.0.1:9117/cron/maintenance/ResumeParseAll 60
 ```
 
-Hourly `parse` — источник свежести. `ParseAllTask` обходит карту форумов (~13–16k страниц): одна GET листинга на страницу, `sid`/`pir` мержатся в FileDB. Topic GET (магнит) только если title сменился. Пустой magnet с форума не затирает сохранённый. Цикл живёт в `Data/temp/rutracker_parseAllCycle.json`. Стены по часам нет: обход идёт до pending=0, shutdown или 45 мин без прогресса. После обслуживания: `curl /cron/maintenance/ParseAllStatus` и `ResumeParseAll` (ещё срабатывает сам через ~45 с после старта процесса).
+Hourly `parse` — источник свежести. `ParseAllTask` обходит карту форумов (~13–16k страниц): одна GET листинга на страницу, `sid`/`pir` мержатся в FileDB. Topic GET (магнит) если сменились title или размер, или дата на форуме новее последней записи магнита. Пустой magnet с форума не затирает сохранённый. Обход родителя не заменяет детей: UHD-листы вроде `1669` должны быть в карте. Цикл живёт в `Data/temp/rutracker_parseAllCycle.json`. Стены по часам нет: обход идёт до pending=0, shutdown или 45 мин без прогресса. После обслуживания: `curl /cron/maintenance/ParseAllStatus` и `ResumeParseAll` (ещё срабатывает сам через ~45 с после старта процесса).
 
 ## Принцип работы с Cloudflare
 

--- a/docs/trackers/rutracker.mdx
+++ b/docs/trackers/rutracker.mdx
@@ -102,6 +102,10 @@ curl "http://localhost:9117/cron/cloudflare/Warmup"
 # Запустить парсинг вручную
 curl "http://localhost:9117/cron/rutracker/parse"
 
+# После деплоя карты: очередь страниц и первая страница UHD США/Канада (Silo t=6601495)
+curl "http://localhost:9117/cron/rutracker/UpdateTasksParse?cat=1669"
+curl "http://localhost:9117/cron/rutracker/parse?page=0&cat=1669&maxTopics=20"
+
 # Проверить фоновые задачи
 curl "http://localhost:9117/health/background-jobs"
 

--- a/scripts/cron_rutracker_smoke.sh
+++ b/scripts/cron_rutracker_smoke.sh
@@ -4,7 +4,7 @@
 # Covers:
 #   1) /cron/cloudflare/Warmup
 #   2) /cron/rutracker/parse            (one cat, maxTopics)
-#   3) /cron/rutracker/UpdateTasksParse (one cat — NOT all 211 forums)
+#   3) /cron/rutracker/UpdateTasksParse (one cat — NOT all 246 forums)
 #   4) /cron/rutracker/ParseAllTask     (one cat, maxPages — NOT full backlog)
 #
 # Background jobs are polled via /health/background-jobs (re-calling cron

--- a/scripts/dry_run_rutracker_parser.py
+++ b/scripts/dry_run_rutracker_parser.py
@@ -2,10 +2,12 @@
 """
 Dry-run Rutracker forum listings vs JacRed category map + HTML field shape.
 
-Fetches a representative sample (not all ~211 forums):
+Fetches a representative sample (not the full map):
   Movie, Serial, NonStandard(anime), sport, doc, tvshow.
 
   python3 scripts/dry_run_rutracker_parser.py
+  python3 scripts/dry_run_rutracker_parser.py --check-snapshot
+  python3 scripts/dry_run_rutracker_parser.py --probe-tree
   python3 scripts/dry_run_rutracker_parser.py --refresh-fixtures
 
 Then:
@@ -30,6 +32,15 @@ from typing import Dict, List, Optional, Tuple
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CATEGORIES_CS = REPO_ROOT / "Infrastructure" / "Trackers" / "Rutracker" / "RutrackerCategories.cs"
 DEFAULT_FIXTURE_DIR = REPO_ROOT / "tests" / "JacRed.Tests" / "Fixtures" / "Rutracker"
+DEFAULT_SNAPSHOT = DEFAULT_FIXTURE_DIR / "forum_tree_snapshot.json"
+FS_URL = os.environ.get("FS_URL", "http://127.0.0.1:8191/v1")
+
+# Parent forums whose viewforum subforum table is the real leaf catalog.
+# index.php sf_title is incomplete (under 119 it only shows 1171).
+VIDEO_TREE_PARENTS = (
+    "119", "2366", "189", "2100", "911", "718", "4", "921", "7", "22",
+    "33", "9", "81", "812", "46", "314", "24", "255",
+)
 
 # Representative forums: one per TitleKind + sport + doc + tvshow
 SAMPLE_FORUMS: Dict[str, str] = {
@@ -67,6 +78,114 @@ def parse_map(path: Path) -> Dict[str, Tuple[List[str], str, bool]]:
         quick = m.group(4) == "true"
         out[fid] = (types, kind, quick)
     return out
+
+
+def flaresolverr_get(url: str, session: str, timeout: int = 180) -> str:
+    payload = json.dumps(
+        {"cmd": "request.get", "url": url, "session": session, "maxTimeout": 120000}
+    ).encode()
+    req = urllib.request.Request(
+        FS_URL, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode())
+    sol = data.get("solution") or {}
+    return sol.get("response") or ""
+
+
+def flaresolverr_session() -> str:
+    payload = json.dumps({"cmd": "sessions.create"}).encode()
+    req = urllib.request.Request(
+        FS_URL, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read().decode())
+    session = data.get("session")
+    if not session:
+        raise RuntimeError(f"FlareSolverr sessions.create failed: {data}")
+    return session
+
+
+FORUMLINK_RE = re.compile(
+    r'<h4 class="forumlink"><a href="viewforum\.php\?f=(\d+)">([^<]+)</a>',
+    re.I,
+)
+PAGE_OF_RE = re.compile(r"Страница <b>1</b> из <b>([0-9]+)</b>")
+
+
+def parse_children(html: str) -> List[Tuple[str, str]]:
+    return [(m.group(1), m.group(2).strip()) for m in FORUMLINK_RE.finditer(html)]
+
+
+def page_count(html: str) -> int:
+    m = PAGE_OF_RE.search(html)
+    return int(m.group(1)) if m else 1
+
+
+def check_snapshot(mp: Dict[str, Tuple[List[str], str, bool]], path: Path) -> bool:
+    if not path.is_file():
+        print(f"[FAIL] snapshot missing: {path}")
+        return False
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    forums = data.get("forums") or []
+    p0 = sorted({f["id"] for f in forums if f.get("priority") == "p0"})
+    print(f"=== snapshot {path.relative_to(REPO_ROOT)} p0={len(p0)} captured={data.get('captured')} ===")
+    ok = True
+    if len(p0) != 14:
+        print(f"[FAIL] expected 14 P0 forums, got {len(p0)}")
+        ok = False
+    for fid in p0:
+        if fid not in mp:
+            print(f"[FAIL] P0 f={fid} not in RutrackerCategories.Map")
+            ok = False
+            continue
+        _types, _kind, quick = mp[fid]
+        if not quick:
+            print(f"[FAIL] P0 f={fid} is in map but QuickParse=false")
+            ok = False
+        else:
+            print(f"[OK]   f={fid:<5} QuickParse types={mp[fid][0]}")
+    return ok
+
+
+def probe_tree(mp: Dict[str, Tuple[List[str], str, bool]], host: str) -> int:
+    print(f"=== live forum tree via FlareSolverr {FS_URL} ===")
+    session = flaresolverr_session()
+    missing_p0 = []
+    unknown = []
+    for parent in VIDEO_TREE_PARENTS:
+        url = f"{host}/forum/viewforum.php?f={parent}"
+        try:
+            html = flaresolverr_get(url, session)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as ex:
+            print(f"[FAIL] parent f={parent} fetch: {ex}")
+            return 1
+        kids = parse_children(html)
+        pages = page_count(html)
+        in_map = parent in mp
+        print(f"parent f={parent:<5} inMap={in_map} pages={pages} children={len(kids)}")
+        for fid, name in kids:
+            mapped = fid in mp
+            mark = "IN" if mapped else "MISS"
+            print(f"  {mark:4} f={fid:<5} {name}")
+            if not mapped:
+                unknown.append((fid, name, parent))
+
+    p0_from_snapshot = []
+    snap = DEFAULT_SNAPSHOT
+    if snap.is_file():
+        data = json.loads(snap.read_text(encoding="utf-8"))
+        p0_from_snapshot = [f["id"] for f in data.get("forums") or [] if f.get("priority") == "p0"]
+        for fid in p0_from_snapshot:
+            if fid not in mp:
+                missing_p0.append(fid)
+
+    if missing_p0:
+        print(f"[FAIL] P0 still missing from map: {missing_p0}")
+        return 1
+    print(f"unknown children not in map: {len(unknown)} (P1/meta; not a P0 failure)")
+    return 0
 
 
 def fetch(url: str) -> str:
@@ -113,11 +232,30 @@ def main(argv: Optional[List[str]] = None) -> int:
     p.add_argument("--refresh-fixtures", action="store_true")
     p.add_argument("--fixture-dir", default=str(DEFAULT_FIXTURE_DIR))
     p.add_argument("--json-out", default="")
+    p.add_argument(
+        "--check-snapshot",
+        action="store_true",
+        help="Offline: P0 forums in forum_tree_snapshot.json must be QuickParse in the C# map",
+    )
+    p.add_argument(
+        "--probe-tree",
+        action="store_true",
+        help="Live BFS of video parent viewforum pages via FlareSolverr (FS_URL)",
+    )
+    p.add_argument("--snapshot", default=str(DEFAULT_SNAPSHOT))
     args = p.parse_args(argv)
 
     mp = parse_map(CATEGORIES_CS)
     host = args.host.rstrip("/")
     fixture_dir = Path(args.fixture_dir)
+    snapshot = Path(args.snapshot)
+
+    if args.check_snapshot or args.probe_tree:
+        failed_snap = not check_snapshot(mp, snapshot)
+        if args.probe_tree:
+            rc = probe_tree(mp, host)
+            return 1 if failed_snap or rc else 0
+        return 1 if failed_snap else 0
 
     if args.refresh_fixtures:
         fixture_dir.mkdir(parents=True, exist_ok=True)
@@ -126,6 +264,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     report = []
     failed = False
+    if not check_snapshot(mp, snapshot):
+        failed = True
+    print()
     print(f"=== Rutracker parser dry-run ({len(SAMPLE_FORUMS)} sample forums) ===\n")
 
     for fid, label in SAMPLE_FORUMS.items():

--- a/tests/JacRed.Tests/Fixtures/Rutracker/forum_tree_snapshot.json
+++ b/tests/JacRed.Tests/Fixtures/Rutracker/forum_tree_snapshot.json
@@ -1,0 +1,30 @@
+{
+  "captured": "2026-09-10",
+  "source": "rutracker.org viewforum BFS via FlareSolverr; not Jackett (forum ids were reused).",
+  "note": "Parent crawl does not list child topics. P0 must stay in RutrackerCategories QuickParse. P1 is deferred.",
+  "forums": [
+    {"id": "1669", "name": "Сериалы США и Канады (UHD Video)", "parent": "119", "pages": 18, "priority": "p0"},
+    {"id": "2393", "name": "Сериалы Великобритании и Ирландии (UHD Video)", "parent": "119", "pages": 2, "priority": "p0"},
+    {"id": "625", "name": "Европейские сериалы (UHD Video)", "parent": "119", "pages": 2, "priority": "p0"},
+    {"id": "1949", "name": "Сериалы Австралии и Новой Зеландии (UHD Video)", "parent": "119", "pages": 1, "priority": "p0"},
+    {"id": "173", "name": "Сериалы совместного производства нескольких стран (UHD Video)", "parent": "119", "pages": 5, "priority": "p0"},
+    {"id": "820", "name": "Азиатские сериалы (UHD Video)", "parent": "2100", "pages": 9, "priority": "p0"},
+    {"id": "1242", "name": "Корейские сериалы (HD Video)", "parent": "2100", "pages": 38, "priority": "p0"},
+    {"id": "717", "name": "Китайские сериалы", "parent": "2100", "pages": 24, "priority": "p0"},
+    {"id": "2412", "name": "Сериалы Таиланда, Индонезии, Сингапура", "parent": "2100", "pages": 6, "priority": "p0"},
+    {"id": "1463", "name": "Сериалы стран Африки, Ближнего и Среднего Востока (HD Video)", "parent": "2366", "pages": 1, "priority": "p0"},
+    {"id": "84", "name": "Мультфильмы (UHD Video)", "parent": "4", "pages": 8, "priority": "p0"},
+    {"id": "498", "name": "Мультсериалы (UHD Video)", "parent": "921", "pages": 1, "priority": "p0"},
+    {"id": "272", "name": "Азиатские фильмы (UHD Video)", "parent": "718", "pages": 2, "priority": "p0"},
+    {"id": "775", "name": "Классика мирового кинематографа (UHD Video)", "parent": "718", "pages": 3, "priority": "p0"},
+    {"id": "1171", "name": "Новинки и сериалы в стадии показа (UHD Video)", "parent": "119", "pages": 1, "priority": "mapped"},
+    {"id": "119", "name": "Зарубежные сериалы (UHD Video)", "parent": "189", "pages": 1, "priority": "mapped"},
+    {"id": "273", "name": "Для некондиционных раздач (UHD Video)", "parent": "119", "pages": 1, "priority": "p1"},
+    {"id": "2406", "name": "Архив Зарубежные сериалы (UHD Video)", "parent": "119", "pages": 1, "priority": "skip"},
+    {"id": "816", "name": "Мультсериалы (DVD Video)", "parent": "921", "pages": 16, "priority": "p1"},
+    {"id": "1900", "name": "Отечественные мультфильмы (DVD)", "parent": "4", "pages": 16, "priority": "p1"},
+    {"id": "594", "name": "Сериалы Венесуэлы", "parent": "911", "pages": 0, "priority": "p1"},
+    {"id": "1301", "name": "Сериалы Индии", "parent": "911", "pages": 0, "priority": "p1"},
+    {"id": "2198", "name": "HD Video", "parent": "7", "pages": 33, "priority": "skip"}
+  ]
+}

--- a/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
@@ -17,12 +17,13 @@ public class RutrackerCategoriesTests
     }
 
     /// <summary>
-    /// Разделы, добавленные 15.08.2026, и почему их отсутствие било по выдаче.
+    /// Разделы, которых не было в карте, и почему обход родителя не спасает.
     ///
     /// У rutracker раздел может иметь и подразделы, и собственные темы, поэтому
-    /// обход родителя НЕ заменяет обход детей. Так «Дом дракона» S3 в 2160p
-    /// (t=6873874) не попадал в базу вовсе: он лежит в 1171, а в списке был
-    /// только родительский 119, где своих тем два десятка.
+    /// обход родителя НЕ заменяет обход детей. «Дом дракона» S3 в 2160p
+    /// (t=6873874) лежит в 1171, а в списке был только родитель 119.
+    /// Silo S2 UHD (t=6601495) уехала в 1669 «Сериалы США и Канады (UHD Video)»
+    /// при том же родителе 119.
     /// </summary>
     [Theory]
     [InlineData("1171")]   // Новинки и сериалы в стадии показа (UHD Video)
@@ -84,6 +85,7 @@ public class RutrackerCategoriesTests
     [InlineData("1105", "anime", RutrackerTitleKind.NonStandard, true)]
     [InlineData("709", "documovie", RutrackerTitleKind.Movie, false)]
     [InlineData("24", "tvshow", RutrackerTitleKind.NonStandard, false)]
+    [InlineData("915", "serial", RutrackerTitleKind.NonStandard, true)]
     [InlineData("1669", "serial", RutrackerTitleKind.Serial, true)]
     [InlineData("820", "serial", RutrackerTitleKind.NonStandard, true)]
     [InlineData("84", "multfilm", RutrackerTitleKind.Movie, true)]

--- a/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerCategoriesTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.Json;
 using JacRed.Infrastructure.Trackers.Rutracker;
 using Xunit;
 
@@ -9,8 +10,8 @@ public class RutrackerCategoriesTests
     [Fact]
     public void Map_HasExpectedCounts()
     {
-        Assert.Equal(232, RutrackerCategories.Map.Count);
-        Assert.Equal(84, RutrackerCategories.QuickParseIds.Count());
+        Assert.Equal(246, RutrackerCategories.Map.Count);
+        Assert.Equal(98, RutrackerCategories.QuickParseIds.Count());
         Assert.Equal(RutrackerCategories.Map.Count, RutrackerCategories.Ids.Distinct().Count());
         Assert.True(RutrackerCategories.QuickParseIds.All(id => RutrackerCategories.Map.ContainsKey(id)));
     }
@@ -31,6 +32,20 @@ public class RutrackerCategoriesTests
     [InlineData("812")]    // Русские сериалы (UHD Video)
     [InlineData("718")]    // UHD Video
     [InlineData("1106")]   // Онгоинги (HD Video)
+    [InlineData("1669")]   // Сериалы США и Канады (UHD Video) — Silo t=6601495
+    [InlineData("2393")]   // Сериалы Великобритании и Ирландии (UHD Video)
+    [InlineData("625")]    // Европейские сериалы (UHD Video)
+    [InlineData("1949")]   // Сериалы Австралии и Новой Зеландии (UHD Video)
+    [InlineData("173")]    // Сериалы совместного производства (UHD Video)
+    [InlineData("820")]    // Азиатские сериалы (UHD Video)
+    [InlineData("1242")]   // Корейские сериалы (HD Video)
+    [InlineData("717")]    // Китайские сериалы
+    [InlineData("2412")]   // Сериалы Таиланда, Индонезии, Сингапура
+    [InlineData("1463")]   // Сериалы Африки / Ближнего и Среднего Востока (HD Video)
+    [InlineData("84")]     // Мультфильмы (UHD Video)
+    [InlineData("498")]    // Мультсериалы (UHD Video)
+    [InlineData("272")]    // Азиатские фильмы (UHD Video)
+    [InlineData("775")]    // Классика мирового кинематографа (UHD Video)
     public void FormerlyMissingSections_AreInQuickParse(string id)
     {
         Assert.True(RutrackerCategories.Map.ContainsKey(id));
@@ -69,7 +84,11 @@ public class RutrackerCategoriesTests
     [InlineData("1105", "anime", RutrackerTitleKind.NonStandard, true)]
     [InlineData("709", "documovie", RutrackerTitleKind.Movie, false)]
     [InlineData("24", "tvshow", RutrackerTitleKind.NonStandard, false)]
-    [InlineData("915", "serial", RutrackerTitleKind.NonStandard, true)]
+    [InlineData("1669", "serial", RutrackerTitleKind.Serial, true)]
+    [InlineData("820", "serial", RutrackerTitleKind.NonStandard, true)]
+    [InlineData("84", "multfilm", RutrackerTitleKind.Movie, true)]
+    [InlineData("498", "multserial", RutrackerTitleKind.Serial, true)]
+    [InlineData("272", "movie", RutrackerTitleKind.Movie, true)]
     public void Map_SampleEntries_MatchExpected(string id, string type, RutrackerTitleKind kind, bool quick)
     {
         Assert.True(RutrackerCategories.Map.TryGetValue(id, out var meta));
@@ -85,6 +104,27 @@ public class RutrackerCategoriesTests
         Assert.Equal(new[] { "docuserial", "documovie" }, meta.Types);
         Assert.Equal(RutrackerTitleKind.NonStandard, meta.TitleKind);
         Assert.False(meta.QuickParse);
+    }
+
+    [Fact]
+    public void ForumTreeSnapshot_P0Leaves_AreInQuickParse()
+    {
+        string json = FixtureLoader.Read("Rutracker/forum_tree_snapshot.json");
+        using var doc = JsonDocument.Parse(json);
+        var p0 = doc.RootElement.GetProperty("forums")
+            .EnumerateArray()
+            .Where(f => f.GetProperty("priority").GetString() == "p0")
+            .Select(f => f.GetProperty("id").GetString())
+            .Distinct()
+            .ToList();
+
+        Assert.Equal(14, p0.Count);
+        Assert.Contains("1669", p0);
+        Assert.All(p0, id =>
+        {
+            Assert.True(RutrackerCategories.Map.ContainsKey(id), $"P0 forum {id} missing from map");
+            Assert.Contains(id, RutrackerCategories.QuickParseIds);
+        });
     }
 
     [Fact]

--- a/tests/JacRed.Tests/Rutracker/RutrackerParserFixtureTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerParserFixtureTests.cs
@@ -17,7 +17,7 @@ public class RutrackerParserFixtureTests
 {
     readonly ITestOutputHelper _output;
 
-    // Representative sample (not full 211-forum map).
+    // Representative sample (not full 246-forum map).
     static readonly (string id, string file)[] SampleFixtures =
     {
         ("1950", "forum_1950.html"),

--- a/tests/JacRed.Tests/Rutracker/RutrackerParserMagnetTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerParserMagnetTests.cs
@@ -1,0 +1,101 @@
+using System;
+using JacRed.Infrastructure.Trackers.Rutracker;
+using JacRed.Models.Details;
+using Xunit;
+
+namespace JacRed.Tests.Rutracker;
+
+public class RutrackerParserMagnetTests
+{
+    const string Title = "Укрытие / Бункер / Silo / Сезон: 2 / Серии: 1-10 из 10";
+    const string Size = "101.97 GB";
+    const string Magnet = "magnet:?xt=urn:btih:EE33E008E78DDE68559CDA46AA36C0A6B301DB58&tr=http://bt4.t-ru.org/ann?magnet";
+
+    static TorrentDetails Cached(
+        string title = Title,
+        string size = Size,
+        string magnet = Magnet,
+        DateTime? create = null,
+        DateTime? update = null) => new()
+    {
+        title = title,
+        sizeName = size,
+        magnet = magnet,
+        createTime = create ?? new DateTime(2026, 2, 4, 12, 8, 3, DateTimeKind.Utc),
+        updateTime = update ?? new DateTime(2026, 2, 4, 12, 8, 3, DateTimeKind.Utc)
+    };
+
+    static TorrentDetails Listing(
+        string title = Title,
+        string size = Size,
+        DateTime? create = null) => new()
+    {
+        title = title,
+        sizeName = size,
+        createTime = create ?? new DateTime(2026, 2, 4, 1, 51, 0, DateTimeKind.Utc)
+    };
+
+    [Fact]
+    public void ShouldSkipTopicFetch_SameTitleSizeAndFreshMagnet_Skips()
+    {
+        Assert.True(RutrackerParser.ShouldSkipTopicFetch(Cached(), Listing()));
+    }
+
+    [Fact]
+    public void ShouldSkipTopicFetch_TitleChanged_Fetches()
+    {
+        var listing = Listing(title: Title + " [4k]");
+        Assert.False(RutrackerParser.ShouldSkipTopicFetch(Cached(), listing));
+    }
+
+    [Fact]
+    public void ShouldSkipTopicFetch_SizeChanged_Fetches()
+    {
+        Assert.False(RutrackerParser.ShouldSkipTopicFetch(Cached(), Listing(size: "120 GB")));
+    }
+
+    [Fact]
+    public void ShouldSkipTopicFetch_ListingNewerThanMagnetWrite_Fetches()
+    {
+        // Silo: listing createTime July, magnet updateTime February, title/size unchanged.
+        var listing = Listing(create: new DateTime(2026, 7, 5, 1, 51, 0, DateTimeKind.Utc));
+        Assert.False(RutrackerParser.ShouldSkipTopicFetch(Cached(), listing));
+    }
+
+    [Fact]
+    public void ShouldSkipTopicFetch_EmptyMagnet_Fetches()
+    {
+        Assert.False(RutrackerParser.ShouldSkipTopicFetch(Cached(magnet: ""), Listing()));
+        Assert.False(RutrackerParser.ShouldSkipTopicFetch(null, Listing()));
+    }
+
+    [Fact]
+    public void ShouldSkipTopicFetch_NbspSize_StillEqual()
+    {
+        var listing = Listing(size: "101.97\u00a0GB");
+        Assert.True(RutrackerParser.ShouldSkipTopicFetch(Cached(), listing));
+    }
+
+    [Fact]
+    public void ApplyTopicPageDetails_HtmlDecodesMagnetAmpersands()
+    {
+        var t = new TorrentDetails();
+        string html =
+            "<a class=\"p-link small\" href=\"viewtopic.php?t=6601495\">05-07-26 01:51</a>" +
+            "<a href=\"magnet:?xt=urn:btih:DD734DA14142D211010A82D540431A86C737498E&amp;tr=http%3A%2F%2Fbt4.t-ru.org%2Fann%3Fmagnet&amp;dn=Silo\" class=\"magnet-link\">";
+
+        Assert.True(RutrackerParser.ApplyTopicPageDetails(t, html));
+        Assert.Equal(
+            "magnet:?xt=urn:btih:DD734DA14142D211010A82D540431A86C737498E&tr=http%3A%2F%2Fbt4.t-ru.org%2Fann%3Fmagnet&dn=Silo",
+            t.magnet);
+    }
+
+    [Fact]
+    public void ApplyTopicPageDetails_MedMagnetLinkClass_Matches()
+    {
+        var t = new TorrentDetails();
+        string html = "<a href=\"magnet:?xt=urn:btih:AABB\" class=\"med magnet-link\">";
+        Assert.True(RutrackerParser.ApplyTopicPageDetails(t, html));
+        Assert.Equal("magnet:?xt=urn:btih:AABB", t.magnet);
+    }
+}

--- a/tests/JacRed.Tests/Rutracker/RutrackerParserTitleTests.cs
+++ b/tests/JacRed.Tests/Rutracker/RutrackerParserTitleTests.cs
@@ -42,6 +42,12 @@ public class RutrackerParserTitleTests
         "Укрытие",
         "Silo",
         2026)]
+    [InlineData(
+        "1669",
+        "Укрытие / Бункер / Silo / Сезон: 2 / Серии: 1-10 из 10 (Майкл Диннер, Арик Авелино) [2024, США, фантастика, драма, триллер, Dolby Vision, HDR10+, WEB-DL 2160p, 4k]",
+        "Укрытие",
+        "Silo",
+        2024)]
     public void Serial_ParsesNameOrigYear(string cat, string title, string name, string orig, int year)
     {
         var t = Assert.Single(RutrackerParser.ParseTorrentsFromPage(ForumRow(title), cat));


### PR DESCRIPTION
- Added new forum categories and updated existing ones to reflect changes in Rutracker's structure, increasing the total from 232 to 246.
- Improved the logic for skipping topic fetches based on title, size, and timestamp to prevent unnecessary requests for unchanged torrents.
- Introduced a dry-run script for validating forum listings against the updated category map.
- Updated documentation and tests to ensure consistency with the new category structure and parsing behavior.